### PR TITLE
Fix --target-platform for branch-based triggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.2.74"
+version = "0.2.75"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -970,6 +970,8 @@ def generate_benchmark_stream_request(
     result = True
     if b"platform" in testDetails:
         build_stream_fields["platform"] = testDetails[b"platform"]
+    if b"target_platform" in testDetails:
+        build_stream_fields["target_platform"] = testDetails[b"target_platform"]
     return build_stream_fields, result
 
 

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -487,6 +487,9 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                 commit_dict["build_artifacts"] = args.build_artifacts
             if args.build_command != "":
                 commit_dict["build_command"] = args.build_command
+            if args.target_platform is not None:
+                commit_dict["target_platform"] = args.target_platform
+                logging.info(f"Targeting specific runner: {args.target_platform}")
             if args.deployment_name_regexp != ".*":
                 commit_dict["deployment_name_regexp"] = args.deployment_name_regexp
             if args.command_regex != ".*":


### PR DESCRIPTION
## Summary
- Fix `--target-platform` not working with `--use-branch` triggers
- The field was only added in the dockerhub path; branch triggers use `request_build_from_commit_info` which goes through the builder
- Add `target_platform` to `commit_dict` in the branch trigger path
- Forward `target_platform` from builder `testDetails` to runner stream entry (same pattern as existing `platform` field)
- Bumps version to 0.2.75

## Test plan
- [x] 34 existing tests pass
- [ ] CI passes
- [ ] Manual test: trigger with `--target-platform` and `--use-branch`, verify only the targeted runner picks up work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how build requests are tagged and routed through Redis streams, which could affect runner selection and scheduling; changes are small and additive (new field only).
> 
> **Overview**
> Fixes branch-based triggers so `--target-platform` is included in the commit/build request payload and forwarded into the benchmark stream entry, matching the existing `platform` propagation.
> 
> Bumps the package version from `0.2.74` to `0.2.75`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194c62cdd63b56aa8b16a815ebe0bf8ee658f81b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->