### PR TITLE
Add listpack integer set benchmarks (SISMEMBER + SADD)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.2.75"
+version = "0.2.76"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-mixed-elements-listpack-sadd-integer.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-mixed-elements-listpack-sadd-integer.yml
@@ -1,0 +1,54 @@
+version: 0.4
+name: memtier_benchmark-1key-set-100-mixed-elements-listpack-sadd-integer
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SET key. The SET
+  contains 100 mixed elements (50 integers + 50 strings) in listpack encoding, and
+  we issue SADD with integer values that are already members (constant set size).
+  This exercises the lpFind integer comparison path during SADD duplicate check.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  resources:
+    requests:
+      memory: 1g
+  init_commands:
+  - '"SADD" "set:mixed100" "1001" "1002" "1003" "1004" "1005" "1006" "1007" "1008"
+    "1009" "1010" "1011" "1012" "1013" "1014" "1015" "1016" "1017" "1018" "1019"
+    "1020" "1021" "1022" "1023" "1024" "1025" "1026" "1027" "1028" "1029" "1030"
+    "1031" "1032" "1033" "1034" "1035" "1036" "1037" "1038" "1039" "1040" "1041"
+    "1042" "1043" "1044" "1045" "1046" "1047" "1048" "1049" "1050"
+    "abcdefghij" "bcdefghijk" "cdefghijkl" "defghijklm" "efghijklmn"
+    "fghijklmno" "ghijklmnop" "hijklmnopq" "ijklmnopqr" "jklmnopqrs"
+    "klmnopqrst" "lmnopqrstu" "mnopqrstuv" "nopqrstuvw" "opqrstuvwx"
+    "pqrstuvwxy" "qrstuvwxyz" "rstuvwxyza" "stuvwxyzab" "tuvwxyzabc"
+    "uvwxyzabcd" "vwxyzabcde" "wxyzabcdef" "xyzabcdefg" "yzabcdefgh"
+    "zabcdefghi" "aabbccddee" "bbccddeeff" "ccddeeffgg" "ddeeffgghh"
+    "eeffgghhii" "ffgghhiijj" "gghhiijjkk" "hhiijjkkll" "iijjkkllmm"
+    "jjkkllmmnn" "kkllmmnnoo" "llmmnnoopq" "mmnnooppqr" "nnooppqqrs"
+    "ooppqqrrss" "ppqqrrsstt" "qqrrssttuv" "rrssttuuvw" "ssttuuvvwx"
+    "ttuuvvwwxy" "uuvvwwxxyz" "vvwwxxyyzz" "wwxxyyzzzz" "xxyyzzzaaa"'
+  dataset_name: 1key-set-100-mixed-elements-listpack
+  dataset_description: This dataset contains 1 set key with 100 mixed elements (50
+    integers + 50 strings) in listpack encoding. The mix of types forces listpack
+    encoding (not intset).
+tested-groups:
+- set
+tested-commands:
+- sadd
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="SADD set:mixed100 __key__" --key-minimum 1001 --key-maximum
+    1050 --key-prefix "" --hide-histogram --test-time 180
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 30

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-mixed-elements-listpack-sismember-integer.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-mixed-elements-listpack-sismember-integer.yml
@@ -1,0 +1,54 @@
+version: 0.4
+name: memtier_benchmark-1key-set-100-mixed-elements-listpack-sismember-integer
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SET key. The SET
+  contains 100 mixed elements (50 integers + 50 strings) in listpack encoding, and
+  we query it using SISMEMBER looking up an integer member. This exercises the
+  lpFind integer comparison path in listpack-encoded sets.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  resources:
+    requests:
+      memory: 1g
+  init_commands:
+  - '"SADD" "set:mixed100" "1001" "1002" "1003" "1004" "1005" "1006" "1007" "1008"
+    "1009" "1010" "1011" "1012" "1013" "1014" "1015" "1016" "1017" "1018" "1019"
+    "1020" "1021" "1022" "1023" "1024" "1025" "1026" "1027" "1028" "1029" "1030"
+    "1031" "1032" "1033" "1034" "1035" "1036" "1037" "1038" "1039" "1040" "1041"
+    "1042" "1043" "1044" "1045" "1046" "1047" "1048" "1049" "1050"
+    "abcdefghij" "bcdefghijk" "cdefghijkl" "defghijklm" "efghijklmn"
+    "fghijklmno" "ghijklmnop" "hijklmnopq" "ijklmnopqr" "jklmnopqrs"
+    "klmnopqrst" "lmnopqrstu" "mnopqrstuv" "nopqrstuvw" "opqrstuvwx"
+    "pqrstuvwxy" "qrstuvwxyz" "rstuvwxyza" "stuvwxyzab" "tuvwxyzabc"
+    "uvwxyzabcd" "vwxyzabcde" "wxyzabcdef" "xyzabcdefg" "yzabcdefgh"
+    "zabcdefghi" "aabbccddee" "bbccddeeff" "ccddeeffgg" "ddeeffgghh"
+    "eeffgghhii" "ffgghhiijj" "gghhiijjkk" "hhiijjkkll" "iijjkkllmm"
+    "jjkkllmmnn" "kkllmmnnoo" "llmmnnoopq" "mmnnooppqr" "nnooppqqrs"
+    "ooppqqrrss" "ppqqrrsstt" "qqrrssttuv" "rrssttuuvw" "ssttuuvvwx"
+    "ttuuvvwwxy" "uuvvwwxxyz" "vvwwxxyyzz" "wwxxyyzzzz" "xxyyzzzaaa"'
+  dataset_name: 1key-set-100-mixed-elements-listpack
+  dataset_description: This dataset contains 1 set key with 100 mixed elements (50
+    integers + 50 strings) in listpack encoding. The mix of types forces listpack
+    encoding (not intset).
+tested-groups:
+- set
+tested-commands:
+- sismember
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="SISMEMBER set:mixed100 1025" --hide-histogram --test-time
+    180
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 30


### PR DESCRIPTION
## Summary
- Add two new test specs for listpack-encoded sets with mixed integer+string members
- These exercise the `lpFind` integer comparison path — currently no benchmark covers this

## New tests

1. **`memtier_benchmark-1key-set-100-mixed-elements-listpack-sismember-integer`** — SISMEMBER lookup of integer `1025` in a 100-element mixed set (50 ints + 50 strings)
2. **`memtier_benchmark-1key-set-100-mixed-elements-listpack-sadd-integer`** — SADD with existing integer members `1001-1050` (constant size, exercises duplicate-check path)

The mix of integer + string members forces listpack encoding (not intset), targeting the integer comparison fast path specifically.

## Version
Bumped to 0.2.76.

## Test plan
- [x] Verified encoding is `listpack` with redis-cli `OBJECT ENCODING`
- [x] YAML structure matches existing test spec format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new benchmark YAML specs and bumps the package version, with no changes to runtime code paths. Main risk is only misconfiguration causing benchmark scheduling/runtime failures.
> 
> **Overview**
> Adds two new memtier benchmark test suites targeting listpack-encoded sets with mixed integer+string members: one for `SISMEMBER` integer lookups and one for `SADD` duplicate-checking with existing integer members.
> 
> Bumps the project version in `pyproject.toml` from `0.2.75` to `0.2.76`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97893f7d1c7d1a4b4095b03d3f4fcc67c46868b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->