### PR TITLE
Add HyperLogLog benchmarks: PFCOUNT and PFMERGE

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfcount-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfcount-100B-values.yml
@@ -26,7 +26,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --test-time 180 --command "PFCOUNT memtier-1 memtier-2 memtier-3" -c 50 -t 4 --hide-histogram
+  arguments: --test-time 60 --command "PFCOUNT memtier-1 memtier-2 memtier-3" -c 50 -t 4 --hide-histogram
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfmerge-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfmerge-100B-values.yml
@@ -26,7 +26,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --test-time 180 --command "PFMERGE merged memtier-1 memtier-2 memtier-3" -c 50 -t 4 --hide-histogram
+  arguments: --test-time 60 --command "PFMERGE merged memtier-1 memtier-2 memtier-3" -c 50 -t 4 --hide-histogram
   resources:
     requests:
       cpus: '4'


### PR DESCRIPTION
This PR adds two new memtier benchmark test suites for evaluating dense HyperLogLog implementations:

### Changes:
- **PFCOUNT benchmark**: Tests performance of counting multiple pre-loaded HyperLogLog keys
- **PFMERGE benchmark**: Tests performance of merging multiple pre-loaded HyperLogLog keys

### Test Configuration:
- Pre-loads 3 HyperLogLog keys with 10K random elements each using PFADD (dense format)
- Uses 100B sized random elements to ensure dense HyperLogLog representation
- Runs with 50 connections and 4 threads for 180 seconds
- Targets both amd64 and arm64 architectures

### Purpose:
These benchmarks are specifically designed to evaluate different HyperLogLog dense implementations:
- **Scalar implementations**
- **AVX SIMD** (x86_64 optimization)
- **NEON SIMD** (ARM64 optimization)

Note: the dense HyperLogLog format is particularly suitable for SIMD optimisations due to its regular data structure and parallel processing opportunities.