### PR TITLE
Include a DECR benchmark covering embstring object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.1.71"
+version = "0.1.72"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decr.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decr.yml
@@ -1,0 +1,33 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-get-100B
+description: Runs memtier_benchmark, for a keyspace length of 1M keys testing use embedded string object encoding on the string and doing decr command.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: ' --command "SET __key__ 9223372036854775807" --command-key-pattern="P" -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      memory: 1g
+tested-commands:
+- get
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:8.5.0-amd64-debian-buster-default
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 180 --command "DECR __key__" --command-key-pattern="R" --key-minimum=1 --key-maximum 1000000 -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+
+tested-groups:
+- string
+priority: 98

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decr.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decr.yml
@@ -1,5 +1,5 @@
 version: 0.4
-name: memtier_benchmark-1Mkeys-string-get-100B
+name: memtier_benchmark-1Mkeys-string-decr
 description: Runs memtier_benchmark, for a keyspace length of 1M keys testing use embedded string object encoding on the string and doing decr command.
 dbconfig:
   configuration-parameters:
@@ -14,7 +14,7 @@ dbconfig:
     requests:
       memory: 1g
 tested-commands:
-- get
+- decr
 redis-topologies:
 - oss-standalone
 build-variants:


### PR DESCRIPTION

Reference:
https://github.com/redis/redis/pull/12250


