### PR TITLE
Added memtier_benchmark-3Mkeys-load-string-with-512B-values. Included 2,4,8,16,32,64 io-threads setups.

### DIFF
--- a/redis_benchmarks_specification/__common__/spec.py
+++ b/redis_benchmarks_specification/__common__/spec.py
@@ -1,4 +1,56 @@
 import math
+import logging
+
+
+def extract_redis_dbconfig_parameters(benchmark_config, dbconfig_keyname):
+    redis_configuration_parameters = {}
+    modules_configuration_parameters_map = {}
+    dataset_load_timeout_secs = 120
+    dataset_name = None
+    dbconfig_present = False
+    if dbconfig_keyname in benchmark_config:
+        dbconfig_present = True
+        if type(benchmark_config[dbconfig_keyname]) == list:
+            for k in benchmark_config[dbconfig_keyname]:
+                if "configuration-parameters" in k:
+                    cp = k["configuration-parameters"]
+                    for item in cp:
+                        for k, v in item.items():
+                            redis_configuration_parameters[k] = v
+                if "dataset_load_timeout_secs" in k:
+                    dataset_load_timeout_secs = k["dataset_load_timeout_secs"]
+                if "dataset_name" in k:
+                    dataset_name = k["dataset_name"]
+        if type(benchmark_config[dbconfig_keyname]) == dict:
+            if "configuration-parameters" in benchmark_config[dbconfig_keyname]:
+                cp = benchmark_config[dbconfig_keyname]["configuration-parameters"]
+                for k, v in cp.items():
+                    redis_configuration_parameters[k] = v
+            if "dataset_load_timeout_secs" in benchmark_config[dbconfig_keyname]:
+                dataset_load_timeout_secs = benchmark_config[dbconfig_keyname][
+                    "dataset_load_timeout_secs"
+                ]
+            if "dataset_name" in benchmark_config[dbconfig_keyname]:
+                dataset_name = benchmark_config[dbconfig_keyname]["dataset_name"]
+
+    return (
+        dbconfig_present,
+        dataset_name,
+        redis_configuration_parameters,
+        dataset_load_timeout_secs,
+        modules_configuration_parameters_map,
+    )
+
+
+def extract_redis_configuration_from_topology(topologies_map, topology_spec_name):
+    redis_arguments = ""
+    topology_spec = topologies_map[topology_spec_name]
+    if "redis_arguments" in topology_spec:
+        redis_arguments = topology_spec["redis_arguments"]
+        logging.info(
+            f"extracted redis_arguments: {redis_arguments} from topology: {topology_spec_name}"
+        )
+    return redis_arguments
 
 
 def extract_client_cpu_limit(benchmark_config):

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -8,7 +8,7 @@ from redis_benchmarks_specification.__self_contained_coordinator__.cpuset import
 
 
 def generate_standalone_redis_server_args(
-    binary, port, dbdir, configuration_parameters=None
+    binary, port, dbdir, configuration_parameters=None, redis_arguments=""
 ):
     added_params = ["port", "protected-mode", "dir"]
     # start redis-server
@@ -30,6 +30,10 @@ def generate_standalone_redis_server_args(
                         parameter_value,
                     ]
                 )
