### PR TITLE
Fixed self_contained_coordinator r.ping() using 6379 port and not redis_proc_start_port

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.1.33"
+version = "0.1.34"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -502,7 +502,7 @@ def process_self_contained_coordinator_stream(
                             )
                             redis_containers.append(container)
 
-                            r = redis.StrictRedis(port=6379)
+                            r = redis.StrictRedis(port=redis_proc_start_port)
                             r.ping()
                             redis_pids = []
                             first_redis_pid = r.info()["process_id"]


### PR DESCRIPTION
Fixes #108 