### PR TITLE
Allow topology override (with regex support)

### DIFF
--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -618,6 +618,7 @@ def builder_process_stream(
                         github_repo,
                         artifact_keys,  # Pass existing artifact keys
                         deployment_name_regexp,
+                        "",  # override_topology - not used for reuse case
                     )
                     # Add to benchmark stream even when reusing artifacts
                     if result is True:
@@ -731,6 +732,7 @@ def builder_process_stream(
                     github_repo,
                     None,  # existing_artifact_keys - None for new builds
                     deployment_name_regexp,
+                    "",  # override_topology - not available at builder level
                 )
                 if result is True:
                     arch_specific_stream = get_arch_specific_stream_name(build_arch)
@@ -878,6 +880,7 @@ def generate_benchmark_stream_request(
     github_repo="redis",
     existing_artifact_keys=None,
     deployment_name_regexp=".*",
+    override_topology="",
 ):
     build_stream_fields = {
         "id": id,
@@ -897,6 +900,8 @@ def generate_benchmark_stream_request(
     }
     if deployment_name_regexp != ".*":
         build_stream_fields["deployment_name_regexp"] = deployment_name_regexp
+    if override_topology != "":
+        build_stream_fields["override_topology"] = override_topology
     if build_config_metadata is not None:
         build_stream_fields["metadata"] = json.dumps(build_config_metadata)
     if compiler is not None:

--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -851,8 +851,6 @@ def store_airgap_image_redis(conn, docker_client, run_image):
         )
 
 
-
-
 def generate_benchmark_stream_request(
     id,
     conn,

--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -3,7 +3,6 @@ import datetime
 import io
 import json
 import logging
-import re
 import tempfile
 import shutil
 import docker
@@ -15,7 +14,6 @@ from redis_benchmarks_specification.__builder__.schema import (
     get_build_config,
     get_build_config_metadata,
 )
-from redis_benchmarks_specification.__setups__.topologies import get_topologies
 from redis_benchmarks_specification.__common__.builder_schema import (
     get_branch_version_from_test_details,
 )

--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import logging
+import re
 import tempfile
 import shutil
 import docker
@@ -14,6 +15,7 @@ from redis_benchmarks_specification.__builder__.schema import (
     get_build_config,
     get_build_config_metadata,
 )
+from redis_benchmarks_specification.__setups__.topologies import get_topologies
 from redis_benchmarks_specification.__common__.builder_schema import (
     get_branch_version_from_test_details,
 )
@@ -618,7 +620,7 @@ def builder_process_stream(
                         github_repo,
                         artifact_keys,  # Pass existing artifact keys
                         deployment_name_regexp,
-                        "",  # override_topology - not used for reuse case
+                        "",  # override_deployment_regexp - not used for reuse case
                     )
                     # Add to benchmark stream even when reusing artifacts
                     if result is True:
@@ -732,7 +734,7 @@ def builder_process_stream(
                     github_repo,
                     None,  # existing_artifact_keys - None for new builds
                     deployment_name_regexp,
-                    "",  # override_topology - not available at builder level
+                    "",  # override_deployment_regexp - not available at builder level
                 )
                 if result is True:
                     arch_specific_stream = get_arch_specific_stream_name(build_arch)
@@ -849,6 +851,8 @@ def store_airgap_image_redis(conn, docker_client, run_image):
         )
 
 
