### PR TITLE
delete the stopped container by default at tear down

### DIFF
--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -387,7 +387,7 @@ def process_self_contained_coordinator_stream(
                                 "mode": "rw",
                             },
                         },
-                        auto_remove=False,
+                        auto_remove=True,
                         privileged=True,
                         working_dir=benchmark_tool_workdir,
                         command=benchmark_command_str,


### PR DESCRIPTION
After testing with : 
redis-benchmarks-spec-client-runner --db_server_host localhost --db_server_port 6379 --preserve_temporary_client_dirs --client_aggregated_results_folder ./test1

I found that I quickly ran out of 100GB of space. After some investigation, I could see that all the space is occupied by a bunch of stopped docker containers. These containers did not seem to be reused on a subsequent run I started, but rather the list grew. 

Thus, I suggest removing the unused containers automatically upon tear down. 