Simple run:
```
$ redis-benchmarks-spec-client-runner --test memtier_benchmark-1Mkeys-string-decr.yml  --override-memtier-test-time 10
2023-06-18 10:14:24 INFO redis-benchmarks-spec-client-runner (solely client) 0.1.71
2023-06-18 10:14:24 INFO Using test-suites folder dir /home/fco/.local/lib/python3.10/site-packages/redis_benchmarks_specification/test-suites
2023-06-18 10:14:24 INFO Running specific benchmark in 1 files: ['/home/fco/.local/lib/python3.10/site-packages/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decr.yml']
2023-06-18 10:14:24 INFO There are a total of 1 test-suites in folder /home/fco/.local/lib/python3.10/site-packages/redis_benchmarks_specification/test-suites
2023-06-18 10:14:24 INFO Overriding memtier benchmark --test-time to 10 seconds
2023-06-18 10:14:24 INFO Running the benchmark specs.
2023-06-18 10:14:24 INFO Loading default specifications from file: /home/fco/.local/lib/python3.10/site-packages/redis_benchmarks_specification/test-suites/defaults.yml
2023-06-18 10:14:24 INFO Found RedisTimeSeries default metrics specification. Will include the following metrics on all benchmarks $."BEST RUN RESULTS".Totals."Ops/sec" $."BEST RUN RESULTS".Totals."Latency" $."BEST RUN RESULTS".Totals."Misses/sec" $."BEST RUN RESULTS".Totals."Percentile Latencies"."p50.00" $."WORST RUN RESULTS".Totals."Ops/sec" $."WORST RUN RESULTS".Totals."Latency" $."WORST RUN RESULTS".Totals."Misses/sec" $."WORST RUN RESULTS".Totals."Percentile Latencies"."p50.00" $."AGGREGATED AVERAGE RESULTS (3 runs)".Totals."Ops/sec" $."AGGREGATED AVERAGE RESULTS (3 runs)".Totals."Latency" $."AGGREGATED AVERAGE RESULTS (3 runs)".Totals."Misses/sec" $."AGGREGATED AVERAGE RESULTS (5 runs)".Totals."Percentile Latencies"."p50.00" $."ALL STATS".Totals."Ops/sec" $."ALL STATS".Totals."Latency" $."ALL STATS".Totals."Misses/sec" $."ALL STATS".Totals."Percentile Latencies"."p50.00"
2023-06-18 10:14:24 INFO Found RedisTimeSeries default time metric specification. Will use the following JSON path to retrieve the test time $."ALL STATS".Runtime."Start time"
2023-06-18 10:14:24 INFO Benchmark required memory: 1073741824 Bytes
2023-06-18 10:14:24 INFO  Using total system memory as max 33346134016
2023-06-18 10:14:24 INFO Resetting commmandstats for shard 0
2023-06-18 10:14:24 INFO Test memtier_benchmark-1Mkeys-string-get-100B priority (98) is within the priority limit [0,100000]
2023-06-18 10:14:24 INFO Using docker image redislabs/memtier_benchmark:edge as benchmark PRELOAD image (cpuset=0,1,2,3) with the following args: /usr/local/bin/memtier_benchmark --port 6379 --server localhost --json-out-file oss-standalone-2023-06-18-09-14-24-NA-preload__memtier_benchmark-1Mkeys-string-get-100B.json  --command "SET __key__ 9223372036854775807" --command-key-pattern="P" -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram
2023-06-18 10:14:28 INFO Preload duration 4 secs.
2023-06-18 10:14:28 INFO Tool 4 seconds to load data. Output b'4         Threads\n50        Connections per thread\n5000      Requests per client\n\n\nALL STATS\n==================================================================================================\nType         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec \n--------------------------------------------------------------------------------------------------\nSets       271621.77         0.72978         0.69500         1.45500         4.79900     17212.14 \nTotals     271621.77         0.72978         0.69500         1.45500         4.79900     17212.14 \n'
2023-06-18 10:14:28 INFO Benchmark used memory at start of benchmark: 1g
2023-06-18 10:14:28 INFO Checking if there is a keyspace check being enforced
2023-06-18 10:14:28 INFO Ensuring keyspace length requirement = 1000000 is met.
2023-06-18 10:14:28 INFO The total numbers of keys in setup matches the expected spec: 1000000==1000000
2023-06-18 10:14:28 INFO Will store benchmark json output to local file oss-standalone-2023-06-18-09-14-28-NA-memtier_benchmark-1Mkeys-string-get-100B.json
2023-06-18 10:14:28 INFO Using docker image redislabs/memtier_benchmark:edge as benchmark client image (cpuset=0,1,2,3) with the following args: /usr/local/bin/memtier_benchmark --port 6379 --server localhost --json-out-file oss-standalone-2023-06-18-09-14-28-NA-memtier_benchmark-1Mkeys-string-get-100B.json --test-time=10 --command "DECR __key__" --command-key-pattern="R" --key-minimum=1 --key-maximum 1000000 -c 4 -t 4 --hide-histogram
2023-06-18 10:14:39 INFO Benchmark duration 11 secs.
2023-06-18 10:14:39 WARNING Benchmark duration of 11 secs is bellow the considered minimum duration for a stable run (60 secs).
2023-06-18 10:14:39 INFO Printing client tool stdout output
2023-06-18 10:14:39 INFO Benchmark used memory at end of benchmark: 1g
2023-06-18 10:14:39 INFO Reading results json from /home/fco/tmpm5txmixj/oss-standalone-2023-06-18-09-14-28-NA-memtier_benchmark-1Mkeys-string-get-100B.json
# Results for memtier_benchmark-1Mkeys-string-get-100B test-case on oss-standalone topology
|                 Metric JSON Path                 |Metric Value|
|--------------------------------------------------|-----------:|
|"ALL STATS".Totals."Ops/sec"                      |  250742.070|
|"ALL STATS".Totals."Latency"                      |       0.064|
|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|"ALL STATS".Totals."Percentile Latencies"."p50.00"|       0.063|
2023-06-18 10:14:39 INFO Using datapoint_time_ms: 1687079668434
2023-06-18 10:14:39 ERROR Requested to push data to RedisTimeSeries but no exporter definition was found. Missing "exporter" config.
2023-06-18 10:14:39 INFO Collecting memory metrics
2023-06-18 10:14:39 INFO Adding a total of 35 server side metrics collected at the end of benchmark
2023-06-18 10:14:39 INFO Collecting commandstat metrics
2023-06-18 10:14:39 INFO Adding a total of 20 server side metrics collected at the end of benchmark
2023-06-18 10:14:39 INFO Tearing down setup
2023-06-18 10:14:39 INFO Removing temporary client dir /home/fco/tmpm5txmixj
# Results for entire test-suite
|               Test Name                |                 Metric JSON Path                 |Metric Value|
|----------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1Mkeys-string-get-100B|"ALL STATS".Totals."Ops/sec"                      |  250742.070|
|memtier_benchmark-1Mkeys-string-get-100B|"ALL STATS".Totals."Latency"                      |       0.064|
|memtier_benchmark-1Mkeys-string-get-100B|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1Mkeys-string-get-100B|"ALL STATS".Totals."Percentile Latencies"."p50.00"|       0.063|
```