### PR TITLE
Aligned lhash* test-files' names with name inside file

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hexists.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hexists.yml
@@ -1,5 +1,5 @@
 version: 0.4
-name: memtier_benchmark-1Mkeys-lhash-hexists
+name: memtier_benchmark-1Mkeys-hash-hexists
 description: Runs memtier_benchmark, for a keyspace length of 1M keys loading HASHES with 5 fields each. Each field value has a data size of 100 Bytes. After loading test HEXISTS command. 
 dbconfig:
   configuration-parameters:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hincrby.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hincrby.yml
@@ -1,5 +1,5 @@
 version: 0.4
-name: memtier_benchmark-1Mkeys-lhash-hincbry
+name: memtier_benchmark-1Mkeys-hash-hincrby
 description: Runs memtier_benchmark, for a keyspace length of 1M keys loading HASHES with 5 fields each. Each field value has a data size of 1000 Bytes.
 dbconfig:
   configuration-parameters:


### PR DESCRIPTION
There difference in file test with test description and "name" in test's description itself. 
Suggest to align tests' names by renaming of files:

$ less memtier_benchmark-1Mkeys-**hash**-hinc**rb**y.yml | grep name
name: memtier_benchmark-1Mkeys-**lhash**-hinc**br**y
$ less memtier_benchmark-1Mkeys-**hash**-hexists.yml | grep name
name: memtier_benchmark-1Mkeys-**lhash**-hexists

Suggested solution - align name in description with file name.