### PR TITLE
Move temporary dir deletion to inner function, delete temp dir in skipped benchmarks

### DIFF
--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -912,9 +912,7 @@ def process_self_contained_coordinator_stream(
                                     logging.critical("Printing redis container log....")
                                     print("-" * 60)
                                     print(
-                                        redis_container.logs(
-                                            stdout=True, stderr=True, logs=True
-                                        )
+                                        redis_container.logs(stdout=True, stderr=True)
                                     )
                                     print("-" * 60)
                                 test_result = False


### PR DESCRIPTION
Opened again from branch created in this repository instead of forked branch.

Probably connected with issue: https://github.com/redis/redis-benchmarks-specification/issues/244.

So far when some check resulted with skipping benchmark, it would keep an empty temporary directory in home directory. Deletion of temporary dir should happen in such situation before continuing to the next benchmark.

This PR moves temporary directory deletion to inner function in process_self_contained_coordinator_stream and invokes it before skipping any benchmark