### PR TITLE
Add topdown-profiler integration for automated TMA collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.2.72"
+version = "0.2.73"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1857,17 +1857,18 @@ def process_self_contained_coordinator_stream(
                                     profiler_call_graph_mode,
                                 )
 
+                                # Extract test time from benchmark command (used for
+                                # both topdown duration and container timeout)
+                                test_time_match = re.search(
+                                    r"--?test-time[=\s]+(\d+)", benchmark_command_str
+                                )
+
                                 # Start topdown-profiler collection alongside benchmark
                                 if _topdown_available and topdown_labels:
-                                    # Extract expected benchmark duration for topdown collection
                                     topdown_duration = 30  # default
-                                    td_match = re.search(
-                                        r"--?test-time[=\s]+(\d+)",
-                                        benchmark_command_str,
-                                    )
-                                    if td_match:
+                                    if test_time_match:
                                         topdown_duration = min(
-                                            int(td_match.group(1)), 30
+                                            int(test_time_match.group(1)), 30
                                         )
                                     topdown_collector = TopdownCollector(
                                         process_name=executable.split("/")[-1],
@@ -1891,10 +1892,6 @@ def process_self_contained_coordinator_stream(
                                 container_timeout = 300  # 5 minutes default
                                 buffer_timeout = 60  # Default buffer
 
-                                # Try to extract test time from command and add buffer
-                                test_time_match = re.search(
-                                    r"--?test-time[=\s]+(\d+)", benchmark_command_str
-                                )
                                 if test_time_match:
                                     test_time = int(test_time_match.group(1))
                                     container_timeout = test_time + buffer_timeout
@@ -2310,6 +2307,14 @@ def process_self_contained_coordinator_stream(
                                     )
 
                                 test_result = False
+                            # Clean up topdown collector if still running
+                            if topdown_collector is not None:
+                                try:
+                                    topdown_collector.wait_for_completion(timeout=5)
+                                except Exception:
+                                    pass
+                                topdown_collector = None
+
                             # tear-down
                             logging.info("Tearing down setup")
                             if docker_keep_env is False:

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -125,6 +125,12 @@ from redis_benchmarks_specification.__self_contained_coordinator__.parca_agent i
     update_parca_agent_labels,
     extract_test_labels_from_benchmark_config,
 )
+from redis_benchmarks_specification.__self_contained_coordinator__.topdown_profiler import (
+    check_topdown_available,
+    check_perf_event_paranoid,
+    TopdownCollector,
+    extract_topdown_labels_from_benchmark,
+)
 
 # Global variables for HTTP server control
 _reset_queue_requested = False
@@ -136,6 +142,10 @@ _flush_timestamp = None
 # Global variables for parca-agent integration
 _parca_agent_available = False
 _parca_startup_labels = {}
+
+# Global variables for topdown-profiler integration
+_topdown_available = False
+_topdown_startup_labels = {}
 
 # Global variables for heartbeat
 _heartbeat_status = "idle"  # idle, running, waiting
@@ -821,6 +831,21 @@ def main():
             "coordinator_version": project_version,
         }
         logging.info(f"Parca-agent startup labels: {_parca_startup_labels}")
