### PR TITLE
feat: explicit-only runner mode + stream replay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.2.88"
+version = "0.2.89"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -23,6 +23,7 @@ CLI_TOOL_STATS = "stats"
 CLI_TOOL_TRIGGER = "trigger"
 CLI_TOOL_DOCKERHUB = "dockerhub"
 CLI_TOOL_ADMIN = "admin"
+CLI_TOOL_REPLAY = "replay"
 PERFORMANCE_GH_TOKEN = os.getenv("PERFORMANCE_GH_TOKEN", None)
 
 
@@ -118,7 +119,13 @@ def spec_cli_args(parser):
         default=CLI_TOOL_TRIGGER,
         help="subtool to use. One of '{}' ".format(
             ",".join(
-                [CLI_TOOL_STATS, CLI_TOOL_TRIGGER, CLI_TOOL_DOCKERHUB, CLI_TOOL_ADMIN]
+                [
+                    CLI_TOOL_STATS,
+                    CLI_TOOL_TRIGGER,
+                    CLI_TOOL_DOCKERHUB,
+                    CLI_TOOL_ADMIN,
+                    CLI_TOOL_REPLAY,
+                ]
             )
         ),
     )
@@ -269,5 +276,14 @@ def spec_cli_args(parser):
         type=str,
         default="",
         help="Builder consumer group name for skip-builders/reset-builders commands (e.g. builders-cg-amd64).",
+    )
+    # Replay tool arguments
+    parser.add_argument(
+        "--replay-stream-id",
+        type=str,
+        default=None,
+        help="Benchmark stream ID to replay (e.g. '1737123456789-0'). "
+        "The runner will re-run the already-built artifact from this "
+        "stream entry without triggering a new build. Use with --tool replay.",
     )
     return parser

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -63,6 +63,130 @@ logging.basicConfig(
 )
 
 
