### PR TITLE
Fix tested-groups: use canonical 'sorted-set' instead of 'zset'

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members.yml
@@ -53,7 +53,7 @@ dbconfig:
     This dataset contains 1 million sorted set keys, each with 128 members
     (listpack encoded, at the zset-max-listpack-entries=128 threshold).
 tested-groups:
-- zset
+- sorted-set
 tested-commands:
 - zadd
 - zmscore


### PR DESCRIPTION
The CI stats validator cross-references tested-groups against the command group names in commands.json. Redis maps ZMSCORE to the 'sorted-set' group, not 'zset'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line metadata change in a benchmark YAML to align `tested-groups` with the canonical command group name used by CI validation.
> 
> **Overview**
> Updates the `memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members.yml` benchmark spec to classify its `tested-groups` as `sorted-set` instead of `zset`, aligning the suite’s metadata with Redis command-group naming (e.g., `ZMSCORE`) for CI stats validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dfa316dd440c891dce5f5f4871958c3c94eaac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->