### PR TITLE
Add Redis Streams XREAD/XREADGROUP benchmark test suites

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-10M-entries-xread-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-10M-entries-xread-count-100.yml
@@ -1,0 +1,36 @@
+version: 0.4
+name: memtier_benchmark-stream-10M-entries-xread-count-100
+description: 'Runs memtier_benchmark, pre-loading Redis with 10M stream entries using XADD, then testing XREAD performance with COUNT 100.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key * field __data__" --command-key-pattern="P" -n 50000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: 1M-stream-entries
+  dataset_description: This dataset contains 1 stream key with 1M entries, each with a field containing 100 bytes of data.
+tested-commands:
+- xread
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="XREAD COUNT 100 STREAMS stream-key 0" --hide-histogram -n 1000 -c 25 -t 4
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- stream
+priority: 95

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-10M-entries-xreadgroup-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-10M-entries-xreadgroup-count-100.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-stream-10M-entries-xreadgroup-count-100
+description: 'Runs memtier_benchmark, pre-loading Redis with 10M stream entries using XADD, creating a consumer group, then testing XREADGROUP performance with COUNT 100.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key * field __data__" --command-key-pattern="P" -n 50000 -c 50 -t 4 --hide-histogram'
+  init_commands:
+  - XGROUP CREATE stream-key test-group 0 MKSTREAM
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: 1k-stream-entries-with-consumer-group
+  dataset_description: This dataset contains 1 stream key with 10M entries, each with a field containing 100 bytes of data, and a consumer group named 'test-group'.
+tested-commands:
+- xreadgroup
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="XREADGROUP GROUP test-group consumer1 COUNT 100 STREAMS stream-key >" --hide-histogram -n 1000 -c 25 -t 4
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- stream
+priority: 94

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30.yml
@@ -1,0 +1,50 @@
+version: 0.4
+name: memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30
+description:
+  Starting with a pre-loaded stream of 500K entries, the benchmark tests concurrent stream operations with a consumer group for distributed processing.  
+  70% of commands produce messages with XADD, while 30% consume with XREADGROUP COUNT 10.
+  500K initial entries plus 200K * 70% minus 200K * 10 * (15% + 15%) ≈ 40K left in the stream at the end.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key * field __data__" --command-key-pattern="P" -n 2500 -c 50 -t 4 --hide-histogram'
+  init_commands:
+    - XGROUP CREATE stream-key producer-consumer-group 0 MKSTREAM
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: stream-concurrent-producer-consumer-500k-seed
+  dataset_description: This dataset starts with 500K pre-loaded stream entries, then tests concurrent stream operations with a consumer group for distributed processing.
+tested-commands:
+  - xadd
+  - xreadgroup
+redis-topologies:
+  - oss-standalone
+build-variants:
+  - gcc:15.2.0-amd64-debian-bookworm-default
+  - gcc:15.2.0-arm64-debian-bookworm-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size 100
+    --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=70
+    --command="XREADGROUP GROUP producer-consumer-group consumer1 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=15
+    --command="XREADGROUP GROUP producer-consumer-group consumer2 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=15
+    --hide-histogram
+    -n 1000
+    -c 50
+    -t 4
+  resources:
+    requests:
+      cpus: "4"
+      memory: 2g
+tested-groups:
+  - stream
+priority: 95


### PR DESCRIPTION
This PR introduces comprehensive **benchmark test suites for Redis Streams** functionality, covering both simple stream reading and consumer group-based distributed processing scenarios with large-scale datasets.

---

## Tests Added

### 1. `memtier_benchmark-stream-10M-entries-xread-count-100.yml`
- **Purpose**: Tests `XREAD` performance with batch reading on large datasets  
- **Dataset**: Pre-loads **10M stream entries** using `XADD` (100-byte messages)  
- **Test**: `XREAD COUNT 100` operations reading from stream beginning  
- **Use Case**: Large-scale simple stream consumption without consumer groups  

---

### 2. `memtier_benchmark-stream-10M-entries-xreadgroup-count-100.yml`
- **Purpose**: Tests `XREADGROUP` performance with consumer groups on large datasets  
- **Dataset**: Pre-loads **10M stream entries**, creates consumer group `test-group`  
- **Test**: `XREADGROUP` operations with `COUNT 100` for distributed processing  
- **Use Case**: Large-scale consumer group-based stream processing

---

### 3. `memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30.yml`
- **Purpose**: Tests **concurrent producer/consumer workloads** in real-time scenarios  
- **Dataset**: Starts with **500K pre-loaded stream entries**  
- **Test**: Mixed workload with **70% `XADD` (producers)** and **30% `XREADGROUP` (consumers)**  
- **Consumer Setup**: Dual consumers (`consumer1` / `consumer2`) with **15% ratio each** for load distribution  
- **Use Case**: Real-world streaming applications with continuous production and consumption  