### PR TITLE
Move topology filtering logic

### DIFF
--- a/redis_benchmarks_specification/__runner__/args.py
+++ b/redis_benchmarks_specification/__runner__/args.py
@@ -215,11 +215,6 @@ def create_client_runner_args(project_name):
         help="Run client in cluster mode.",
     )
     parser.add_argument(
-        "--topology",
-        default="",
-        help="Filter tests to run only with the specified topology (e.g. oss-standalone)",
-    )
-    parser.add_argument(
         "--unix-socket",
         default="",
         help="UNIX Domain socket name",

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -117,7 +117,6 @@ def process_self_contained_coordinator_stream(
     docker_air_gap=False,
     verbose=False,
     run_tests_with_dataset=False,
-    args=None,
 ):
     stream_id = "n/a"
     overall_result = False
@@ -199,17 +198,6 @@ def process_self_contained_coordinator_stream(
                                 )
                             )
                     for topology_spec_name in benchmark_config["redis-topologies"]:
-                        # Filter by topology if specified
-                        if (
-                            args.topology
-                            and args.topology != ""
-                            and topology_spec_name != args.topology
-                        ):
-                            logging.info(
-                                f"Skipping topology {topology_spec_name} as it doesn't match the requested topology {args.topology}"
-                            )
-                            continue
-
                         test_result = False
                         try:
                             current_cpu_pos = cpuset_start_pos

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -494,6 +494,7 @@ def process_self_contained_coordinator_stream(
     default_metrics_str="ALL_STATS.Totals.Ops/sec",
     docker_keep_env=False,
     restore_build_artifacts_default=True,
+    args=None,
 ):
     stream_id = "n/a"
     overall_result = False
@@ -780,6 +781,18 @@ def process_self_contained_coordinator_stream(
                         for topology_spec_name in benchmark_config["redis-topologies"]:
                             setup_name = topology_spec_name
                             setup_type = "oss-standalone"
+
+                            # Filter by topology if specified
+                            if (
+                                args is not None
+                                and args.topology
+                                and topology_spec_name != args.topology
+                            ):
+                                logging.info(
+                                    f"Skipping topology {topology_spec_name} as it doesn't match the requested topology {args.topology}"
+                                )
+                                continue
+
                             if topology_spec_name in topologies_map:
                                 topology_spec = topologies_map[topology_spec_name]
                                 setup_type = topology_spec["type"]


### PR DESCRIPTION
By analysing the code, git history and unit tests I *think* that `process_self_contained_coordinator_stream` is now on `redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py` file.

This PR moves the filtering logic from `runners.py` to `self_contained_coordinator.py`.