### PR TITLE
Test runs req memory

### DIFF
--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -463,7 +463,12 @@ def process_self_contained_coordinator_stream(
                         benchmark_config
                     )
                     maxmemory = get_maxmemory(r)
-                    if benchmark_required_memory > maxmemory:
+
+                    test_iterations = 1
+                    if override_test_runs > 1: 
+                            test_iterations = override_test_runs
+                    
+                    if benchmark_required_memory * test_iterations > maxmemory:
                         logging.warning(
                             "Skipping test {} given maxmemory of server is bellow the benchmark required memory: {} < {}".format(
                                 test_name, maxmemory, benchmark_required_memory

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -465,9 +465,9 @@ def process_self_contained_coordinator_stream(
                     maxmemory = get_maxmemory(r)
 
                     test_iterations = 1
-                    if override_test_runs > 1: 
-                            test_iterations = override_test_runs
-                    
+                    if override_test_runs > 1:
+                        test_iterations = override_test_runs
+
                     if benchmark_required_memory * test_iterations > maxmemory:
                         logging.warning(
                             "Skipping test {} given maxmemory of server is bellow the benchmark required memory: {} < {}".format(


### PR DESCRIPTION
If we have a test, which loads data into Redis, running this test repeatedly using "override_test_runs" may result in consuming too much memory -in the worst case crashing the redis server. 

With this pull request, we calculate the required memory per test by taking into account the number of test runs. 
The current pull request is conservative, since some tests do not grow their memory footprint over time - but we nevertheless multiply their requirements by the number of test runs. 