### PR TITLE
Add missing pipeline params

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-400_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-400_conns.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-get-with-1KiB-values-400_conns
+description: Runs memtier_benchmark, for a keyspace length of 3M keys loading STRINGs in which the value has a data size of 1000 Bytes, with 400 clients running random GET commands.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 3000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 1000 --ratio 1:0 -n allkeys --pipeline 10 --key-maximum 3000000 --key-pattern P:P --key-minimum 1 --hide-histogram -t 4 -c 10
+  resources:
+    requests:
+      memory: 3g
+tested-commands:
+  - set
+redis-topologies:
+  - oss-standalone
+  - oss-standalone-02-io-threads
+  - oss-standalone-04-io-threads
+  - oss-standalone-08-io-threads
+  - oss-standalone-16-io-threads
+build-variants:
+  - gcc:8.5.0-amd64-debian-buster-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "1000" --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
+  resources:
+    requests:
+      cpus: "10"
+      memory: 3g
+
+tested-groups:
+  - string
+priority: 17

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-40_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-40_conns.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-get-with-1KiB-values-40_conns
+description: Runs memtier_benchmark, for a keyspace length of 3M keys loading STRINGs in which the value has a data size of 1000 Bytes, with 40 clients running random GET commands.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 3000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 1000 --ratio 1:0 -n allkeys --pipeline 10 --key-maximum 3000000 --key-pattern P:P --key-minimum 1 --hide-histogram -t 4 -c 10
+  resources:
+    requests:
+      memory: 3g
+tested-commands:
+  - set
+redis-topologies:
+  - oss-standalone
+  - oss-standalone-02-io-threads
+  - oss-standalone-04-io-threads
+  - oss-standalone-08-io-threads
+  - oss-standalone-16-io-threads
+build-variants:
+  - gcc:8.5.0-amd64-debian-buster-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "1000" --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 4 -t 10 --hide-histogram'
+  resources:
+    requests:
+      cpus: "10"
+      memory: 3g
+
+tested-groups:
+  - string
+priority: 17

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-2000_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-2000_conns.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "1000" --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 200 -t 10 --hide-histogram'
+  arguments: '"--data-size" "1000" --pipeline 10 --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 200 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-400_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-400_conns.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "1000" --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
+  arguments: '"--data-size" "1000" --pipeline 10 --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-40_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-40_conns.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "1000" --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 4 -t 10 --hide-histogram'
+  arguments: '"--data-size" "1000" --pipeline 10 --distinct-client-seed --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 4 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-400_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-400_conns.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-400_conns
+description: Runs memtier_benchmark, for a keyspace length of 3M keys loading STRINGs in which the value has a data size of 1000 Bytes, with 400 clients running random GET commands.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 3000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 512 --ratio 1:0 -n allkeys --pipeline 10 --key-maximum 3000000 --key-pattern P:P --key-minimum 1 --hide-histogram -t 4 -c 10
+  resources:
+    requests:
+      memory: 3g
+tested-commands:
+  - set
+redis-topologies:
+  - oss-standalone
+  - oss-standalone-02-io-threads
+  - oss-standalone-04-io-threads
+  - oss-standalone-08-io-threads
+  - oss-standalone-16-io-threads
+build-variants:
+  - gcc:8.5.0-amd64-debian-buster-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "512" --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
+  resources:
+    requests:
+      cpus: "10"
+      memory: 3g
+
+tested-groups:
+  - string
+priority: 17

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-2000_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-2000_conns.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "512" --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 200 -t 10 --hide-histogram'
+  arguments: '"--data-size" "512" --pipeline 10 --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 200 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-400_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-400_conns.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "512" --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
+  arguments: '"--data-size" "512" --pipeline 10 --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-5200_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-5200_conns.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "512" --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 520 -t 10 --hide-histogram'
+  arguments: '"--data-size" "512" --pipeline 10 --distinct-client-seed --ratio 1:4 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 520 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-50-50-with-512B-values-with-expiration-pipeline-10-400_conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-mixed-50-50-with-512B-values-with-expiration-pipeline-10-400_conns.yml
@@ -28,7 +28,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "512" --distinct-client-seed --ratio 1:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
+  arguments: '"--data-size" "512" --pipeline 10 --distinct-client-seed --ratio 1:1 --key-pattern R:R --key-minimum=1 --key-maximum 3000000 --test-time 180 -c 40 -t 10 --hide-histogram'
   resources:
     requests:
       cpus: '10'


### PR DESCRIPTION
This PR addresses missing pipeline configurations in memtier_benchmark test suites and adds corresponding non-pipeline variants to ensure comprehensive benchmark coverage.

## Changes Made

### 1. Fix Missing Pipeline Arguments (commit ca08d03)
- **Fixed 7 test suite files** that were missing the `--pipeline 10` argument despite having "pipeline-10" in their filenames
- **Files affected:**
  - `memtier_benchmark-3Mkeys-string-get-with-1KiB-values-pipeline-10-*_conns.yml` (3 variants)
  - `memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-pipeline-10-*_conns.yml` (3 variants)  
  - `memtier_benchmark-3Mkeys-string-mixed-50-50-with-512B-values-with-expiration-pipeline-10-400_conns.yml`

### 2. Add Non-Pipeline Variants (commit 315c85b)
- **Added 3 new test suite files** for non-pipeline benchmarks to complement the existing pipeline variants
- **New files:**
  - `memtier_benchmark-3Mkeys-string-get-with-1KiB-values-400_conns.yml`
  - `memtier_benchmark-3Mkeys-string-get-with-1KiB-values-40_conns.yml`
  - `memtier_benchmark-3Mkeys-string-mixed-20-80-with-512B-values-400_conns.yml`