### PR TITLE
Client runner: enabled oss cluster benchmarks for string (just set and get commands) benchmarks

### DIFF
--- a/redis_benchmarks_specification/__cli__/stats.py
+++ b/redis_benchmarks_specification/__cli__/stats.py
@@ -357,7 +357,7 @@ def generate_stats_cli_command_logic(args, project_name, project_version):
                     row.append(usec_per_call)
                     row.append(pct)
                     row.append(pct_usec)
-                    row.append(pct_usec)
+                    row.append(diff_pct)
                     writer.writerow(row)
 
         if total_tracked_count > 0:

--- a/redis_benchmarks_specification/__cli__/stats.py
+++ b/redis_benchmarks_specification/__cli__/stats.py
@@ -101,6 +101,11 @@ def generate_stats_cli_command_logic(args, project_name, project_version):
                 if is_memtier:
                     arguments = benchmark_config["clientconfig"]["arguments"]
                     arguments_split = arguments.split("--command")
+
+                    if len(arguments_split) == 1:
+                        # this means no arbitrary command is being used so we default to memtier default group, which is 'string'
+                        tested_groups.append("string")
+
                     for command_part in arguments_split[1:]:
                         command_part = command_part.strip()
                         command_p = command_part.split(" ", 1)[0]
@@ -248,6 +253,8 @@ def generate_stats_cli_command_logic(args, project_name, project_version):
             for row in csv_reader:
                 if len(row) == 0:
                     continue
+                if "cmdstat_" not in row[0]:
+                    continue
                 # row variable is a list that represents a row in csv
                 cmdstat = row[0]
                 cmdstat = cmdstat.replace("cmdstat_", "")
@@ -323,8 +330,10 @@ def generate_stats_cli_command_logic(args, project_name, project_version):
                 "usecs",
                 "tracked",
                 "deprecated",
+                "usec_per_call",
                 "% count",
                 "% usecs",
+                "diff count usecs",
             ]
             import csv
 
@@ -339,9 +348,15 @@ def generate_stats_cli_command_logic(args, project_name, project_version):
                     usec = row[3]
                     pct = count / total_count
                     pct_usec = "n/a"
+                    usec_per_call = "n/a"
+                    diff_pct = "n/a"
                     if usec is not None:
                         pct_usec = usec / total_usecs
+                        usec_per_call = float(usec) / float(count)
+                        diff_pct = pct_usec - pct
+                    row.append(usec_per_call)
                     row.append(pct)
+                    row.append(pct_usec)
                     row.append(pct_usec)
                     writer.writerow(row)
 

--- a/redis_benchmarks_specification/__common__/runner.py
+++ b/redis_benchmarks_specification/__common__/runner.py
@@ -178,7 +178,6 @@ def exporter_datasink_common(
             ]
         },
     )
-    print(overall_end_time_metrics)
     # 7 days from now
     expire_redis_metrics_ms = 7 * 24 * 60 * 60 * 1000
     export_redis_metrics(

--- a/redis_benchmarks_specification/__runner__/args.py
+++ b/redis_benchmarks_specification/__runner__/args.py
@@ -190,4 +190,10 @@ def create_client_runner_args(project_name):
         type=int,
         help="override memtier number of runs for each benchmark. By default will run once each test",
     )