+def replay_stream_cli_command_logic(args, project_name, project_version):
+    """Read an existing benchmark stream entry and re-add it to the stream,
+    optionally overriding target_platform, tests_regexp, etc.
+    This allows re-running a benchmark without rebuilding from source."""
+    logging.info(
+        "Using: {project_name} {project_version}".format(
+            project_name=project_name, project_version=project_version
+        )
+    )
+    stream_id = args.replay_stream_id
+    if stream_id is None:
+        logging.error("--replay-stream-id is required for the replay tool")
+        sys.exit(1)
+
+    arch = args.arch
+    logging.info(
+        "Checking connection to redis with user: {}, host: {}, port: {}".format(
+            args.redis_user,
+            args.redis_host,
+            args.redis_port,
+        )
+    )
+    conn = redis.StrictRedis(
+        host=args.redis_host,
+        port=args.redis_port,
+        password=args.redis_pass,
+        username=args.redis_user,
+        decode_responses=False,
+    )
+    conn.ping()
+
+    # Determine which stream to read from
+    arch_specific_stream = get_arch_specific_stream_name(arch)
+    logging.info(
+        "Reading stream entry {} from {}".format(stream_id, arch_specific_stream)
+    )
+
+    # Read the existing entry
+    entries = conn.xrange(arch_specific_stream, min=stream_id, max=stream_id)
+    if not entries:
+        logging.error(
+            "Stream ID {} not found in {}. "
+            "Check the arch (--arch) or the stream ID.".format(
+                stream_id, arch_specific_stream
+            )
+        )
+        sys.exit(1)
+
+    _, orig_fields = entries[0]
+    logging.info("Found stream entry with {} fields".format(len(orig_fields)))
+
+    # Validate the entry has required fields
+    if b"run_image" not in orig_fields:
+        logging.error(
+            "Stream entry {} is missing run_image field. "
+            "It may not be a valid benchmark stream entry.".format(stream_id)
+        )
+        sys.exit(1)
+
+    # Check artifact keys still exist
+    build_artifacts_str = orig_fields.get(b"build_artifacts", b"redis-server").decode()
+    build_artifacts = build_artifacts_str.split(",")
+    for artifact in build_artifacts:
+        artifact_key = orig_fields.get(artifact.encode())
+        if artifact_key is not None:
+            if not conn.exists(artifact_key):
+                logging.error(
+                    "Artifact key {} for '{}' has expired or does not exist. "
+                    "You may need to re-build from source (artifacts expire after 7 days).".format(
+                        artifact_key.decode(), artifact
+                    )
+                )
+                sys.exit(1)
+            else:
+                logging.info(
+                    "Artifact key {} for '{}' exists".format(
+                        artifact_key.decode(), artifact
+                    )
+                )
+
+    # Build the new stream fields dict from original fields
+    new_fields = {}
+    for k, v in orig_fields.items():
+        k_str = k.decode() if isinstance(k, bytes) else k
+        v_str = v.decode() if isinstance(v, bytes) else v
+        new_fields[k_str] = v_str
+
+    # Apply metadata
+    new_fields["replayed_from"] = stream_id
+    new_fields["triggered_by"] = _get_caller_identity()
+
+    # Apply overrides
+    if args.target_platform is not None:
+        new_fields["target_platform"] = args.target_platform
+        logging.info("Overriding target_platform to: {}".format(args.target_platform))
+
+    if args.tests_regexp != ".*":
+        new_fields["tests_regexp"] = args.tests_regexp
+        logging.info("Overriding tests_regexp to: {}".format(args.tests_regexp))
+
+    if hasattr(args, "deployment_name_regexp") and args.deployment_name_regexp != ".*":
+        new_fields["deployment_name_regexp"] = args.deployment_name_regexp
+        logging.info(
+            "Overriding deployment_name_regexp to: {}".format(
+                args.deployment_name_regexp
+            )
+        )
+
+    if hasattr(args, "command_regex") and args.command_regex != ".*":
+        new_fields["command_regexp"] = args.command_regex
+        logging.info("Overriding command_regexp to: {}".format(args.command_regex))
+
+    # Write the new entry to the benchmark stream
+    new_stream_id = conn.xadd(arch_specific_stream, new_fields)
+    new_stream_id_str = (
+        new_stream_id.decode() if isinstance(new_stream_id, bytes) else new_stream_id
+    )
+    logging.info(
+        "Successfully replayed stream {} as new entry {}. "
+        "Arch stream: {}".format(stream_id, new_stream_id_str, arch_specific_stream)
+    )
+    print("Replayed. New stream ID: {}".format(new_stream_id_str))
+
+
 def trigger_tests_dockerhub_cli_command_logic(args, project_name, project_version):
     logging.info(
         "Using: {project_name} {project_version}".format(
@@ -183,6 +307,8 @@ def main():
         trigger_tests_dockerhub_cli_command_logic(args, project_name, project_version)
     if args.tool == "admin":
         admin_command_logic(args, project_name, project_version)
+    if args.tool == "replay":
+        replay_stream_cli_command_logic(args, project_name, project_version)
 
 
 def get_commits_by_branch(args, repo):

--- a/redis_benchmarks_specification/__self_contained_coordinator__/args.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/args.py
@@ -207,4 +207,13 @@ def create_self_contained_coordinator_args(project_name):
         action="store_true",
         help="Skip automatically clearing pending messages and resetting consumer group position on startup. By default, pending messages are cleared and consumer group is reset to latest position to skip old work and recover from crashes.",
     )
+    parser.add_argument(
+        "--explicit-only",
+        default=False,
+        action="store_true",
+        help="Explicit-only mode: only process stream entries that have a "
+        "target_platform field matching this runner's platform name. "
+        "Untargeted entries (no target_platform field) are skipped. "
+        "Useful for dedicated runners that should only run on-demand work.",
+    )
     return parser

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -189,6 +189,7 @@ def _start_heartbeat(conn, platform, arch, version, args):
                     "exclusive_hardware": str(
                         getattr(args, "exclusive_hardware", False)
                     ),
+                    "explicit_only": str(getattr(args, "explicit_only", False)),
                 }
                 conn.hset(key, mapping=fields)
                 conn.expire(key, HEARTBEAT_EXPIRE_SECS)
@@ -857,6 +858,14 @@ def main():
         args,
     )
 
+    explicit_only = args.explicit_only
+    if explicit_only:
+        logging.info(
+            "Explicit-only mode enabled: only processing streams with target_platform={}".format(
+                running_platform
+            )
+        )
+
     logging.info("Entering blocking read waiting for work.")
     if stream_id is None:
         stream_id = args.consumer_start_id
@@ -886,6 +895,7 @@ def main():
             priority_upper_limit,
             default_baseline_branch,
             default_metrics_str,
+            explicit_only=explicit_only,
         )
 
 