+
+
 def generate_benchmark_stream_request(
     id,
     conn,
@@ -880,7 +884,7 @@ def generate_benchmark_stream_request(
     github_repo="redis",
     existing_artifact_keys=None,
     deployment_name_regexp=".*",
-    override_topology="",
+    override_deployment_regexp="",
 ):
     build_stream_fields = {
         "id": id,
@@ -900,8 +904,8 @@ def generate_benchmark_stream_request(
     }
     if deployment_name_regexp != ".*":
         build_stream_fields["deployment_name_regexp"] = deployment_name_regexp
-    if override_topology != "":
-        build_stream_fields["override_topology"] = override_topology
+    if override_deployment_regexp != "":
+        build_stream_fields["override_deployment_regexp"] = override_deployment_regexp
     if build_config_metadata is not None:
         build_stream_fields["metadata"] = json.dumps(build_config_metadata)
     if compiler is not None:

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -233,10 +233,10 @@ def spec_cli_args(parser):
         help="Filter topologies/deployments by name using regex. Only topologies matching this pattern will be executed. E.g. '.*io-threads' to only run IO-thread variants.",
     )
     parser.add_argument(
-        "--override-topology",
+        "--override-deployment-regexp",
         type=str,
         default="",
-        help="Override the redis-topologies from all benchmark configs and use only the specified topology name instead. E.g. 'oss-standalone-01-replicas'. Takes precedence over --deployment-name-regexp.",
+        help="Override the redis-topologies from all benchmark configs and use only topologies matching this regex pattern. E.g. 'oss-standalone-0[12]-replicas' or 'oss-standalone-01-replicas'. Can be combined with --deployment-name-regexp for additional filtering.",
     )
     parser.add_argument(
         "--wait-benchmark",

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -233,6 +233,12 @@ def spec_cli_args(parser):
         help="Filter topologies/deployments by name using regex. Only topologies matching this pattern will be executed. E.g. '.*io-threads' to only run IO-thread variants.",
     )
     parser.add_argument(
+        "--override-topology",
+        type=str,
+        default="",
+        help="Override the redis-topologies from all benchmark configs and use only the specified topology name instead. E.g. 'oss-standalone-01-replicas'. Takes precedence over --deployment-name-regexp.",
+    )
+    parser.add_argument(
         "--wait-benchmark",
         default=False,
         action="store_true",

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -136,6 +136,11 @@ def trigger_tests_dockerhub_cli_command_logic(args, project_name, project_versio
             if hasattr(args, "deployment_name_regexp")
             else ".*"
         ),
+        (
+            args.override_topology
+            if hasattr(args, "override_topology")
+            else ""
+        ),
     )
     build_stream_fields["github_repo"] = args.gh_repo
     build_stream_fields["github_org"] = args.gh_org
@@ -794,23 +799,28 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                             test_name = config["name"]
                             if not tests_regexp_compiled.match(test_name):
                                 continue
-                            topologies = config.get("redis-topologies", [])
-                            if deployment_name_regexp_filter != ".*":
-                                topologies = [
-                                    t
-                                    for t in topologies
-                                    if re.match(deployment_name_regexp_filter, t)
-                                ]
+                            if args.override_topology:
+                                topologies = [args.override_topology]
+                                logging.info(f"  {test_name}: Using override topology -> {args.override_topology}")
+                            else:
+                                topologies = config.get("redis-topologies", [])
+                                if deployment_name_regexp_filter != ".*":
+                                    topologies = [
+                                        t
+                                        for t in topologies
+                                        if re.match(deployment_name_regexp_filter, t)
+                                    ]
                             if topologies:
                                 total_tests += 1
                                 total_topology_runs += len(topologies)
-                                if len(topologies) > 1:
+                                if not args.override_topology and len(topologies) > 1:
                                     logging.info(
                                         f"  {test_name}: {len(topologies)} topologies -> {', '.join(topologies)}"
                                     )
-                        logging.info(
-                            f"DRY-RUN SUMMARY: {total_tests} tests x topologies = {total_topology_runs} benchmark runs"
-                        )
+                        summary_msg = f"DRY-RUN SUMMARY: {total_tests} tests x topologies = {total_topology_runs} benchmark runs"
+                        if args.override_topology:
+                            summary_msg += f" (using override topology: {args.override_topology})"
+                        logging.info(summary_msg)
                     except Exception as e:
                         logging.debug(f"Could not compute topology breakdown: {e}")
             else:

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -782,9 +782,15 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                         from redis_benchmarks_specification.__common__.runner import (
                             get_benchmark_specs,
                         )
+                        from redis_benchmarks_specification.__setups__.topologies import get_topologies
+                        from redis_benchmarks_specification.__common__.env import SPECS_PATH_SETUPS
 
                         testsuites_folder = os.path.abspath(args.test_suites_folder)
                         spec_files = get_benchmark_specs(testsuites_folder)
+
+                        # Load all available topologies for override functionality
+                        topologies_file = os.path.join(SPECS_PATH_SETUPS, "topologies", "topologies.yml")
+                        topologies_map = get_topologies(topologies_file)
                         total_tests = 0
                         total_topology_runs = 0
                         deployment_name_regexp_filter = args.deployment_name_regexp
@@ -800,13 +806,15 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                             if not tests_regexp_compiled.match(test_name):
                                 continue
                             
-                            # Start with base topologies
-                            topologies = config.get("redis-topologies", [])
-
-                            # Apply override filter if specified
+                            # Start with appropriate topology base
                             if args.override_deployment_regexp:
-                                topologies = [t for t in topologies if re.match(args.override_deployment_regexp, t)]
-                                logging.info(f"  {test_name}: Override deployment regexp '{args.override_deployment_regexp}' -> {len(topologies)} matches: {topologies}")
+                                # Start with all available topologies when overriding
+                                all_available_topologies = list(topologies_map.keys())
+                                topologies = [t for t in all_available_topologies if re.match(args.override_deployment_regexp, t)]
+                                logging.info(f"  {test_name}: Override deployment regexp '{args.override_deployment_regexp}' -> {len(topologies)} matches from {len(all_available_topologies)} available: {topologies}")
+                            else:
+                                # Start with base topologies from config
+                                topologies = config.get("redis-topologies", [])
 
                             # Apply deployment filter if specified
                             if deployment_name_regexp_filter != ".*":

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -137,8 +137,8 @@ def trigger_tests_dockerhub_cli_command_logic(args, project_name, project_versio
             else ".*"
         ),
         (
-            args.override_topology
-            if hasattr(args, "override_topology")
+            args.override_deployment_regexp
+            if hasattr(args, "override_deployment_regexp")
             else ""
         ),
     )
@@ -799,27 +799,29 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                             test_name = config["name"]
                             if not tests_regexp_compiled.match(test_name):
                                 continue
-                            if args.override_topology:
-                                topologies = [args.override_topology]
-                                logging.info(f"  {test_name}: Using override topology -> {args.override_topology}")
-                            else:
-                                topologies = config.get("redis-topologies", [])
-                                if deployment_name_regexp_filter != ".*":
-                                    topologies = [
-                                        t
-                                        for t in topologies
-                                        if re.match(deployment_name_regexp_filter, t)
-                                    ]
+                            
+                            # Start with base topologies
+                            topologies = config.get("redis-topologies", [])
+
+                            # Apply override filter if specified
+                            if args.override_deployment_regexp:
+                                topologies = [t for t in topologies if re.match(args.override_deployment_regexp, t)]
+                                logging.info(f"  {test_name}: Override deployment regexp '{args.override_deployment_regexp}' -> {len(topologies)} matches: {topologies}")
+
+                            # Apply deployment filter if specified
+                            if deployment_name_regexp_filter != ".*":
+                                topologies = [t for t in topologies if re.match(deployment_name_regexp_filter, t)]
+                                logging.info(f"  {test_name}: Deployment name regexp '{deployment_name_regexp_filter}' -> {len(topologies)} matches: {topologies}")
                             if topologies:
                                 total_tests += 1
                                 total_topology_runs += len(topologies)