+    parser.add_argument(
+        "--cluster-mode",
+        default=False,
+        action="store_true",
+        help="Run client in cluster mode.",
+    )
     return parser

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -410,7 +410,7 @@ def process_self_contained_coordinator_stream(
                     port = args.db_server_port
                     host = args.db_server_host
                     password = args.db_server_password
-
+                    oss_cluster_api_enabled = args.cluster_mode
                     ssl_cert_reqs = "required"
                     if tls_skip_verify:
                         ssl_cert_reqs = None
@@ -553,6 +553,7 @@ def process_self_contained_coordinator_stream(
                             test_tls_cacert,
                             resp_version,
                             password,
+                            oss_cluster_api_enabled,
                         )
                     execute_init_commands(
                         benchmark_config, r, dbconfig_keyname="dbconfig"
@@ -596,6 +597,7 @@ def process_self_contained_coordinator_stream(
                             local_benchmark_output_filename
                         )
                     )
+
                     if "memtier_benchmark" not in benchmark_tool:
                         # prepare the benchmark command
                         (
@@ -622,7 +624,7 @@ def process_self_contained_coordinator_stream(
                             host,
                             password,
                             local_benchmark_output_filename,
-                            False,
+                            oss_cluster_api_enabled,
                             tls_enabled,
                             tls_skip_verify,
                             test_tls_cert,
@@ -970,6 +972,7 @@ def data_prepopulation_step(
     tls_cacert=None,
     resp_version=None,
     password=None,
+    oss_cluster_api_enabled=False,
 ):
     # setup the benchmark
     (
@@ -999,7 +1002,7 @@ def data_prepopulation_step(
             host,
             password,
             local_benchmark_output_filename,
-            False,
+            oss_cluster_api_enabled,
             tls_enabled,
             tls_skip_verify,
             tls_cert,

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10.yml
@@ -18,7 +18,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--pipeline" "10" "--data-size" "100" --command "SET __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+  arguments: '"--pipeline" "10" "--data-size" "100" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-100B-values.yml
@@ -23,7 +23,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "100" --command "SET __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+  arguments: '"--data-size" "100" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-10.yml
@@ -18,7 +18,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--pipeline" "10" "--data-size" "10" --command "SET __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+  arguments: '"--pipeline" "10" "--data-size" "10" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values.yml
@@ -18,7 +18,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "10" --command "SET __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+  arguments: '"--data-size" "10" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-1KiB-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-1KiB-values.yml
@@ -18,7 +18,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "1000" --command "SET __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+  arguments: '"--data-size" "1000" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B-pipeline-10.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
+    arguments: '"--data-size" "100" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
   resources:
     requests:
       memory: 1g
@@ -22,10 +22,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--pipeline" "10" "--data-size" "100" --command "GET __key__" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180'
+  arguments: '"--pipeline" "10" "--data-size" "100" --ratio 0:1 --key-pattern R:R -c 25 -t 4 --hide-histogram --test-time 180'
   resources:
     requests:
-      cpus: '2'
+      cpus: '4'
       memory: 2g
 
 tested-groups:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-100B.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
+    arguments: '"--data-size" "100" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
   resources:
     requests:
       memory: 1g
@@ -22,10 +22,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "100" --command "GET __key__" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180'
+  arguments: '--data-size 100 --ratio 0:1 --key-pattern R:R -c 25 -t 4 --hide-histogram --test-time 180'
   resources:
     requests:
-      cpus: '2'
+      cpus: '4'
       memory: 2g
 
 tested-groups:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-10.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "10" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
   resources:
     requests:
       memory: 1g
@@ -22,10 +22,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--pipeline" "10" "--data-size" "10" --command "GET __key__" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180'
+  arguments: '"--pipeline" "10" "--data-size" "10" --ratio 0:1 --key-pattern R:R -c 25 -t 4 --hide-histogram --test-time 180'
   resources:
     requests:
-      cpus: '2'
+      cpus: '4'
       memory: 2g
 
 tested-groups:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "10" "--command" "SET __key__ __data__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
   resources:
     requests:
       memory: 1g
@@ -22,10 +22,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "10" --command "GET __key__" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180'
+  arguments: '"--data-size" "10" --ratio 0:1 --key-pattern R:R -c 25 -t 4 --hide-histogram --test-time 180'
   resources:
     requests:
-      cpus: '2'
+      cpus: '4'
       memory: 2g
 
 tested-groups:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB-pipeline-10.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --data-size 1000 "--command" "SET __key__ __data__" --command-key-pattern="P" -c 50 -t 2  --hide-histogram --key-minimum 1
+    arguments: '"--data-size" "1000" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
   resources:
     requests:
       memory: 2g
@@ -22,10 +22,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --pipeline 10 --data-size 1000 --command "GET __key__" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180
+  arguments: --pipeline 10 --data-size 1000 --ratio 0:1 --key-pattern R:R -c 25 -t 4 --hide-histogram --test-time 180
   resources:
     requests:
-      cpus: '2'
+      cpus: '4'
       memory: 2g
 
 tested-groups:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-1KiB.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --data-size 1000 "--command" "SET __key__ __data__" --command-key-pattern="P" -c 50 -t 2  --hide-histogram --key-minimum 1
+    arguments: '"--data-size" "1000" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1"'
   resources:
     requests:
       memory: 2g
@@ -22,10 +22,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --data-size 1000 --command "GET __key__" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180
+  arguments: --data-size 1000  --ratio 0:1 --key-pattern R:R -c 25 -t 4 --hide-histogram --test-time 180
   resources:
     requests:
-      cpus: '2'
+      cpus: '4'
       memory: 2g
 
 tested-groups:

--- a/utils/tests/test_runner.py
+++ b/utils/tests/test_runner.py
@@ -23,7 +23,7 @@ def test_prepare_memtier_benchmark_parameters():
         assert client_tool == "memtier_benchmark"
         local_benchmark_output_filename = "1.json"
         oss_api_enabled = False
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -36,7 +36,7 @@ def test_prepare_memtier_benchmark_parameters():
             benchmark_command_str
             == 'memtier_benchmark --port 12000 --server localhost --json-out-file 1.json "--data-size" "100" --command "SETEX __key__ 10 __data__" --command-key-pattern="R" --command "SET __key__ __data__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time 300'
         )
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -57,7 +57,7 @@ def test_prepare_memtier_benchmark_parameters():
             == 'memtier_benchmark --port 12000 --server localhost --json-out-file 1.json "--data-size" "100" --command "SETEX __key__ 10 __data__" --command-key-pattern="R" --command "SET __key__ __data__" --command-key-pattern="R" --command "GET __key__" --command-key-pattern="R" --command "DEL __key__" --command-key-pattern="R"  -c 50 -t 2 --hide-histogram --test-time=5'
         )
         oss_api_enabled = True
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -78,7 +78,7 @@ def test_prepare_memtier_benchmark_parameters():
         tls_key = None
 
         # ensure that when tls is disabled we dont change the args
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -97,7 +97,7 @@ def test_prepare_memtier_benchmark_parameters():
         )
 
         tls_enabled = True
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -116,7 +116,7 @@ def test_prepare_memtier_benchmark_parameters():
         )
 
         tls_skip_verify = False
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -137,7 +137,7 @@ def test_prepare_memtier_benchmark_parameters():
         tls_skip_verify = False
         tls_cert = "cert.file"
         tls_key = "key.file"
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,
@@ -156,7 +156,7 @@ def test_prepare_memtier_benchmark_parameters():
         )
 
         tls_cacert = "cacert.file"
-        (_, benchmark_command_str,) = prepare_memtier_benchmark_parameters(
+        (_, benchmark_command_str, _) = prepare_memtier_benchmark_parameters(
             benchmark_config["clientconfig"],
             client_tool,
             12000,


### PR DESCRIPTION
Benchmarks that we can now use on an OSS cluster deployment (It implied that we moved from `--command` to `--ratio` ) :

- memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10.yml
- memtier_benchmark-1Mkeys-load-string-with-100B-values.yml
- memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-10.yml
- memtier_benchmark-1Mkeys-load-string-with-10B-values.yml
- memtier_benchmark-1Mkeys-load-string-with-1KiB-values.yml
- memtier_benchmark-1Mkeys-string-get-100B-pipeline-10.yml
- memtier_benchmark-1Mkeys-string-get-100B.yml
- memtier_benchmark-1Mkeys-string-get-10B-pipeline-10.yml
- memtier_benchmark-1Mkeys-string-get-10B.yml
- memtier_benchmark-1Mkeys-string-get-1KiB-pipeline-10.yml
- memtier_benchmark-1Mkeys-string-get-1KiB.yml

For the benchmarks that use `--command` on memtier we check for that keyword on the client arguments preparation and skip that benchmark when cluster-mode is enabled.