+
+    # Check topdown-profiler availability and set startup labels
+    global _topdown_available, _topdown_startup_labels
+    _topdown_available = check_topdown_available()
+    if _topdown_available:
+        if not check_perf_event_paranoid():
+            logging.warning(
+                "topdown-profiler: perf_event_paranoid too restrictive - collection may fail"
+            )
+        _topdown_startup_labels = {
+            "platform": running_platform,
+            "arch": arch,
+            "coordinator_version": project_version,
+        }
+        logging.info(f"topdown-profiler startup labels: {_topdown_startup_labels}")
 
     # Start heartbeat thread — writes runner state to Redis every 30s
     heartbeat_thread = _start_heartbeat(
@@ -1516,18 +1541,32 @@ def process_self_contained_coordinator_stream(
 
                             # Update parca-agent labels if available
                             global _parca_agent_available, _parca_startup_labels
+                            test_labels = extract_test_labels_from_benchmark_config(
+                                benchmark_config
+                            )
+                            # Override topology with current iteration's topology
+                            test_labels["topology"] = topology_spec_name
+
                             if _parca_agent_available:
-                                test_labels = extract_test_labels_from_benchmark_config(
-                                    benchmark_config
-                                )
-                                # Override topology with current iteration's topology
-                                test_labels["topology"] = topology_spec_name
                                 all_labels = {
                                     **_parca_startup_labels,
                                     **parca_build_labels,
                                     **test_labels,
                                 }
                                 update_parca_agent_labels(all_labels)
+
+                            # Prepare topdown-profiler collector if available
+                            global _topdown_available, _topdown_startup_labels
+                            topdown_collector = None
+                            if _topdown_available:
+                                topdown_labels = extract_topdown_labels_from_benchmark(
+                                    _topdown_startup_labels,
+                                    parca_build_labels,
+                                    test_labels,
+                                )
+                                logging.info(
+                                    f"topdown-profiler: prepared labels for {test_name}/{topology_spec_name}"
+                                )
 
                             # Track topology-level: move from pending to running
                             topo_tracking_entry = f"{test_name}::{topology_spec_name}"
@@ -1818,6 +1857,26 @@ def process_self_contained_coordinator_stream(
                                     profiler_call_graph_mode,
                                 )
 
+                                # Start topdown-profiler collection alongside benchmark
+                                if _topdown_available and topdown_labels:
+                                    # Extract expected benchmark duration for topdown collection
+                                    topdown_duration = 30  # default
+                                    td_match = re.search(
+                                        r"--?test-time[=\s]+(\d+)",
+                                        benchmark_command_str,
+                                    )
+                                    if td_match:
+                                        topdown_duration = min(
+                                            int(td_match.group(1)), 30
+                                        )
+                                    topdown_collector = TopdownCollector(
+                                        process_name=executable.split("/")[-1],
+                                        duration_seconds=topdown_duration,
+                                        level=2,
+                                        labels=topdown_labels,
+                                    )
+                                    topdown_collector.start()
+
                                 logging.info(
                                     "Using docker image {} as benchmark client image (cpuset={}) with the following args: {}".format(
                                         client_container_image,
@@ -1952,6 +2011,22 @@ def process_self_contained_coordinator_stream(
                                 logging.info(
                                     "output {}".format(client_container_stdout)
                                 )
+
+                                # Wait for topdown-profiler if it was started
+                                if topdown_collector is not None:
+                                    topdown_run_id = topdown_collector.wait_for_completion(
+                                        timeout=60
+                                    )
+                                    if topdown_run_id:
+                                        logging.info(
+                                            f"topdown-profiler: collection complete, "
+                                            f"run_id={topdown_run_id}"
+                                        )
+                                    else:
+                                        logging.warning(
+                                            "topdown-profiler: collection failed or timed out"
+                                        )
+                                    topdown_collector = None
 
                                 (
                                     _,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -2011,8 +2011,10 @@ def process_self_contained_coordinator_stream(
 
                                 # Wait for topdown-profiler if it was started
                                 if topdown_collector is not None:
-                                    topdown_run_id = topdown_collector.wait_for_completion(
-                                        timeout=60
+                                    topdown_run_id = (
+                                        topdown_collector.wait_for_completion(
+                                            timeout=60
+                                        )
                                     )
                                     if topdown_run_id:
                                         logging.info(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/topdown_profiler.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/topdown_profiler.py
@@ -1,0 +1,287 @@
+"""
+topdown-profiler integration for the self-contained coordinator.
+
+This module provides functions to check if topdown-profiler is available
+and to collect Intel Top-Down Microarchitecture Analysis (TMA) data
+alongside benchmark runs, with labels matching the parca-agent label system.
+"""
+
+import logging
+import shutil
+import subprocess
+from typing import Dict, Optional
+
+
+def check_topdown_available() -> bool:
+    """
+    Check if topdown-profiler CLI is available on the system.
+
+    Returns True only if:
+      1. `topdown` command exists in PATH
+      2. `topdown version` runs successfully
+      3. System is x86_64 (Intel TMA requires Intel CPU)
+    """
+    import platform
+
+    # Step 1: Check architecture — TMA only works on x86_64 Intel
+    machine = platform.machine()
+    if machine not in ("x86_64", "AMD64"):
+        logging.info(
+            f"topdown-profiler: architecture {machine} not supported (requires x86_64) - disabled"
+        )
+        return False
+
+    # Step 2: Check if topdown command exists
+    if shutil.which("topdown") is None:
+        logging.info("topdown command not found in PATH - topdown integration disabled")
+        return False
+
+    # Step 3: Verify it runs
+    try:
+        result = subprocess.run(
+            ["topdown", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            logging.info(
+                f"topdown version failed (rc={result.returncode}) - topdown integration disabled"
+            )
+            return False
+        version = result.stdout.strip()
+        logging.info(f"topdown-profiler available: {version} - integration enabled")
+        return True
+    except subprocess.TimeoutExpired:
+        logging.warning("Timeout running topdown version")
+        return False
+    except Exception as e:
+        logging.warning(f"Failed to check topdown availability: {e}")
+        return False
+
+
+def check_perf_event_paranoid() -> bool:
+    """
+    Check if perf_event_paranoid is set low enough for TMA collection.
+
+    Returns True if perf_event_paranoid <= 1 (or running as root).
+    """
+    import os
+
+    if os.geteuid() == 0:
+        return True
+
+    try:
+        with open("/proc/sys/kernel/perf_event_paranoid", "r") as f:
+            value = int(f.read().strip())
+            if value <= 1:
+                return True
+            else:
+                logging.warning(
+                    f"perf_event_paranoid={value} (need <=1) - topdown collection may fail. "
+                    f"Fix with: sudo sysctl kernel.perf_event_paranoid=1"
+                )
+                return False
+    except Exception as e:
+        logging.warning(f"Could not read perf_event_paranoid: {e}")
+        return False
+
+
+def build_topdown_labels(labels: Dict[str, str]) -> list:
+    """
+    Convert a label dictionary to topdown CLI --label arguments.
+
+    Returns a list of ['--label', 'key=value', '--label', 'key=value', ...] args.
+    """
+    args = []
+    for key, value in labels.items():
+        if value is not None:
+            # topdown-profiler stores labels as JSON, so less sanitization needed
+            # than parca-agent, but we still clean up for safety
+            clean_value = str(value).replace("'", "").replace('"', "")
+            args.extend(["--label", f"{key}={clean_value}"])
+    return args
+
+
+def collect_topdown(
+    process_name: str,
+    duration_seconds: int,
+    level: int,
+    labels: Dict[str, str],
+    db_path: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> Optional[str]:
+    """
+    Run a TMA collection for a process with labels.
+
+    Args:
+        process_name: Process name to profile (e.g., 'redis-server')
+        duration_seconds: Collection duration in seconds
+        level: TMA analysis level (1-6, default 2)
+        labels: Dictionary of label key-value pairs
+        db_path: Optional path to SQLite database
+        timeout: Subprocess timeout (default: duration + 60s buffer)
+
+    Returns:
+        Run ID string if successful, None on failure
+    """
+    if timeout is None:
+        timeout = duration_seconds + 60
+
+    cmd = [
+        "topdown",
+        "collect",
+        "--process",
+        process_name,
+        "--level",
+        str(level),
+        "--duration",
+        f"{duration_seconds}s",
+    ]
+
+    # Add labels
+    cmd.extend(build_topdown_labels(labels))
+
+    # Add database path if specified
+    env = None
+    if db_path:
+        import os
+
+        env = {**os.environ, "TOPDOWN_DB_PATH": db_path}
+
+    try:
+        logging.info(
+            f"Starting topdown collection: process={process_name}, "
+            f"level={level}, duration={duration_seconds}s, labels={len(labels)}"
+        )
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+
+        if result.returncode != 0:
+            logging.warning(f"topdown collect failed (rc={result.returncode}): {result.stderr}")
+            return None
+
+        # Extract run ID from output (format: "Done. Run ID: <uuid>")
+        for line in result.stdout.splitlines():
+            if "Run ID:" in line:
+                run_id = line.split("Run ID:")[-1].strip()
+                logging.info(f"topdown collection complete: run_id={run_id}")
+                return run_id
+
+        logging.info(f"topdown collection complete (no run ID parsed)")
+        return "unknown"
+
+    except subprocess.TimeoutExpired:
+        logging.warning(
+            f"topdown collection timed out after {timeout}s "
+            f"(duration was {duration_seconds}s)"
+        )
+        return None
+    except Exception as e:
+        logging.warning(f"topdown collection failed: {e}")
+        return None
+
+
+class TopdownCollector:
+    """
+    Thread-based topdown collector that runs alongside a benchmark.
+
+    Usage:
+        collector = TopdownCollector(
+            process_name="redis-server",
+            duration_seconds=30,
+            level=2,
+            labels={...},
+        )
+        collector.start()
+        # ... run benchmark ...
+        run_id = collector.wait_for_completion()
+    """
+
+    def __init__(
+        self,
+        process_name: str,
+        duration_seconds: int,
+        level: int = 2,
+        labels: Optional[Dict[str, str]] = None,
+        db_path: Optional[str] = None,
+    ):
+        self.process_name = process_name
+        self.duration_seconds = duration_seconds
+        self.level = level
+        self.labels = labels or {}
+        self.db_path = db_path
+        self._thread = None
+        self._run_id = None
+        self._error = None
+
+    def start(self):
+        """Start topdown collection in a background thread."""
+        import threading
+
+        self._thread = threading.Thread(target=self._collect_worker, daemon=True)
+        self._thread.start()
+        logging.info(
+            f"TopdownCollector started: process={self.process_name}, "
+            f"duration={self.duration_seconds}s, level={self.level}"
+        )
+
+    def _collect_worker(self):
+        """Worker thread that runs topdown collect."""
+        try:
+            self._run_id = collect_topdown(
+                process_name=self.process_name,
+                duration_seconds=self.duration_seconds,
+                level=self.level,
+                labels=self.labels,
+                db_path=self.db_path,
+            )
+        except Exception as e:
+            self._error = str(e)
+            logging.warning(f"TopdownCollector error: {e}")
+
+    def wait_for_completion(self, timeout: int = 120) -> Optional[str]:
+        """
+        Wait for collection to complete.
+
+        Returns the run ID if successful, None on failure/timeout.
+        """
+        if self._thread is None:
+            logging.warning("TopdownCollector: start() was not called")
+            return None
+
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            logging.warning(f"TopdownCollector: timed out after {timeout}s")
+            return None
+
+        if self._error:
+            logging.warning(f"TopdownCollector: failed with error: {self._error}")
+            return None
+
+        return self._run_id
+
+
+def extract_topdown_labels_from_benchmark(
+    startup_labels: Dict[str, str],
+    build_labels: Dict[str, str],
+    test_labels: Dict[str, str],
+) -> Dict[str, str]:
+    """
+    Merge all label tiers into a single dict for topdown collection.
+
+    Same label hierarchy as parca-agent:
+      1. Startup labels (platform, arch, coordinator_version)
+      2. Build labels (git_hash, git_branch, build_variant, github_org, github_repo)
+      3. Test labels (test_name, topology, client_tool, tested_commands, etc.)
+    """
+    return {
+        **startup_labels,
+        **build_labels,
+        **test_labels,
+    }

--- a/redis_benchmarks_specification/__self_contained_coordinator__/topdown_profiler.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/topdown_profiler.py
@@ -163,7 +163,9 @@ def collect_topdown(
         )
 
         if result.returncode != 0:
-            logging.warning(f"topdown collect failed (rc={result.returncode}): {result.stderr}")
+            logging.warning(
+                f"topdown collect failed (rc={result.returncode}): {result.stderr}"
+            )
             return None
 
         # Extract run ID from output (format: "Done. Run ID: <uuid>")

--- a/utils/tests/test_topdown_profiler.py
+++ b/utils/tests/test_topdown_profiler.py
@@ -1,0 +1,392 @@
+"""
+Tests for topdown_profiler module.
+
+Unit tests for availability detection, label building, and collection logic.
+These tests mock subprocess calls so they run on any platform (including CI
+which is ubuntu without topdown-profiler or Intel PMU access).
+"""
+
+import platform
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from redis_benchmarks_specification.__self_contained_coordinator__.topdown_profiler import (
+    build_topdown_labels,
+    check_perf_event_paranoid,
+    check_topdown_available,
+    collect_topdown,
+    extract_topdown_labels_from_benchmark,
+    TopdownCollector,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_topdown_available
+# ---------------------------------------------------------------------------
+
+
+@patch("platform.machine", return_value="aarch64")
+@patch("shutil.which", return_value="/usr/bin/topdown")
+def test_check_topdown_available_arm_rejected(mock_which, mock_machine):
+    """ARM architecture should be rejected — TMA is Intel-only."""
+    assert check_topdown_available() is False
+
+
+@patch("platform.machine", return_value="x86_64")
+@patch("shutil.which", return_value=None)
+def test_check_topdown_available_not_in_path(mock_which, mock_machine):
+    """If topdown command is not in PATH, should return False."""
+    assert check_topdown_available() is False
+
+
+@patch("platform.machine", return_value="x86_64")
+@patch("shutil.which", return_value="/usr/local/bin/topdown")
+@patch("subprocess.run")
+def test_check_topdown_available_version_fails(mock_run, mock_which, mock_machine):
+    """If topdown version returns non-zero, should return False."""
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+    assert check_topdown_available() is False
+
+
+@patch("platform.machine", return_value="x86_64")
+@patch("shutil.which", return_value="/usr/local/bin/topdown")
+@patch("subprocess.run")
+def test_check_topdown_available_version_timeout(mock_run, mock_which, mock_machine):
+    """If topdown version times out, should return False."""
+    import subprocess
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="topdown", timeout=10)
+    assert check_topdown_available() is False
+
+
+@patch("platform.machine", return_value="x86_64")
+@patch("shutil.which", return_value="/usr/local/bin/topdown")
+@patch("subprocess.run")
+def test_check_topdown_available_success(mock_run, mock_which, mock_machine):
+    """Happy path: x86_64, in PATH, version succeeds."""
+    mock_run.return_value = MagicMock(returncode=0, stdout="topdown-profiler 0.1.0")
+    assert check_topdown_available() is True
+
+
+# ---------------------------------------------------------------------------
+# check_perf_event_paranoid
+# ---------------------------------------------------------------------------
+
+
+@patch("os.geteuid", return_value=0)
+def test_check_perf_event_paranoid_root(mock_euid):
+    """Root always has PMU access."""
+    assert check_perf_event_paranoid() is True
+
+
+@patch("os.geteuid", return_value=1000)
+@patch("builtins.open", mock.mock_open(read_data="1\n"))
+def test_check_perf_event_paranoid_ok(mock_euid):
+    """perf_event_paranoid=1 should be allowed."""
+    assert check_perf_event_paranoid() is True
+
+
+@patch("os.geteuid", return_value=1000)
+@patch("builtins.open", mock.mock_open(read_data="-1\n"))
+def test_check_perf_event_paranoid_minus_one(mock_euid):
+    """perf_event_paranoid=-1 should be allowed."""
+    assert check_perf_event_paranoid() is True
+
+
+@patch("os.geteuid", return_value=1000)
+@patch("builtins.open", mock.mock_open(read_data="4\n"))
+def test_check_perf_event_paranoid_too_high(mock_euid):
+    """perf_event_paranoid=4 (Ubuntu default) should return False."""
+    assert check_perf_event_paranoid() is False
+
+
+@patch("os.geteuid", return_value=1000)
+@patch("builtins.open", side_effect=FileNotFoundError)
+def test_check_perf_event_paranoid_file_missing(mock_open, mock_euid):
+    """Missing /proc file should return False gracefully."""
+    assert check_perf_event_paranoid() is False
+
+
+# ---------------------------------------------------------------------------
+# build_topdown_labels
+# ---------------------------------------------------------------------------
+
+
+def test_build_topdown_labels_empty():
+    """Empty dict should produce empty list."""
+    assert build_topdown_labels({}) == []
+
+
+def test_build_topdown_labels_basic():
+    """Basic labels should produce --label key=value pairs."""
+    result = build_topdown_labels({"git_branch": "unstable", "test_name": "set-get"})
+    assert result == [
+        "--label",
+        "git_branch=unstable",
+        "--label",
+        "test_name=set-get",
+    ]
+
+
+def test_build_topdown_labels_none_value_skipped():
+    """None values should be skipped."""
+    result = build_topdown_labels({"git_branch": "unstable", "optional": None})
+    assert result == ["--label", "git_branch=unstable"]
+
+
+def test_build_topdown_labels_sanitizes_quotes():
+    """Quotes in values should be stripped."""
+    result = build_topdown_labels({"variant": 'release"debug'})
+    assert result == ["--label", "variant=releasedebug"]
+
+
+def test_build_topdown_labels_integer_value():
+    """Integer values should be converted to string."""
+    result = build_topdown_labels({"level": 3})
+    assert result == ["--label", "level=3"]
+
+
+# ---------------------------------------------------------------------------
+# extract_topdown_labels_from_benchmark
+# ---------------------------------------------------------------------------
+
+
+def test_extract_topdown_labels_merges_all_tiers():
+    """Labels from all three tiers should be merged, later tiers taking precedence."""
+    startup = {"platform": "aws", "arch": "x86_64"}
+    build = {"git_branch": "unstable", "git_hash": "abc123"}
+    test = {"test_name": "set-get-100", "topology": "oss-standalone"}
+
+    result = extract_topdown_labels_from_benchmark(startup, build, test)
+
+    assert result == {
+        "platform": "aws",
+        "arch": "x86_64",
+        "git_branch": "unstable",
+        "git_hash": "abc123",
+        "test_name": "set-get-100",
+        "topology": "oss-standalone",
+    }
+
+
+def test_extract_topdown_labels_later_tier_overrides():
+    """Test-level labels should override startup-level if same key."""
+    startup = {"platform": "aws"}
+    build = {"platform": "gcp"}  # override
+    test = {}
+
+    result = extract_topdown_labels_from_benchmark(startup, build, test)
+    assert result["platform"] == "gcp"
+
+
+# ---------------------------------------------------------------------------
+# collect_topdown
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+def test_collect_topdown_success(mock_run):
+    """Successful collection should return the run ID."""
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout=(
+            "Found 1 PID(s) for 'redis-server': [12345]\n"
+            "Collecting level 2 data for 30s...\n"
+            "Done. Run ID: 7f3a2b1c-abcd-1234-ef56-789012345678\n"
+            "  Samples: 2340 | Duration: 30.2s\n"
+        ),
+        stderr="",
+    )
+
+    run_id = collect_topdown(
+        process_name="redis-server",
+        duration_seconds=30,
+        level=2,
+        labels={"git_branch": "unstable"},
+    )
+
+    assert run_id == "7f3a2b1c-abcd-1234-ef56-789012345678"
+
+    # Verify the command was constructed correctly
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "topdown"
+    assert cmd[1] == "collect"
+    assert "--process" in cmd
+    assert "redis-server" in cmd
+    assert "--level" in cmd
+    assert "2" in cmd
+    assert "--duration" in cmd
+    assert "30s" in cmd
+    assert "--label" in cmd
+    assert "git_branch=unstable" in cmd
+
+
+@patch("subprocess.run")
+def test_collect_topdown_failure(mock_run):
+    """Failed collection should return None."""
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr="Error: process not found",
+    )
+
+    run_id = collect_topdown(
+        process_name="redis-server",
+        duration_seconds=30,
+        level=2,
+        labels={},
+    )
+
+    assert run_id is None
+
+
+@patch("subprocess.run")
+def test_collect_topdown_timeout(mock_run):
+    """Timeout should return None."""
+    import subprocess
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="topdown", timeout=90)
+
+    run_id = collect_topdown(
+        process_name="redis-server",
+        duration_seconds=30,
+        level=2,
+        labels={},
+    )
+
+    assert run_id is None
+
+
+@patch("subprocess.run")
+def test_collect_topdown_custom_db_path(mock_run):
+    """Custom db_path should be passed as TOPDOWN_DB_PATH env var."""
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="Done. Run ID: abc123\n",
+        stderr="",
+    )
+
+    collect_topdown(
+        process_name="redis-server",
+        duration_seconds=10,
+        level=3,
+        labels={},
+        db_path="/tmp/test.db",
+    )
+
+    # Check env was passed
+    call_kwargs = mock_run.call_args[1]
+    assert call_kwargs["env"]["TOPDOWN_DB_PATH"] == "/tmp/test.db"
+
+
+@patch("subprocess.run")
+def test_collect_topdown_multiple_labels(mock_run):
+    """Multiple labels should all appear in the command."""
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="Done. Run ID: abc123\n",
+        stderr="",
+    )
+
+    labels = {
+        "git_branch": "unstable",
+        "test_name": "set-get-100",
+        "topology": "oss-standalone",
+        "build_variant": "release",
+    }
+    collect_topdown(
+        process_name="redis-server",
+        duration_seconds=30,
+        level=2,
+        labels=labels,
+    )
+
+    cmd = mock_run.call_args[0][0]
+    label_args = [cmd[i + 1] for i, v in enumerate(cmd) if v == "--label"]
+    assert "git_branch=unstable" in label_args
+    assert "test_name=set-get-100" in label_args
+    assert "topology=oss-standalone" in label_args
+    assert "build_variant=release" in label_args
+
+
+# ---------------------------------------------------------------------------
+# TopdownCollector
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "redis_benchmarks_specification.__self_contained_coordinator__"
+    ".topdown_profiler.collect_topdown"
+)
+def test_topdown_collector_success(mock_collect):
+    """TopdownCollector should start, collect, and return run ID."""
+    mock_collect.return_value = "run-id-123"
+
+    collector = TopdownCollector(
+        process_name="redis-server",
+        duration_seconds=10,
+        level=2,
+        labels={"test_name": "set-get"},
+    )
+    collector.start()
+    run_id = collector.wait_for_completion(timeout=5)
+
+    assert run_id == "run-id-123"
+    mock_collect.assert_called_once_with(
+        process_name="redis-server",
+        duration_seconds=10,
+        level=2,
+        labels={"test_name": "set-get"},
+        db_path=None,
+    )
+
+
+@patch(
+    "redis_benchmarks_specification.__self_contained_coordinator__"
+    ".topdown_profiler.collect_topdown"
+)
+def test_topdown_collector_failure(mock_collect):
+    """TopdownCollector should return None on collection failure."""
+    mock_collect.return_value = None
+
+    collector = TopdownCollector(
+        process_name="redis-server",
+        duration_seconds=10,
+        level=2,
+    )
+    collector.start()
+    run_id = collector.wait_for_completion(timeout=5)
+
+    assert run_id is None
+
+
+def test_topdown_collector_not_started():
+    """Calling wait without start should return None."""
+    collector = TopdownCollector(
+        process_name="redis-server",
+        duration_seconds=10,
+        level=2,
+    )
+    run_id = collector.wait_for_completion(timeout=1)
+    assert run_id is None
+
+
+@patch(
+    "redis_benchmarks_specification.__self_contained_coordinator__"
+    ".topdown_profiler.collect_topdown"
+)
+def test_topdown_collector_exception(mock_collect):
+    """TopdownCollector should handle exceptions gracefully."""
+    mock_collect.side_effect = RuntimeError("unexpected error")
+
+    collector = TopdownCollector(
+        process_name="redis-server",
+        duration_seconds=10,
+        level=2,
+    )
+    collector.start()
+    run_id = collector.wait_for_completion(timeout=5)
+
+    assert run_id is None


### PR DESCRIPTION
## Summary
- Add `topdown_profiler.py` module to the self-contained coordinator that automatically collects Intel Top-Down Microarchitecture Analysis (TMA) data alongside each benchmark run on x86 runners
- Detection at coordinator startup: checks `topdown` CLI in PATH, verifies x86_64 arch, warns on perf_event_paranoid restrictions
- Uses the same 3-tier label hierarchy as parca-agent (startup + build + test labels) so TMA data is queryable by git_branch, test_name, topology, etc.
- Collection runs in a background thread (`TopdownCollector`) parallel to the benchmark, level 2 TMA for up to 30 seconds per test
- Bumps version to 0.2.70

## Test plan
- [x] 26 unit tests added in `test_topdown_profiler.py` — all passing
  - `check_topdown_available`: arch rejection, PATH detection, version check, timeout
  - `check_perf_event_paranoid`: root, allowed, restricted, missing file
  - `build_topdown_labels`: empty, basic, None skip, sanitization, int coercion
  - `collect_topdown`: success, failure, timeout, custom db_path, multi-label
  - `TopdownCollector`: success, failure, not-started, exception handling
- [ ] CI passes on Python 3.10/3.11/3.12
- [ ] Verify on x86 runner with topdown-profiler installed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new subprocess/thread-based profiling path in the self-contained coordinator that runs during benchmarks; failures/timeouts or environment/permissions issues (e.g., `perf_event_paranoid`) could affect run stability and timing.
> 
> **Overview**
> Adds **topdown-profiler integration** to the self-contained coordinator to optionally collect Intel Top-Down Microarchitecture Analysis (TMA) data during each benchmark run when the `topdown` CLI is available on x86_64.
> 
> At coordinator startup it detects `topdown` and warns when `perf_event_paranoid` is restrictive; per test/topology it builds parca-compatible labels, starts a background `TopdownCollector` for up to 30s (bounded by `--test-time` when present), waits for completion after the benchmark, and performs best-effort cleanup on failures.
> 
> Introduces new module `topdown_profiler.py` (availability checks, label args, collection runner, threaded collector) with unit tests, and bumps package version `0.2.72` → `0.2.73`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e0c5f12e4c4074bc167ddd0e7b237a382f9c18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->