-                                if not args.override_topology and len(topologies) > 1:
+                                if not args.override_deployment_regexp and len(topologies) > 1:
                                     logging.info(
                                         f"  {test_name}: {len(topologies)} topologies -> {', '.join(topologies)}"
                                     )
                         summary_msg = f"DRY-RUN SUMMARY: {total_tests} tests x topologies = {total_topology_runs} benchmark runs"
-                        if args.override_topology:
-                            summary_msg += f" (using override topology: {args.override_topology})"
+                        if args.override_deployment_regexp:
+                            summary_msg += f" (using override deployment regexp: {args.override_deployment_regexp})"
                         logging.info(summary_msg)
                     except Exception as e:
                         logging.debug(f"Could not compute topology breakdown: {e}")

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -791,6 +791,7 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                         # Load all available topologies for override functionality
                         topologies_file = os.path.join(SPECS_PATH_SETUPS, "topologies", "topologies.yml")
                         topologies_map = get_topologies(topologies_file)
+                        all_available_topologies = list(topologies_map.keys())
                         total_tests = 0
                         total_topology_runs = 0
                         deployment_name_regexp_filter = args.deployment_name_regexp
@@ -806,20 +807,21 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                             if not tests_regexp_compiled.match(test_name):
                                 continue
                             
-                            # Start with appropriate topology base
+                            topologies = config.get("redis-topologies", [])
+
+                            # Override topology if specified
                             if args.override_deployment_regexp:
                                 # Start with all available topologies when overriding
-                                all_available_topologies = list(topologies_map.keys())
                                 topologies = [t for t in all_available_topologies if re.match(args.override_deployment_regexp, t)]
-                                logging.info(f"  {test_name}: Override deployment regexp '{args.override_deployment_regexp}' -> {len(topologies)} matches from {len(all_available_topologies)} available: {topologies}")
-                            else:
-                                # Start with base topologies from config
-                                topologies = config.get("redis-topologies", [])
 
                             # Apply deployment filter if specified
                             if deployment_name_regexp_filter != ".*":
-                                topologies = [t for t in topologies if re.match(deployment_name_regexp_filter, t)]
-                                logging.info(f"  {test_name}: Deployment name regexp '{deployment_name_regexp_filter}' -> {len(topologies)} matches: {topologies}")
+                                topologies = [
+                                    t
+                                    for t in topologies
+                                    if re.match(deployment_name_regexp_filter, t)
+                                ]
+
                             if topologies:
                                 total_tests += 1
                                 total_topology_runs += len(topologies)
@@ -827,10 +829,9 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                                     logging.info(
                                         f"  {test_name}: {len(topologies)} topologies -> {', '.join(topologies)}"
                                     )
-                        summary_msg = f"DRY-RUN SUMMARY: {total_tests} tests x topologies = {total_topology_runs} benchmark runs"
-                        if args.override_deployment_regexp:
-                            summary_msg += f" (using override deployment regexp: {args.override_deployment_regexp})"
-                        logging.info(summary_msg)
+                        logging.info(
+                            f"DRY-RUN SUMMARY: {total_tests} tests x topologies = {total_topology_runs} benchmark runs"
+                        )
                     except Exception as e:
                         logging.debug(f"Could not compute topology breakdown: {e}")
             else:

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -782,14 +782,20 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                         from redis_benchmarks_specification.__common__.runner import (
                             get_benchmark_specs,
                         )
-                        from redis_benchmarks_specification.__setups__.topologies import get_topologies
-                        from redis_benchmarks_specification.__common__.env import SPECS_PATH_SETUPS
+                        from redis_benchmarks_specification.__setups__.topologies import (
+                            get_topologies,
+                        )
+                        from redis_benchmarks_specification.__common__.env import (
+                            SPECS_PATH_SETUPS,
+                        )
 
                         testsuites_folder = os.path.abspath(args.test_suites_folder)
                         spec_files = get_benchmark_specs(testsuites_folder)
 
                         # Load all available topologies for override functionality
-                        topologies_file = os.path.join(SPECS_PATH_SETUPS, "topologies", "topologies.yml")
+                        topologies_file = os.path.join(
+                            SPECS_PATH_SETUPS, "topologies", "topologies.yml"
+                        )
                         topologies_map = get_topologies(topologies_file)
                         all_available_topologies = list(topologies_map.keys())
                         total_tests = 0
@@ -806,13 +812,17 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                             test_name = config["name"]
                             if not tests_regexp_compiled.match(test_name):
                                 continue
-                            
+
                             topologies = config.get("redis-topologies", [])
 
                             # Override topology if specified
                             if args.override_deployment_regexp:
                                 # Start with all available topologies when overriding
-                                topologies = [t for t in all_available_topologies if re.match(args.override_deployment_regexp, t)]
+                                topologies = [
+                                    t
+                                    for t in all_available_topologies
+                                    if re.match(args.override_deployment_regexp, t)
+                                ]
 
                             # Apply deployment filter if specified
                             if deployment_name_regexp_filter != ".*":
@@ -825,7 +835,10 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                             if topologies:
                                 total_tests += 1
                                 total_topology_runs += len(topologies)
