### PR TITLE
Add memtier benchmark test suites for 4KiB string SET/GET

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-1.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-1.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-1
+description: Runs memtier_benchmark, for a keyspace of 1M keys with 10% SETs and 90%
+  GETs (mixed) with a data size of 4096 Bytes and pipeline 10.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 4096 --pipeline 50 -n allkeys --ratio 1:0 --key-pattern
+      P:P -c 1 -t 4 --hide-histogram --key-minimum 1 --key-maximum 1000000
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-4KiB-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 4 KiB.
+tested-commands:
+- set
+- get
+tested-groups:
+- string
+redis-topologies:
+- oss-standalone-08-io-threads
+- oss-standalone-04-io-threads
+- oss-standalone-02-io-threads
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "4096" --ratio 1:10 --key-pattern R:R --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram --pipeline 1'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-10.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-10
+description: Runs memtier_benchmark, for a keyspace of 1M keys with 10% SETs and 90%
+  GETs (mixed) with a data size of 4096 Bytes and pipeline 10.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 4096 --pipeline 50 -n allkeys --ratio 1:0 --key-pattern
+      P:P -c 1 -t 4 --hide-histogram --key-minimum 1 --key-maximum 1000000
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-4KiB-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 4 KiB.
+tested-commands:
+- set
+- get
+tested-groups:
+- string
+redis-topologies:
+- oss-standalone-08-io-threads
+- oss-standalone-04-io-threads
+- oss-standalone-02-io-threads
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "4096" --ratio 1:10 --key-pattern R:R --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram --pipeline 10'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1


### PR DESCRIPTION
- memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-1.yml
- memtier_benchmark-1Mkeys-string-setget200c-4KiB-pipeline-10.yml

Both test suites:
- Use 1M key keyspace with 10% SETs and 90% GETs (1:10 ratio)
- Test 4096-byte string data size
- Include io-threads topology variants (2, 4, 8 threads) and standalone
- Run for 180 seconds with 4 threads, each using 50 clients

These benchmarks complement existing pipeline testing by providing 4KiB data size coverage, helping assess Redis performance with larger payloads.