### PR TITLE
Added conversion for str for git timestamps

### DIFF
--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -73,7 +73,7 @@ def get_commits(args, repo):
                         "git_hash": commit.hexsha,
                         "git_branch": repo.active_branch.name,
                         "commit_summary": commit.summary,
-                        "commit_datetime": commit_datetime,
+                        "commit_datetime": str(commit_datetime),
                     }
                 )
     return commits, total_commits

--- a/redis_benchmarks_specification/__cli__/stats.py
+++ b/redis_benchmarks_specification/__cli__/stats.py
@@ -338,9 +338,6 @@ def generate_stats_cli_command_logic(args, project_name, project_version):
                     logging.warn("Unable to detect group in {}".format(cmd))
 
         priority_list = sorted(((priority[cmd], cmd) for cmd in priority), reverse=True)
-        priority_list_usecs = sorted(
-            ((priority_usecs[cmd], cmd) for cmd in priority_usecs), reverse=True
-        )
 
         priority_json = {}
         top_10_missing = []


### PR DESCRIPTION
Added conversion to avoid error during testing triggering:
```
$ redis-benchmarks-spec-cli --use-branch --from-date 2023-02-11  --redis_port 12010 --redis_host *** --redis_pass *** --redis_user default
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/redis-benchmarks-spec-cli", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/.local/lib/python3.8/site-packages/redis_benchmarks_specification/__cli__/cli.py", line 53, in main
    trigger_tests_cli_command_logic(args, project_name, project_version)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/redis_benchmarks_specification/__cli__/cli.py", line 259, in trigger_tests_cli_command_logic
    ) = request_build_from_commit_info(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/redis_benchmarks_specification/__common__/builder_schema.py", line 151, in request_build_from_commit_info
    raise Exception(
Exception: Type of field commit_datetime is not bytes, string, int or float. Type (<class 'datetime.datetime'>). Value=2023-02-21 18:58:55+02:00
```