@@ -922,6 +932,7 @@ def self_contained_coordinator_blocking_read(
     default_metrics_str="ALL_STATS.Totals.Ops/sec",
     docker_keep_env=False,
     restore_build_artifacts_default=True,
+    explicit_only=False,
 ):
     num_process_streams = 0
     num_process_test_suites = 0
@@ -1006,6 +1017,7 @@ def self_contained_coordinator_blocking_read(
             docker_keep_env,
             restore_build_artifacts_default,
             args,
+            explicit_only=explicit_only,
         )
         num_process_streams = num_process_streams + 1
         num_process_test_suites = num_process_test_suites + total_test_suite_runs
@@ -1097,6 +1109,7 @@ def process_self_contained_coordinator_stream(
     restore_build_artifacts_default=True,
     args=None,
     redis_password="redis_coordinator_password_2024",
+    explicit_only=False,
 ):
     global _heartbeat_current_test
     stream_id = "n/a"
@@ -1295,7 +1308,14 @@ def process_self_contained_coordinator_stream(
                         )
                     )
 
-            if b"target_platform" in testDetails:
+            has_explicit_target = b"target_platform" in testDetails
+            if explicit_only and not has_explicit_target:
+                skip_test = True
+                logging.info(
+                    "explicit-only mode: skipping stream_id {} "
+                    "because it has no target_platform field".format(stream_id)
+                )
+            elif has_explicit_target:
                 target_platform = testDetails[b"target_platform"]
                 target_platform_str = (
                     target_platform.decode()
@@ -1309,6 +1329,17 @@ def process_self_contained_coordinator_stream(
                             stream_id, running_platform, target_platform_str
                         )
                     )
+
+            if b"replayed_from" in testDetails:
+                replayed_from = testDetails[b"replayed_from"]
+                replayed_from_str = (
+                    replayed_from.decode()
+                    if isinstance(replayed_from, bytes)
+                    else replayed_from
+                )
+                logging.info(
+                    "This is a replay of stream entry {}".format(replayed_from_str)
+                )
 
             if run_arch != arch:
                 skip_test = True

--- a/utils/tests/test_target_platform.py
+++ b/utils/tests/test_target_platform.py
@@ -138,3 +138,136 @@ def test_coordinator_handles_string_target_platform():
             skip_test = True
 
     assert skip_test is False
