### PR TITLE
adding flushall after memtier benchmark failure. 

### DIFF
--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -3022,6 +3022,15 @@ def process_self_contained_coordinator_stream(
                     print("-" * 60)
                     test_result = False
 
+                    # Clean up database after exception to prevent contamination of next test
+                    if args.flushall_on_every_test_end or args.flushall_on_every_test_start:
+                        logging.warning("Exception caught - cleaning up database with FLUSHALL")
+                        try:
+                            for r in redis_conns:
+                                r.flushall()
+                        except Exception as e:
+                            logging.error(f"FLUSHALL failed after exception: {e}")
+
                     # Check if user requested exit via Ctrl+C
                     if _exit_requested:
                         logging.info(


### PR DESCRIPTION
Otherwise what may happen is that a test fails (after a timeout) but some data has been inserted into redis. The following test will find the database to contain unexpected data and fail. 