### PR TITLE
Fixed memtier_benchmark-1key-zset-100-elements-zrangebyscore-all-elements-long-scores key and prepopulation stage

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-100-elements-zrangebyscore-all-elements-long-scores.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-100-elements-zrangebyscore-all-elements-long-scores.yml
@@ -10,7 +10,7 @@ dbconfig:
     requests:
       memory: 1g
   init_commands:
-  - '"ZADD" "zset:10:long_score" "10000000" "lysbgqqfqw" "10000001" "mtccjerdon" "10000002" "jekkafodvk" "10000003" "nmgxcctxpn" "10000004" "vyqqkuszzh" "10000005" "pytrnqdhvs" "10000006" "oguwnmniig" "10000007" "gekntrykfh" "10000008" "nhfnbxqgol" "10000009" "cgoeihlnei"'
+  - '"ZADD" "zset:100:long_score" "10000000" "vyoomgwuzv" "10000001" "xamjodnbpf" "10000002" "ewomnmugfa" "10000003" "ljcgdooafo" "10000004" "pcxdhdjwnf" "10000005" "djetcyfxuc" "10000006" "licotqplim" "10000007" "alqlzsvuuz" "10000008" "ijsmoyesvd" "10000009" "whmotknaff" "10000010" "rkaznetutk" "10000011" "ksqpdywgdd" "10000012" "gorgpnnqwr" "10000013" "gekntrykfh" "10000014" "rjkknoigmu" "10000015" "luemuetmia" "10000016" "gxephxbdru" "10000017" "ncjfckgkcl" "10000018" "hhjclfbbka" "10000019" "cgoeihlnei" "10000020" "zwnitejtpg" "10000021" "upodnpqenn" "10000022" "mibvtmqxcy" "10000023" "htvbwmfyic" "10000024" "rqvryfvlie" "10000025" "nxcdcaqgit" "10000026" "gfdqdrondm" "10000027" "lysbgqqfqw" "10000028" "nxzsnkmxvi" "10000029" "nsxaigrnje" "10000030" "cwaveajmcz" "10000031" "xsepfhdizi" "10000032" "owtkxlzaci" "10000033" "agsdggdghc" "10000034" "tcjvjofxtd" "10000035" "kgqrovsxce" "10000036" "ouuybhtvyb" "10000037" "ueyrvldzwl" "10000038" "vpbkvwgxsf" "10000039" "pytrnqdhvs" "10000040" "qbiwbqiubb" "10000041" "ssjqrsluod" "10000042" "urvgxwbiiz" "10000043" "ujrxcmpvsq" "10000044" "mtccjerdon" "10000045" "xczfmrxrja" "10000046" "imyizmhzjk" "10000047" "oguwnmniig" "10000048" "mxwgdcutnb" "10000049" "pqyurbvifk" "10000050" "ccagtnjilc" "10000051" "mbxohpancs" "10000052" "lgrkndhekf" "10000053" "eqlgkwosie" "10000054" "jxoxtnzujs" "10000055" "lbtpbknelm" "10000056" "ichqzmiyot" "10000057" "mbgehjiauu" "10000058" "aovfsvbwjg" "10000059" "nmgxcctxpn" "10000060" "vyqqkuszzh" "10000061" "rojeolnopp" "10000062" "ibhohmfxzt" "10000063" "qbyhorvill" "10000064" "nhfnbxqgol" "10000065" "wkbasfyzqz" "10000066" "mjjuylgssm" "10000067" "imdqxmkzdj" "10000068" "oapbvnisyq" "10000069" "bqntlsaqjb" "10000070" "ocrcszcznp" "10000071" "hhniikmtsx" "10000072" "hlpdstpvzw" "10000073" "wqiwdbncmt" "10000074" "vymjzlzqcn" "10000075" "hhjchwjlmc" "10000076" "ypfeltycpy" "10000077" "qjyeqcfhjj" "10000078" "uapsgmizgh" "10000079" "owbbdezgxn" "10000080" "qrosceblyo" "10000081" "sahqeskveq" "10000082" "dapacykoah" "10000083" "wvcnqbvlnf" "10000084" "perfwnpvkl" "10000085" "ulbrotlhze" "10000086" "fhuvzpxjbc" "10000087" "holjcdpijr" "10000088" "onzjrteqmu" "10000089" "pquewclxuy" "10000090" "vpmpffdoqz" "10000091" "eouliovvra" "10000092" "vxcbagyymm" "10000093" "jekkafodvk" "10000094" "ypekeuutef" "10000095" "dlbqcynhrn" "10000096" "erxulvebrj" "10000097" "qwxrsgafzy" "10000098" "dlsjwmqzhx" "10000099" "exvhmqxvvp"'
 tested-groups:
 - sorted-set
 tested-commands:
@@ -22,7 +22,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="ZRANGEBYSCORE zset:100:long_score 0 1 WITHSCORES"  --hide-histogram --test-time 180
+  arguments: --command="ZRANGEBYSCORE zset:100:long_score 0 1000000000 WITHSCORES"  --hide-histogram --test-time 180
   resources:
     requests:
       cpus: '4'


### PR DESCRIPTION
- By analyzing the test we saw that the input key and the benchmark key where different.
- We also saw that the number of elements did not matched. 