-                                if not args.override_deployment_regexp and len(topologies) > 1:
+                                if (
+                                    not args.override_deployment_regexp
+                                    and len(topologies) > 1
+                                ):
                                     logging.info(
                                         f"  {test_name}: {len(topologies)} topologies -> {', '.join(topologies)}"
                                     )

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1347,13 +1347,14 @@ def process_self_contained_coordinator_stream(
                     pipeline.lpush(stream_test_list_pending, test_name)
                     test_names_added.append(test_name)
                     # Add topology-level entries
-                    # Start with base topologies
-                    topologies = benchmark_config.get("redis-topologies", [])
-
-                    # Apply deployment name override if specified
                     if override_deployment_regexp:
-                        topologies = [t for t in topologies if re.match(override_deployment_regexp, t)]
-                        logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name} -> {len(topologies)} matches: {topologies}")
+                        # Start with all available topologies when overriding
+                        all_available_topologies = list(topologies_map.keys())
+                        topologies = [t for t in all_available_topologies if re.match(override_deployment_regexp, t)]
+                        logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name} -> {len(topologies)} matches from {len(all_available_topologies)} available: {topologies}")
+                    else:
+                        # Start with base topologies from config
+                        topologies = benchmark_config.get("redis-topologies", [])
 
                     # Apply deployment name filter if specified
                     if deployment_name_regexp != ".*":