+    if redis_arguments != "":
+        redis_arguments_arr = redis_arguments.split(" ")
+        logging.info(f"adding redis arguments {redis_arguments_arr}")
+        command.extend(redis_arguments_arr)
     return command
 
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -32,7 +32,6 @@ from redisbench_admin.run.redistimeseries import (
 from redisbench_admin.run.run import calculate_client_tool_duration_and_check
 from redisbench_admin.utils.benchmark_config import (
     get_final_benchmark_config,
-    extract_redis_dbconfig_parameters,
 )
 from redisbench_admin.utils.local import get_local_run_full_filename
 from redisbench_admin.utils.results import post_process_benchmark_results
@@ -47,6 +46,7 @@ from redis_benchmarks_specification.__common__.spec import (
     extract_client_cpu_limit,
     extract_client_tool,
     extract_client_container_image,
+    extract_redis_dbconfig_parameters,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.artifacts import (
     restore_build_artifacts_from_test_details,

--- a/redis_benchmarks_specification/setups/topologies/topologies.yml
+++ b/redis_benchmarks_specification/setups/topologies/topologies.yml
@@ -10,6 +10,71 @@ spec:
         cpus: "1"
         memory: "10g"
 
+  - name: oss-standalone-02-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 2 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "3"
+        memory: "10g"
+
+  - name: oss-standalone-04-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 4 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "5"
+        memory: "10g"
+
+  - name: oss-standalone-08-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 8 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "9"
+        memory: "10g"
+
+  - name: oss-standalone-16-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 16 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "17"
+        memory: "10g"
+
+  - name: oss-standalone-32-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 32 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "33"
+        memory: "10g"
+
+  - name: oss-standalone-64-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 64 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "65"
+        memory: "10g"
   - name: oss-standalone-1replica
     type: oss-standalone
     redis_topology:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-load-string-with-512B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-load-string-with-512B-values.yml
@@ -1,0 +1,30 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-load-string-with-512B-values
+description: Runs memtier_benchmark, for a keyspace length of 3M keys loading STRINGs in which the value has a data size of 512 Bytes, with 650 clients running sequential SET commands.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 0
+  resources:
+    requests:
+      memory: 3g
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:8.5.0-amd64-debian-buster-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "512" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 50 -t 13 --hide-histogram'
+  resources:
+    requests:
+      cpus: '13'
+      memory: 2g
+
+tested-groups:
+- string
+priority: 17

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-load-string-with-512B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-load-string-with-512B-values.yml
@@ -13,6 +13,12 @@ tested-commands:
 - set
 redis-topologies:
 - oss-standalone
+- oss-standalone-02-io-threads
+- oss-standalone-04-io-threads
+- oss-standalone-08-io-threads
+- oss-standalone-16-io-threads
+- oss-standalone-32-io-threads
+- oss-standalone-64-io-threads
 build-variants:
 - gcc:8.5.0-amd64-debian-buster-default
 - dockerhub

--- a/utils/tests/test_data/test-suites/test-memtier-dockerhub-iothreads.yml
+++ b/utils/tests/test_data/test-suites/test-memtier-dockerhub-iothreads.yml
@@ -1,0 +1,30 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-load-string-with-10B-values
+description: Runs memtier_benchmark, for a keyspace length of 1M keys loading STRINGs in which the value has a data size of 10 Bytes.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 0
+  resources:
+    requests:
+      memory: 1g
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone-02-io-threads
+build-variants:
+- gcc:8.5.0-amd64-debian-buster-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "10" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: "1"
+      memory: "2g"
+
+tested-groups:
+- string
+priority: 17

--- a/utils/tests/test_data/test-suites/topologies.yml
+++ b/utils/tests/test_data/test-suites/topologies.yml
@@ -1,0 +1,22 @@
+spec:
+  setups:
+  - name: oss-standalone
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    resources:
+      requests:
+        cpus: "1"
+        memory: "10g"
+
+  - name: oss-standalone-02-io-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --io-threads 2 --io-threads-do-reads yes
+    resources:
+      requests:
+        cpus: "1"
+        memory: "10g"

--- a/utils/tests/test_runner.py
+++ b/utils/tests/test_runner.py
@@ -258,7 +258,7 @@ def test_extract_testsuites():
         ]
     )
     tests = extract_testsuites(args)
-    assert len(tests) == 7
+    assert len(tests) == 9
 
     args = parser.parse_args(
         args=[
@@ -269,7 +269,7 @@ def test_extract_testsuites():
         ]
     )
     tests = extract_testsuites(args)
-    assert len(tests) == 7
+    assert len(tests) == 9
 
     args = parser.parse_args(
         args=[

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -263,3 +263,7 @@ def test_self_contained_coordinator_blocking_read():
 
     except redis.exceptions.ConnectionError:
         pass
+
+
+def test_extract_redis_configuration_from_topology():
+    assert False

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -263,7 +263,3 @@ def test_self_contained_coordinator_blocking_read():
 
     except redis.exceptions.ConnectionError:
         pass
-
-
-def test_extract_redis_configuration_from_topology():
-    assert False

--- a/utils/tests/test_self_contained_coordinator_memtier.py
+++ b/utils/tests/test_self_contained_coordinator_memtier.py
@@ -478,6 +478,133 @@ def test_self_contained_coordinator_dockerhub():
         pass
 
 
+def test_self_contained_coordinator_dockerhub_iothreads():
+    try:
+        if run_coordinator_tests_dockerhub():
+            db_port = int(os.getenv("DATASINK_PORT", "6379"))
+            conn = redis.StrictRedis(port=db_port)
+            conn.ping()
+            conn.flushall()
+
+            id = "dockerhub"
+            redis_version = "7.4.0"
+            run_image = f"redis:{redis_version}"
+            build_arch = "amd64"
+            testDetails = {}
+            build_os = "test_build_os"
+            build_stream_fields, result = generate_benchmark_stream_request(
+                id,
+                conn,
+                run_image,
+                build_arch,
+                testDetails,
+                build_os,
+            )
+            build_stream_fields["mnt_point"] = ""
+            if result is True:
+                benchmark_stream_id = conn.xadd(
+                    STREAM_KEYNAME_NEW_BUILD_EVENTS, build_stream_fields
+                )
+                logging.info(
+                    "sucessfully requested a new run {}. Stream id: {}".format(
+                        build_stream_fields, benchmark_stream_id
+                    )
+                )
+
+            build_variant_name = "gcc:8.5.0-amd64-debian-buster-default"
+            expected_datapoint_ts = None
+
+            assert conn.exists(STREAM_KEYNAME_NEW_BUILD_EVENTS)
+            assert conn.xlen(STREAM_KEYNAME_NEW_BUILD_EVENTS) > 0
+            running_platform = "fco-ThinkPad-T490"
+
+            build_runners_consumer_group_create(conn, running_platform, "0")
+            datasink_conn = redis.StrictRedis(port=db_port)
+            docker_client = docker.from_env()
+            home = str(Path.home())
+            stream_id = ">"
+            topologies_map = get_topologies(
+                "./utils/tests/test_data/test-suites/topologies.yml"
+            )
+            # we use a benchmark spec with smaller CPU limit for client given github machines only contain 2 cores
+            # and we need 1 core for DB and another for CLIENT
+            testsuite_spec_files = [
+                "./utils/tests/test_data/test-suites/test-memtier-dockerhub-iothreads.yml"
+            ]
+            defaults_filename = "./utils/tests/test_data/test-suites/defaults.yml"
+            (
+                _,
+                _,
+                default_metrics,
+                _,
+                _,
+                _,
+            ) = get_defaults(defaults_filename)
+
+            (
+                result,
+                stream_id,
+                number_processed_streams,
+                num_process_test_suites,
+            ) = self_contained_coordinator_blocking_read(
+                conn,
+                True,
+                docker_client,
+                home,
+                stream_id,
+                datasink_conn,
+                testsuite_spec_files,
+                topologies_map,
+                running_platform,
+                False,
+                [],
+                "",
+                0,
+                6399,
+                1,
+                False,
+                5,
+                default_metrics,
+                "amd64",
+                None,
+                0,
+                10000,
+                "unstable",
+                "",
+                True,
+                False,
+            )
+
+            assert result == True
+            assert number_processed_streams == 1
+            assert num_process_test_suites == 1
+            by_version_key = f"ci.benchmarks.redislabs/ci/redis/redis/memtier_benchmark-1Mkeys-load-string-with-10B-values/by.version/{redis_version}/benchmark_end/oss-standalone-02-io-threads/memory_maxmemory"
+            assert datasink_conn.exists(by_version_key)
+            rts = datasink_conn.ts()
+            # check we have by version metrics
+            assert "version" in rts.info(by_version_key).labels
+            assert redis_version == rts.info(by_version_key).labels["version"]
+
+            # get all keys
+            all_keys = datasink_conn.keys("*")
+            by_hash_keys = []
+            for key in all_keys:
+                if "/by.hash/" in key.decode():
+                    by_hash_keys.append(key)
+
+            # ensure we have by hash keys
+            assert len(by_hash_keys) > 0
+            for hash_key in by_hash_keys:
+                # ensure we have both version and hash info on the key
+                assert "version" in rts.info(hash_key).labels
+                assert "oss-standalone-02-io-threads" in hash_key.decode()
+                assert "hash" in rts.info(hash_key).labels
+                assert redis_version == rts.info(hash_key).labels["version"]
+
+    except redis.exceptions.ConnectionError:
+        pass
+
+
 def test_self_contained_coordinator_dockerhub_valkey():
     try:
         if run_coordinator_tests_dockerhub():

--- a/utils/tests/test_spec.py
+++ b/utils/tests/test_spec.py
@@ -11,7 +11,6 @@ from redis_benchmarks_specification.__common__.spec import (
 
 
 def test_extract_build_variant_variations():
-
     with open(
         "./utils/tests/test_data/test-suites/redis-benchmark-full-suite-1Mkeys-100B.yml",
         "r",
@@ -20,6 +19,16 @@ def test_extract_build_variant_variations():
         build_variants = extract_build_variant_variations(benchmark_config)
         assert build_variants == None
 
+    with open(
+        "./redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-100B-expire-use-case.yml",
+        "r",
+    ) as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+        build_variants = extract_build_variant_variations(benchmark_config)
+        assert "gcc:8.5.0-amd64-debian-buster-default" in build_variants
+
+
+def test_extract_redis_dbconfig_parameters():
     with open(
         "./redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-100B-expire-use-case.yml",
         "r",

--- a/utils/tests/test_topologies.py
+++ b/utils/tests/test_topologies.py
@@ -1,3 +1,6 @@
+from redis_benchmarks_specification.__common__.spec import (
+    extract_redis_configuration_from_topology,
+)
 from redis_benchmarks_specification.__setups__.topologies import get_topologies
 
 
@@ -7,3 +10,15 @@ def test_get_topologies():
     )
     assert "oss-standalone" in topologies_map
     assert topologies_map["oss-standalone"]["resources"]["requests"]["cpus"] == "1"
+
+
+def test_extract_redis_configuration_from_topology():
+    topologies_map = get_topologies(
+        "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+    )
+    assert "oss-standalone-04-io-threads" in topologies_map.keys()
+    res = extract_redis_configuration_from_topology(
+        topologies_map, "oss-standalone-04-io-threads"
+    )
+    assert res != ""
+    assert "--io-threads 4 io-threads-do-reads yes" in res

--- a/utils/tests/test_topologies.py
+++ b/utils/tests/test_topologies.py
@@ -21,4 +21,4 @@ def test_extract_redis_configuration_from_topology():
         topologies_map, "oss-standalone-04-io-threads"
     )
     assert res != ""
-    assert "--io-threads 4 io-threads-do-reads yes" in res
+    assert "--io-threads 4 --io-threads-do-reads yes" in res


### PR DESCRIPTION
Runs memtier_benchmark, for a keyspace length of 3M keys loading STRINGs in which the value has a data size of 512 Bytes, with 650 clients running sequential SET commands.