### PR TITLE
Fix for TypeError in self-coordinator

### DIFF
--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -32,6 +32,7 @@ from redis_benchmarks_specification.__common__.runner import (
     extract_testsuites,
     reset_commandstats,
     exporter_datasink_common,
+    execute_init_commands,
 )
 from redis_benchmarks_specification.__runner__.runner import (
     print_results_table_stdout,
@@ -54,7 +55,6 @@ from redisbench_admin.profilers.profilers_local import (
 from redisbench_admin.run.common import (
     get_start_time_vars,
     prepare_benchmark_parameters,
-    execute_init_commands,
 )
 from redisbench_admin.run.grafana import generate_artifacts_table_grafana_redis
 from redisbench_admin.run.redistimeseries import (

--- a/utils/tests/test_data/test-suites/redis-benchmark-full-suite-1Mkeys-100B.yml
+++ b/utils/tests/test_data/test-suites/redis-benchmark-full-suite-1Mkeys-100B.yml
@@ -4,8 +4,8 @@ description: "Runs the default redis-benchmark test suite, for a keyspace length
               with a data size of 100 Bytes for each key. On total 50 concurrent connections 
               will be used, sending 1M requests."
 dbconfig:
-  - configuration-parameters:
-    - save: '""'
+  configuration-parameters:
+    save: '""'
 tested-commands:
   - PING
   - SET


### PR DESCRIPTION
Fix for "TypeError" (see below) includes replacement of exec_init_command function from redis-admin branch to similar (but newer) function in redis-benchmark-specification branch. 
redis-* test syntax was aligned to others tests for passing CI rules 

### Error:
```Traceback (most recent call last):
  File "/root/venv-redis/lib/python3.8/site-packages/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py", line 560, in process_self_contained_coordinator_stream
    execute_init_commands(
  File "/root/venv-redis/lib/python3.8/site-packages/redisbench_admin/run/common.py", line 426, in execute_init_commands
    cmds = k["init_commands"]
TypeError: string indices must be integers
```

### How to reproduce:
Run on testing host: 
```
$ redis-benchmarks-spec-sc-coordinator --platform-name intel64-ubuntu20.04-biredis --event_stream_host benchmarks.redislabs.com --event_stream_port <redacted> --event_stream_pass <redacted> --event_stream_user default --datasink_push_results_redistimeseries --datasink_redistimeseries_host benchmarks.redislabs.com --datasink_redistimeseries_port 12011 --datasink_redistimeseries_pass <redacted> --logname /var/opt/test2.log --redis_proc_start_port 6379 --cpuset_start_pos 0 --docker-air-gap --consumer-id 1
```
In parallell run testing's triggering:
```
redis-benchmarks-spec-cli --use-branch --from-date 2023-03-22 --redis_port 12010 --redis_host benchmarks.redislabs.com --redis_pass ***
```