+
+
+# --- explicit-only mode tests ---
+
+
+def _should_skip(testDetails, running_platform, explicit_only=False):
+    """Replicate the coordinator's skip logic for testing."""
+    skip_test = False
+    has_explicit_target = b"target_platform" in testDetails
+    if explicit_only and not has_explicit_target:
+        skip_test = True
+    elif has_explicit_target:
+        target_platform = testDetails[b"target_platform"]
+        target_platform_str = (
+            target_platform.decode()
+            if isinstance(target_platform, bytes)
+            else target_platform
+        )
+        if running_platform != target_platform_str:
+            skip_test = True
+    return skip_test
+
+
+def test_explicit_only_skips_untargeted():
+    """In explicit-only mode, entries without target_platform are skipped."""
+    testDetails = {b"some_field": b"value"}
+    assert (
+        _should_skip(testDetails, "x86-aws-m7i.metal-24xl", explicit_only=True) is True
+    )
+
+
+def test_explicit_only_processes_matching_target():
+    """In explicit-only mode, entries with matching target_platform are processed."""
+    testDetails = {b"target_platform": b"x86-aws-m7i.metal-24xl-profiler"}
+    assert (
+        _should_skip(testDetails, "x86-aws-m7i.metal-24xl-profiler", explicit_only=True)
+        is False
+    )
+
+
+def test_explicit_only_skips_mismatched_target():
+    """In explicit-only mode, entries with a different target_platform are skipped."""
+    testDetails = {b"target_platform": b"arm-aws-m8g.metal-24xl"}
+    assert (
+        _should_skip(testDetails, "x86-aws-m7i.metal-24xl", explicit_only=True) is True
+    )
+
+
+def test_normal_mode_processes_untargeted():
+    """In normal mode, entries without target_platform are processed (backwards compat)."""
+    testDetails = {b"some_field": b"value"}
+    assert (
+        _should_skip(testDetails, "x86-aws-m7i.metal-24xl", explicit_only=False)
+        is False
+    )
+
+
+# --- CLI args tests for replay tool ---
+
+
+def test_cli_args_replay_stream_id_default():
+    """--replay-stream-id defaults to None."""
+    from redis_benchmarks_specification.__cli__.args import spec_cli_args
+
+    parser = argparse.ArgumentParser()
+    spec_cli_args(parser)
+    args = parser.parse_args([])
+    assert args.replay_stream_id is None
+
+
+def test_cli_args_replay_stream_id_set():
+    """--replay-stream-id accepts a stream ID."""
+    from redis_benchmarks_specification.__cli__.args import spec_cli_args
+
+    parser = argparse.ArgumentParser()
+    spec_cli_args(parser)
+    args = parser.parse_args(
+        ["--tool", "replay", "--replay-stream-id", "1776070055182-0"]
+    )
+    assert args.tool == "replay"
+    assert args.replay_stream_id == "1776070055182-0"
+
+
+def test_cli_args_replay_with_overrides():
+    """--tool replay accepts target-platform and tests-regexp overrides."""
+    from redis_benchmarks_specification.__cli__.args import spec_cli_args
+
+    parser = argparse.ArgumentParser()
+    spec_cli_args(parser)
+    args = parser.parse_args(
+        [
+            "--tool",
+            "replay",
+            "--replay-stream-id",
+            "1776070055182-0",
+            "--target-platform",
+            "x86-aws-m7i.metal-24xl-profiler",
+            "--tests-regexp",
+            "memtier_benchmark-1Mkeys.*expire",
+            "--arch",
+            "arm64",
+        ]
+    )
+    assert args.tool == "replay"
+    assert args.replay_stream_id == "1776070055182-0"
+    assert args.target_platform == "x86-aws-m7i.metal-24xl-profiler"
+    assert args.tests_regexp == "memtier_benchmark-1Mkeys.*expire"
+    assert args.arch == "arm64"
+
+
+# --- coordinator args tests for explicit-only ---
+
+
+def test_coordinator_args_explicit_only_default():
+    """--explicit-only defaults to False."""
+    from redis_benchmarks_specification.__self_contained_coordinator__.args import (
+        create_self_contained_coordinator_args,
+    )
+
+    parser = create_self_contained_coordinator_args("test")
+    args = parser.parse_args([])
+    assert args.explicit_only is False
+
+
+def test_coordinator_args_explicit_only_set():
+    """--explicit-only flag can be enabled."""
+    from redis_benchmarks_specification.__self_contained_coordinator__.args import (
+        create_self_contained_coordinator_args,
+    )
+
+    parser = create_self_contained_coordinator_args("test")
+    args = parser.parse_args(["--explicit-only"])
+    assert args.explicit_only is True


### PR DESCRIPTION
## Summary
- **`--explicit-only` runner flag**: when enabled, the coordinator only processes stream entries with a `target_platform` field matching this runner's platform name. Untargeted entries are ACK'd and skipped. Useful for dedicated runners (e.g. profiler runner) that should only run on-demand work.
- **`--tool replay --replay-stream-id <id>`**: reads an existing benchmark stream entry and re-adds it to the stream with the same artifact keys, optionally overriding `--target-platform`, `--tests-regexp`, and `--deployment-name-regexp`. Skips the build phase entirely — the runner picks up the replayed entry and runs immediately. Validates artifact keys still exist (7-day TTL) before replaying.
- Version bump to 0.2.89

## Test plan
- [x] 17 unit tests pass (9 new + 8 existing)
- [x] Full test suite: 134 passed, 5 pre-existing failures (docker/redis infra-dependent)
- [x] black --check passes
- [ ] CI tox workflow validates on Python 3.10/3.11/3.12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new execution paths that alter which benchmark stream entries runners will process and introduces a replay mechanism that re-enqueues existing work based on stored artifacts; misconfiguration could lead to skipped runs or unexpected reruns.
> 
> **Overview**
> Adds a new CLI `replay` tool (`--tool replay --replay-stream-id`) that reads an existing benchmark stream entry from Redis, validates referenced artifact keys still exist, and re-enqueues it with metadata (`replayed_from`, `triggered_by`) plus optional overrides (e.g. `target_platform`, `tests_regexp`).
> 
> Introduces an `--explicit-only` flag for the self-contained coordinator so runners can *only* process entries explicitly targeted via `target_platform`, while still ACK’ing and skipping untargeted entries; runner heartbeat now reports this mode, and logs annotate replayed entries. Also bumps package version to `0.2.89` and expands unit tests to cover replay args and explicit-only skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b41a9b60e6c5a60308b5f8d9f4d53c8fa2a892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->