@@ -1497,13 +1498,15 @@ def process_self_contained_coordinator_stream(
                         # If all topologies are filtered out, test is considered passed (nothing to run).
                         test_result = True
 
-                        # Start with base topologies
-                        topologies_to_run = benchmark_config["redis-topologies"]
-
-                        # Apply override filter if specified
+                        # Start with appropriate topology base
                         if override_deployment_regexp:
-                            topologies_to_run = [t for t in topologies_to_run if re.match(override_deployment_regexp, t)]
-                            logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name}: {len(topologies_to_run)} matches: {topologies_to_run}")
+                            # Start with all available topologies when overriding
+                            all_available_topologies = list(topologies_map.keys())
+                            topologies_to_run = [t for t in all_available_topologies if re.match(override_deployment_regexp, t)]
+                            logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name}: {len(topologies_to_run)} matches from {len(all_available_topologies)} available: {topologies_to_run}")
+                        else:
+                            # Start with base topologies from config
+                            topologies_to_run = benchmark_config["redis-topologies"]
 
                         # Apply deployment filter if specified
                         if deployment_name_regexp != ".*":

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1340,7 +1340,6 @@ def process_self_contained_coordinator_stream(
                 pipeline = github_event_conn.pipeline()
                 test_names_added = []
                 total_topology_runs = 0
-            
 
                 for test_file in filtered_test_files:
                     with open(test_file, "r") as stream:

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1333,7 +1333,7 @@ def process_self_contained_coordinator_stream(
                 logging.info(
                     f"Adding {len(filtered_test_files)} tests to pending test list"
                 )
-            
+
                 all_available_topologies = list(topologies_map.keys())
 
                 # Use pipeline for efficient bulk operations
@@ -1514,7 +1514,7 @@ def process_self_contained_coordinator_stream(
 
                         # Start with appropriate topology base
                         topologies_to_run = benchmark_config["redis-topologies"]
-                        
+
                         # Override topology if specified
                         if override_deployment_regexp:
                             # Start with all available topologies when overriding

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1254,11 +1254,11 @@ def process_self_contained_coordinator_stream(
                     f"detected a deployment_name_regexp definition on the streamdata {deployment_name_regexp}"
                 )
 
-            override_topology = ""
-            if b"override_topology" in testDetails:
-                override_topology = testDetails[b"override_topology"].decode()
+            override_deployment_regexp = ""
+            if b"override_deployment_regexp" in testDetails:
+                override_deployment_regexp = testDetails[b"override_deployment_regexp"].decode()
                 logging.info(
-                    f"detected an override_topology definition on the streamdata {override_topology}"
+                    f"detected an override_deployment_regexp definition on the streamdata {override_deployment_regexp}"
                 )
 
             skip_test = False
@@ -1347,17 +1347,19 @@ def process_self_contained_coordinator_stream(
                     pipeline.lpush(stream_test_list_pending, test_name)
                     test_names_added.append(test_name)
                     # Add topology-level entries
-                    if override_topology:
-                        # Override with single topology from CLI
-                        topologies = [override_topology]
-                        logging.info(f"Overriding topologies for test {test_name} with: {override_topology}")
-                    else:
-                        topologies = benchmark_config.get("redis-topologies", [])
+                    # Start with base topologies
+                    topologies = benchmark_config.get("redis-topologies", [])
+
+                    # Apply deployment name override if specified
+                    if override_deployment_regexp:
+                        topologies = [t for t in topologies if re.match(override_deployment_regexp, t)]
+                        logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name} -> {len(topologies)} matches: {topologies}")
+
+                    # Apply deployment name filter if specified
+                    if deployment_name_regexp != ".*":
+                        topologies = [t for t in topologies if re.match(deployment_name_regexp, t)]
+                        logging.info(f"Deployment name regexp '{deployment_name_regexp}' for test {test_name} -> {len(topologies)} matches: {topologies}")
                     for topo in topologies:
-                        # Apply deployment_name_regexp filter
-                        if deployment_name_regexp != ".*":
-                            if not re.match(deployment_name_regexp, topo):
-                                continue
                         # Apply CLI topology filter
                         if args is not None and args.topology and topo != args.topology:
                             continue
@@ -1495,12 +1497,18 @@ def process_self_contained_coordinator_stream(
                         # If all topologies are filtered out, test is considered passed (nothing to run).
                         test_result = True
 
-                        # Use override topology if specified, otherwise use config topologies
-                        if override_topology:
-                            topologies_to_run = [override_topology]
-                            logging.info(f"Using override topology for test {test_name}: {override_topology}")
-                        else:
-                            topologies_to_run = benchmark_config["redis-topologies"]
+                        # Start with base topologies
+                        topologies_to_run = benchmark_config["redis-topologies"]
+
+                        # Apply override filter if specified
+                        if override_deployment_regexp:
+                            topologies_to_run = [t for t in topologies_to_run if re.match(override_deployment_regexp, t)]
+                            logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name}: {len(topologies_to_run)} matches: {topologies_to_run}")
+
+                        # Apply deployment filter if specified
+                        if deployment_name_regexp != ".*":
+                            topologies_to_run = [t for t in topologies_to_run if re.match(deployment_name_regexp, t)]
+                            logging.info(f"Deployment name regexp '{deployment_name_regexp}' for test {test_name}: {len(topologies_to_run)} matches: {topologies_to_run}")
 
                         for topology_spec_name in topologies_to_run:
                             setup_name = topology_spec_name
@@ -1517,15 +1525,7 @@ def process_self_contained_coordinator_stream(
                                 )
                                 continue
 
-                            # Filter by deployment_name_regexp from stream (regex match)
-                            if deployment_name_regexp != ".*":
-                                if not re.match(
-                                    deployment_name_regexp, topology_spec_name
-                                ):
-                                    logging.info(
-                                        f"Skipping topology {topology_spec_name} as it doesn't match deployment_name_regexp '{deployment_name_regexp}'"
-                                    )
-                                    continue
+
 
                             if topology_spec_name in topologies_map:
                                 topology_spec = topologies_map[topology_spec_name]

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1256,7 +1256,9 @@ def process_self_contained_coordinator_stream(
 
             override_deployment_regexp = ""
             if b"override_deployment_regexp" in testDetails:
-                override_deployment_regexp = testDetails[b"override_deployment_regexp"].decode()
+                override_deployment_regexp = testDetails[
+                    b"override_deployment_regexp"
+                ].decode()
                 logging.info(
                     f"detected an override_deployment_regexp definition on the streamdata {override_deployment_regexp}"
                 )
@@ -1350,16 +1352,26 @@ def process_self_contained_coordinator_stream(
                     if override_deployment_regexp:
                         # Start with all available topologies when overriding
                         all_available_topologies = list(topologies_map.keys())
-                        topologies = [t for t in all_available_topologies if re.match(override_deployment_regexp, t)]
-                        logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name} -> {len(topologies)} matches from {len(all_available_topologies)} available: {topologies}")
+                        topologies = [
+                            t
+                            for t in all_available_topologies
+                            if re.match(override_deployment_regexp, t)
+                        ]
+                        logging.info(
+                            f"Override deployment regexp '{override_deployment_regexp}' for test {test_name} -> {len(topologies)} matches from {len(all_available_topologies)} available: {topologies}"
+                        )
                     else:
                         # Start with base topologies from config
                         topologies = benchmark_config.get("redis-topologies", [])
 
                     # Apply deployment name filter if specified
                     if deployment_name_regexp != ".*":
-                        topologies = [t for t in topologies if re.match(deployment_name_regexp, t)]
-                        logging.info(f"Deployment name regexp '{deployment_name_regexp}' for test {test_name} -> {len(topologies)} matches: {topologies}")
+                        topologies = [
+                            t for t in topologies if re.match(deployment_name_regexp, t)
+                        ]
+                        logging.info(
+                            f"Deployment name regexp '{deployment_name_regexp}' for test {test_name} -> {len(topologies)} matches: {topologies}"
+                        )
                     for topo in topologies:
                         # Apply CLI topology filter
                         if args is not None and args.topology and topo != args.topology:
@@ -1502,16 +1514,28 @@ def process_self_contained_coordinator_stream(
                         if override_deployment_regexp:
                             # Start with all available topologies when overriding
                             all_available_topologies = list(topologies_map.keys())
-                            topologies_to_run = [t for t in all_available_topologies if re.match(override_deployment_regexp, t)]
-                            logging.info(f"Override deployment regexp '{override_deployment_regexp}' for test {test_name}: {len(topologies_to_run)} matches from {len(all_available_topologies)} available: {topologies_to_run}")
+                            topologies_to_run = [
+                                t
+                                for t in all_available_topologies
+                                if re.match(override_deployment_regexp, t)
+                            ]
+                            logging.info(
+                                f"Override deployment regexp '{override_deployment_regexp}' for test {test_name}: {len(topologies_to_run)} matches from {len(all_available_topologies)} available: {topologies_to_run}"
+                            )
                         else:
                             # Start with base topologies from config
                             topologies_to_run = benchmark_config["redis-topologies"]
 
                         # Apply deployment filter if specified
                         if deployment_name_regexp != ".*":
-                            topologies_to_run = [t for t in topologies_to_run if re.match(deployment_name_regexp, t)]
-                            logging.info(f"Deployment name regexp '{deployment_name_regexp}' for test {test_name}: {len(topologies_to_run)} matches: {topologies_to_run}")
+                            topologies_to_run = [
+                                t
+                                for t in topologies_to_run
+                                if re.match(deployment_name_regexp, t)
+                            ]
+                            logging.info(
+                                f"Deployment name regexp '{deployment_name_regexp}' for test {test_name}: {len(topologies_to_run)} matches: {topologies_to_run}"
+                            )
 
                         for topology_spec_name in topologies_to_run:
                             setup_name = topology_spec_name
@@ -1527,8 +1551,6 @@ def process_self_contained_coordinator_stream(
                                     f"Skipping topology {topology_spec_name} as it doesn't match the requested topology {args.topology}"
                                 )
                                 continue
-
-
 
                             if topology_spec_name in topologies_map:
                                 topology_spec = topologies_map[topology_spec_name]

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1254,6 +1254,13 @@ def process_self_contained_coordinator_stream(
                     f"detected a deployment_name_regexp definition on the streamdata {deployment_name_regexp}"
                 )
 
+            override_topology = ""
+            if b"override_topology" in testDetails:
+                override_topology = testDetails[b"override_topology"].decode()
+                logging.info(
+                    f"detected an override_topology definition on the streamdata {override_topology}"
+                )
+
             skip_test = False
             if b"platform" in testDetails:
                 platform = testDetails[b"platform"]
@@ -1340,7 +1347,12 @@ def process_self_contained_coordinator_stream(
                     pipeline.lpush(stream_test_list_pending, test_name)
                     test_names_added.append(test_name)
                     # Add topology-level entries
-                    topologies = benchmark_config.get("redis-topologies", [])
+                    if override_topology:
+                        # Override with single topology from CLI
+                        topologies = [override_topology]
+                        logging.info(f"Overriding topologies for test {test_name} with: {override_topology}")
+                    else:
+                        topologies = benchmark_config.get("redis-topologies", [])
                     for topo in topologies:
                         # Apply deployment_name_regexp filter
                         if deployment_name_regexp != ".*":
@@ -1482,7 +1494,15 @@ def process_self_contained_coordinator_stream(
                         # Initialize test_result before topology loop.
                         # If all topologies are filtered out, test is considered passed (nothing to run).
                         test_result = True
-                        for topology_spec_name in benchmark_config["redis-topologies"]:
+
+                        # Use override topology if specified, otherwise use config topologies
+                        if override_topology:
+                            topologies_to_run = [override_topology]
+                            logging.info(f"Using override topology for test {test_name}: {override_topology}")
+                        else:
+                            topologies_to_run = benchmark_config["redis-topologies"]
+
+                        for topology_spec_name in topologies_to_run:
                             setup_name = topology_spec_name
                             setup_type = "oss-standalone"
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1333,11 +1333,14 @@ def process_self_contained_coordinator_stream(
                 logging.info(
                     f"Adding {len(filtered_test_files)} tests to pending test list"
                 )
+            
+                all_available_topologies = list(topologies_map.keys())
 
                 # Use pipeline for efficient bulk operations
                 pipeline = github_event_conn.pipeline()
                 test_names_added = []
                 total_topology_runs = 0
+            
 
                 for test_file in filtered_test_files:
                     with open(test_file, "r") as stream:
@@ -1349,9 +1352,11 @@ def process_self_contained_coordinator_stream(
                     pipeline.lpush(stream_test_list_pending, test_name)
                     test_names_added.append(test_name)
                     # Add topology-level entries
+                    topologies = benchmark_config.get("redis-topologies", [])
+
+                    # Override topology if specified
                     if override_deployment_regexp:
                         # Start with all available topologies when overriding
-                        all_available_topologies = list(topologies_map.keys())
                         topologies = [
                             t
                             for t in all_available_topologies
@@ -1360,11 +1365,8 @@ def process_self_contained_coordinator_stream(
                         logging.info(
                             f"Override deployment regexp '{override_deployment_regexp}' for test {test_name} -> {len(topologies)} matches from {len(all_available_topologies)} available: {topologies}"
                         )
-                    else:
-                        # Start with base topologies from config
-                        topologies = benchmark_config.get("redis-topologies", [])
 
-                    # Apply deployment name filter if specified
+                    # Apply topology filter if specified
                     if deployment_name_regexp != ".*":
                         topologies = [
                             t for t in topologies if re.match(deployment_name_regexp, t)
@@ -1372,6 +1374,7 @@ def process_self_contained_coordinator_stream(
                         logging.info(
                             f"Deployment name regexp '{deployment_name_regexp}' for test {test_name} -> {len(topologies)} matches: {topologies}"
                         )
+
                     for topo in topologies:
                         # Apply CLI topology filter
                         if args is not None and args.topology and topo != args.topology:
@@ -1511,9 +1514,11 @@ def process_self_contained_coordinator_stream(
                         test_result = True
 
                         # Start with appropriate topology base
+                        topologies_to_run = benchmark_config["redis-topologies"]
+                        
+                        # Override topology if specified
                         if override_deployment_regexp:
                             # Start with all available topologies when overriding
-                            all_available_topologies = list(topologies_map.keys())
                             topologies_to_run = [
                                 t
                                 for t in all_available_topologies
@@ -1522,9 +1527,6 @@ def process_self_contained_coordinator_stream(
                             logging.info(
                                 f"Override deployment regexp '{override_deployment_regexp}' for test {test_name}: {len(topologies_to_run)} matches from {len(all_available_topologies)} available: {topologies_to_run}"
                             )
-                        else:
-                            # Start with base topologies from config
-                            topologies_to_run = benchmark_config["redis-topologies"]
 
                         # Apply deployment filter if specified
                         if deployment_name_regexp != ".*":

--- a/utils/tests/test_admin.py
+++ b/utils/tests/test_admin.py
@@ -313,7 +313,7 @@ def test_override_deployment_regexp_with_deployment_name_regexp():
         "oss-cluster-01-replicas": {"type": "oss-cluster"},
         "oss-cluster-3-primaries": {"type": "oss-cluster"},
     }
-        
+
     try:
         # Test stream with both filters
         test_details = {
@@ -337,7 +337,6 @@ def test_override_deployment_regexp_with_deployment_name_regexp():
             mock_pipeline = Mock()
             mock_conn = Mock()
             mock_conn.pipeline.return_value = mock_pipeline
-
 
             process_self_contained_coordinator_stream(
                 github_event_conn=mock_conn,

--- a/utils/tests/test_admin.py
+++ b/utils/tests/test_admin.py
@@ -295,20 +295,25 @@ def test_override_deployment_regexp_with_deployment_name_regexp():
     when override_deployment_regexp='oss-standalone-.*' and deployment_name_regexp='.*replicas'.
     """
 
-    # Test config with multiple topologies
-    config = {
-        "name": "test",
-        "redis-topologies": [
-            "oss-standalone-01-replicas",
-            "oss-standalone-04-io-threads",
-            "oss-cluster-01-replicas",
-        ],
-    }
-
+    # Test config with single topology to prove override works from ALL available
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
-        yaml.dump(config, f)
+        yaml.dump(
+            {
+                "name": "test",
+                "redis-topologies": ["oss-standalone-with-redisearch"],
+            },
+            f,
+        )
         test_file = f.name
 
+    # Create realistic topologies_map with all topologies
+    topologies_map = {
+        "oss-standalone-01-replicas": {"type": "oss-standalone"},
+        "oss-standalone-04-io-threads": {"type": "oss-standalone"},
+        "oss-cluster-01-replicas": {"type": "oss-cluster"},
+        "oss-cluster-3-primaries": {"type": "oss-cluster"},
+    }
+        
     try:
         # Test stream with both filters
         test_details = {
@@ -333,6 +338,7 @@ def test_override_deployment_regexp_with_deployment_name_regexp():
             mock_conn = Mock()
             mock_conn.pipeline.return_value = mock_pipeline
 
+
             process_self_contained_coordinator_stream(
                 github_event_conn=mock_conn,
                 datasink_push_results_redistimeseries=False,
@@ -341,7 +347,7 @@ def test_override_deployment_regexp_with_deployment_name_regexp():
                 newTestInfo=[["stream", [[b"123", test_details]]]],
                 datasink_conn=Mock(),
                 testsuite_spec_files=[test_file],
-                topologies_map={},
+                topologies_map=topologies_map,
                 running_platform="test",
             )
 
@@ -352,7 +358,8 @@ def test_override_deployment_regexp_with_deployment_name_regexp():
                 if len(call[0]) == 2 and "::" in str(call[0][1])
             ]
 
-            # Should only get standalone replicas (not io-threads, not cluster)
+            # Should get all standalone topologies that match ".*replicas" filter
+            # With override, we select from ALL available topologies, not just config topologies
             assert queued == ["oss-standalone-01-replicas"]
 
     finally:

--- a/utils/tests/test_admin.py
+++ b/utils/tests/test_admin.py
@@ -6,8 +6,15 @@
 
 import argparse
 import re
+import tempfile
+import yaml
+import os
+from unittest.mock import Mock, patch
 
 import redis
+from redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator import (
+    process_self_contained_coordinator_stream,
+)
 
 from redis_benchmarks_specification.__cli__.args import spec_cli_args
 from redis_benchmarks_specification.__cli__.admin import (
@@ -224,7 +231,7 @@ def test_generate_benchmark_stream_request_deployment_regexp():
             {},
             "linux",
             deployment_name_regexp=".*",
-            override_topology="",
+            override_deployment_regexp="",
         )
         assert "deployment_name_regexp" not in fields
 
@@ -237,11 +244,21 @@ def test_generate_benchmark_stream_request_deployment_regexp():
             {},
             "linux",
             deployment_name_regexp="oss-standalone-0[48]-io-threads",
-            override_topology="",
+            override_deployment_regexp="",
         )
         assert fields["deployment_name_regexp"] == "oss-standalone-0[48]-io-threads"
 
-        # With override_topology - should include field
+    except redis.exceptions.ConnectionError:
+        pass
+
+
+def test_generate_benchmark_stream_request_override_deployment_regexp():
+    """Test that override_deployment_regexp is included correctly in stream fields."""
+    try:
+        conn = redis.StrictRedis(decode_responses=False)
+        conn.ping()
+
+        # Without override_deployment_regexp (default) - should NOT include field
         fields, result = generate_benchmark_stream_request(
             "test-id",
             conn,
@@ -250,12 +267,96 @@ def test_generate_benchmark_stream_request_deployment_regexp():
             {},
             "linux",
             deployment_name_regexp=".*",
-            override_topology="oss-standalone-01-replicas",
+            override_deployment_regexp="",
         )
-        assert fields["override_topology"] == "oss-standalone-01-replicas"
+        assert "override_deployment_regexp" not in fields
+
+        # With override_deployment_regexp - should include field
+        fields, result = generate_benchmark_stream_request(
+            "test-id",
+            conn,
+            "redis",
+            "amd64",
+            {},
+            "linux",
+            deployment_name_regexp=".*",
+            override_deployment_regexp="oss-standalone-0[12]-replicas",
+        )
+        assert fields["override_deployment_regexp"] == "oss-standalone-0[12]-replicas"
 
     except redis.exceptions.ConnectionError:
         pass
+
+
+def test_override_deployment_regexp_with_deployment_name_regexp():
+    """Test topology filtering: override to standalone, filter to replicas.
+
+    Mocks pipeline.lpush to verify only 'oss-standalone-01-replicas' gets queued
+    when override_deployment_regexp='oss-standalone-.*' and deployment_name_regexp='.*replicas'.
+    """
+
+    # Test config with multiple topologies
+    config = {
+        "name": "test",
+        "redis-topologies": [
+            "oss-standalone-01-replicas",
+            "oss-standalone-04-io-threads",
+            "oss-cluster-01-replicas",
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        yaml.dump(config, f)
+        test_file = f.name
+
+    try:
+        # Test stream with both filters
+        test_details = {
+            b"override_deployment_regexp": b"oss-standalone-.*",  # Get standalone
+            b"deployment_name_regexp": b".*replicas",  # Filter to replicas
+            b"run_image": b"redis:latest",
+            b"build_image": b"redis:latest",
+            b"build_variant_name": b"redis",
+            b"metadata": b"{}",
+            b"build_artifacts": b"{}",
+            b"git_hash": b"abc",
+            b"git_branch": b"main",
+            b"git_version": b"1.0",
+        }
+
+        with patch("redis.StrictRedis"), patch("docker.from_env"), patch(
+            "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.get_benchmark_specs",
+            return_value=[test_file],
+        ):
+
+            mock_pipeline = Mock()
+            mock_conn = Mock()
+            mock_conn.pipeline.return_value = mock_pipeline
+
+            process_self_contained_coordinator_stream(
+                github_event_conn=mock_conn,
+                datasink_push_results_redistimeseries=False,
+                docker_client=Mock(),
+                home="/tmp",
+                newTestInfo=[["stream", [[b"123", test_details]]]],
+                datasink_conn=Mock(),
+                testsuite_spec_files=[test_file],
+                topologies_map={},
+                running_platform="test",
+            )
+
+            # Extract queued topologies
+            queued = [
+                call[0][1].split("::")[1]
+                for call in mock_pipeline.lpush.call_args_list
+                if len(call[0]) == 2 and "::" in str(call[0][1])
+            ]
+
+            # Should only get standalone replicas (not io-threads, not cluster)
+            assert queued == ["oss-standalone-01-replicas"]
+
+    finally:
+        os.unlink(test_file)
 
 
 def test_dry_run_topology_breakdown():

--- a/utils/tests/test_admin.py
+++ b/utils/tests/test_admin.py
@@ -224,6 +224,7 @@ def test_generate_benchmark_stream_request_deployment_regexp():
             {},
             "linux",
             deployment_name_regexp=".*",
+            override_topology="",
         )
         assert "deployment_name_regexp" not in fields
 
@@ -236,8 +237,22 @@ def test_generate_benchmark_stream_request_deployment_regexp():
             {},
             "linux",
             deployment_name_regexp="oss-standalone-0[48]-io-threads",
+            override_topology="",
         )
         assert fields["deployment_name_regexp"] == "oss-standalone-0[48]-io-threads"
+
+        # With override_topology - should include field
+        fields, result = generate_benchmark_stream_request(
+            "test-id",
+            conn,
+            "redis",
+            "amd64",
+            {},
+            "linux",
+            deployment_name_regexp=".*",
+            override_topology="oss-standalone-01-replicas",
+        )
+        assert fields["override_topology"] == "oss-standalone-01-replicas"
 
     except redis.exceptions.ConnectionError:
         pass

--- a/utils/tests/test_self_contained_coordinator_memtier.py
+++ b/utils/tests/test_self_contained_coordinator_memtier.py
@@ -1352,6 +1352,7 @@ def test_self_contained_coordinator_duplicated_ts():
                     use_git_timestamp=True,
                     existing_artifact_keys=None,
                     git_version=redis_version,
+                    override_topology="",
                 )
                 build_stream_fields["mnt_point"] = ""
                 if result is True:

--- a/utils/tests/test_self_contained_coordinator_memtier.py
+++ b/utils/tests/test_self_contained_coordinator_memtier.py
@@ -1352,7 +1352,7 @@ def test_self_contained_coordinator_duplicated_ts():
                     use_git_timestamp=True,
                     existing_artifact_keys=None,
                     git_version=redis_version,
-                    override_topology="",
+                    override_deployment_regexp="",
                 )
                 build_stream_fields["mnt_point"] = ""
                 if result is True:


### PR DESCRIPTION
Introduce `--override-deployment-regexp` to override redis-topologies from benchmark configs using regex patterns for flexible deployment selection.

### Key Changes

- **New CLI flag**: `--override-deployment-regexp` overrides config topologies with regex-matched selections from ALL available topologies
- **Regex patterns**: Use patterns like `oss-standalone-0[12]-replicas` to override with multiple matching topologies
- **Works with filtering**: Can combine with `--deployment-name-regexp` for additional filtering on overridden topologies
- **Backward compatible**: When not specified, topologies from benchmark configs are used as before

### Usage Examples

```bash
# Override all configs to use standalone deployments
--override-deployment-regexp "oss-standalone-.*"

# Override to specific replica configurations across all tests
--override-deployment-regexp "oss-standalone-0[12]-replicas"

# Override then filter further
--override-deployment-regexp "oss-.*" --deployment-name-regexp ".*io-threads"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark execution selection logic by allowing configs’ `redis-topologies` to be overridden from the full topology set, which could significantly alter what gets queued/run if misconfigured. Impact is limited to benchmark orchestration (no auth/data-plane changes) but affects run scope and CI load.
> 
> **Overview**
> Adds a new `--override-deployment-regexp` option that **replaces** each benchmark config’s `redis-topologies` with a regex-matched subset of *all available* topologies, and allows combining it with the existing `--deployment-name-regexp` for additional filtering.
> 
> Plumbs this override through stream request generation (`generate_benchmark_stream_request` adds `override_deployment_regexp`) and updates the self-contained coordinator queueing/execution to apply the override when building per-test topology work items; dry-run output is updated to reflect the override behavior. Tests are extended to assert stream field inclusion and correct combined override+filter queuing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862a6b783797b28c19d7a53a2aac0463a1820a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->