### PR TITLE
Fix value bug

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-100B-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-100B-expire-use-case.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "100" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-groups:
 - string
 - generic
@@ -24,7 +24,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "100" --command "SETEX __key__ 10 __value__" --command-key-pattern="R" --command "SET __key__ __value__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
+  arguments: '"--data-size" "100" --command "SETEX __key__ 10 __data__" --command-key-pattern="R" --command "SET __key__ __data__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
   resources:
     requests:
       cpus: '3'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-10B-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-10B-expire-use-case.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "10" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "10" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-groups:
 - string
 - generic
@@ -24,7 +24,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "10" --command "SETEX __key__ 10 __value__" --command-key-pattern="R" --command "SET __key__ __value__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
+  arguments: '"--data-size" "10" --command "SETEX __key__ 10 __data__" --command-key-pattern="R" --command "SET __key__ __data__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
   resources:
     requests:
       cpus: '3'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-1KiB-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-1KiB-expire-use-case.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "1000" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "1000" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-groups:
 - string
 - generic
@@ -24,7 +24,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "1000" --command "SETEX __key__ 10 __value__" --command-key-pattern="R" --command "SET __key__ __value__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
+  arguments: '"--data-size" "1000" --command "SETEX __key__ 10 __data__" --command-key-pattern="R" --command "SET __key__ __data__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
   resources:
     requests:
       cpus: '3'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-4KiB-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-4KiB-expire-use-case.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "1000" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "1000" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-groups:
 - string
 - generic
@@ -24,7 +24,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "4000" --command "SETEX __key__ 10 __value__" --command-key-pattern="R" --command "SET __key__ __value__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
+  arguments: '"--data-size" "4000" --command "SETEX __key__ 10 __data__" --command-key-pattern="R" --command "SET __key__ __data__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
   resources:
     requests:
       cpus: '3'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B-pipeline-10.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "100" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-commands:
 - get
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "100" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-commands:
 - get
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-10.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "10" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "10" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-commands:
 - get
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "10" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "10" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-commands:
 - get
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB-pipeline-10.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "1000" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "1000" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-commands:
 - get
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB.yml
@@ -7,7 +7,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "1000" "--command" "SET __key__ __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
+    arguments: '"--data-size" "1000" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"'
 tested-commands:
 - get
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100MB-string-bitfield.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100MB-string-bitfield.yml
@@ -1,0 +1,37 @@
+version: 0.4
+name: memtier_benchmark-1key-100MB-string-bitfield
+description: Runs memtier_benchmark, for a keyspace length of 1 key with a data size of 100MB for the key. The motivation for BITFIELD is to be able to pack many small integers in a large bitmat. Perform GET, SET and INCRBY using the BITFIELD command with random bit offsets. Since the bit offsets may be up to and including 100000000, some operations may result in enlarging the string (which is OK). 
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 100000000 -n 1 --command "SET key1 __data__" -c 1 -t 1 --hide-histogram
+tested-commands:
+- get
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:8.5.0-amd64-debian-buster-default
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "BITFIELD key1 INCRBY i5 __key__ 1 GET u4 __key__ SET i8 __key__ 1" --key-maximum 100000000 --command-key-pattern="R" --key-prefix "" -c 2 -t 2 --hide-histogram --test-time 180
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+exporter:
+  redistimeseries:
+    break_by:
+    - version
+    - commit
+    timemetric: $."ALL STATS".Runtime."Start time"
+    metrics:
+    - $."ALL STATS".Totals."Ops/sec"
+    - $."ALL STATS".Totals."Latency"
+    - $."ALL STATS".Totals."Misses/sec"
+    - $."ALL STATS".Totals."Percentile Latencies"."p50.00"
+tested-groups:
+- string

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100MB-string-bitfield.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100MB-string-bitfield.yml
@@ -9,7 +9,7 @@ dbconfig:
     tool: memtier_benchmark
     arguments: --data-size 100000000 -n 1 --command "SET key1 __data__" -c 1 -t 1 --hide-histogram
 tested-commands:
-- get
+- bitfield
 redis-topologies:
 - oss-standalone
 build-variants:
@@ -34,4 +34,4 @@ exporter:
     - $."ALL STATS".Totals."Misses/sec"
     - $."ALL STATS".Totals."Percentile Latencies"."p50.00"
 tested-groups:
-- string
+- bitmap


### PR DESCRIPTION
In some test cases we were using "__value__" . 
For example: --command "SET __key__ __value__"
This is a bug, since it does not generate a data pattern with the specified length, but simply assigns the data to the string "__value__". 
We need to replace this with __data__ so that proper data is generated. 