### PR TITLE
Add cluster topology support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.2.89"
+version = "0.3.0"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__common__/spec.py
+++ b/redis_benchmarks_specification/__common__/spec.py
@@ -59,6 +59,12 @@ def extract_replica_count(topologies_map, topology_spec_name):
     return redis_topology.get("replicas", 0)
 
 
+def extract_primary_count(topologies_map, topology_spec_name):
+    topology_spec = topologies_map[topology_spec_name]
+    redis_topology = topology_spec.get("redis_topology", {})
+    return redis_topology.get("primaries", 1)
+
+
 def extract_client_cpu_limit(benchmark_config):
     # Handle both clientconfig (single) and clientconfigs (multiple) formats
     if "clientconfigs" in benchmark_config:

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -203,7 +203,6 @@ def start_redis_container(
         detach=True,
         cpuset_cpus=db_cpuset_cpus,
         pid_mode="host",
-        publish_all_ports=True,
     )
     time.sleep(5)
     redis_containers.append(container)

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -220,7 +220,6 @@ def spin_docker_cluster_redis(
     redis_proc_start_port,
     run_image,
     temporary_dir,
-    start_redis_container_fn=None,
     mnt_point="/mnt/redis/",
     redis_arguments="",
     password=None,
@@ -231,8 +230,6 @@ def spin_docker_cluster_redis(
     Returns:
         tuple: (cluster_conns, current_cpu_pos)
     """
-    if start_redis_container_fn is None:
-        start_redis_container_fn = start_redis_container
     executable = "{}{}-server".format(mnt_point, server_name)
     per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
     cluster_conns = []
@@ -269,7 +266,7 @@ def spin_docker_cluster_redis(
                 i + 1, primary_count, node_port, db_cpuset_cpus
             )
         )
-        start_redis_container_fn(
+        start_redis_container(
             command_str,
             db_cpuset_cpus,
             docker_client,
@@ -344,7 +341,6 @@ def spin_up_redis_replicas(
     redis_configuration_parameters,
     redis_arguments,
     password,
-    start_redis_container_fn,
     replication_sync_timeout=600,
     server_name="redis",
 ):
@@ -391,7 +387,7 @@ def spin_up_redis_replicas(
                 i, replica_count, replica_port, db_cpuset_cpus
             )
         )
-        start_redis_container_fn(
+        start_redis_container(
             command_str,
             db_cpuset_cpus,
             docker_client,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -167,7 +167,7 @@ def generate_cluster_redis_server_args(
     return command
 
 
-def _default_start_redis_container(
+def start_redis_container(
     command_str,
     db_cpuset_cpus,
     docker_client,
@@ -175,22 +175,35 @@ def _default_start_redis_container(
     redis_containers,
     run_image,
     temporary_dir,
+    auto_remove=False,
 ):
-    """Default container start function used when no custom one is provided."""
+    """Start a Redis container with the given configuration.
+
+    Used for standalone, cluster, and replica container startup.
+    """
+    logging.info(
+        "Running redis-server on docker image {} (cpuset={}) with the following args: {}".format(
+            run_image, db_cpuset_cpus, command_str
+        )
+    )
     volumes = {}
+    working_dir = "/"
     if mnt_point:
         volumes = {temporary_dir: {"bind": mnt_point, "mode": "rw"}}
+        logging.info(f"setting volume as follow: {volumes}. working_dir={mnt_point}")
+        working_dir = mnt_point
     container = docker_client.containers.run(
         image=run_image,
         volumes=volumes,
-        auto_remove=True,
+        auto_remove=auto_remove,
         privileged=True,
-        working_dir=mnt_point if mnt_point else "/",
+        working_dir=working_dir,
         command=command_str,
         network_mode="host",
         detach=True,
         cpuset_cpus=db_cpuset_cpus,
         pid_mode="host",
+        publish_all_ports=True,
     )
     time.sleep(5)
     redis_containers.append(container)
@@ -219,7 +232,7 @@ def spin_docker_cluster_redis(
         tuple: (cluster_conns, current_cpu_pos)
     """
     if start_redis_container_fn is None:
-        start_redis_container_fn = _default_start_redis_container
+        start_redis_container_fn = start_redis_container
     executable = "{}{}-server".format(mnt_point, server_name)
     per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
     cluster_conns = []

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -274,6 +274,7 @@ def spin_docker_cluster_redis(
             redis_containers,
             run_image,
             temporary_dir,
+            auto_remove=True,
         )
         r = redis.StrictRedis(port=node_port, password=password)
         r.ping()
@@ -395,6 +396,7 @@ def spin_up_redis_replicas(
             redis_containers,
             run_image,
             temporary_dir,
+            auto_remove=True,
         )
         replica_r = redis.StrictRedis(port=replica_port, password=password)
         replica_r.ping()

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -142,6 +142,176 @@ def spin_docker_standalone_redis(
     return current_cpu_pos
 
 
+def generate_cluster_redis_server_args(
+    binary,
+    port,
+    dbdir,
+    configuration_parameters=None,
+    redis_arguments="",
+    password=None,
+):
+    """Generate redis-server args with cluster mode enabled."""
+    command = generate_standalone_redis_server_args(
+        binary, port, dbdir, configuration_parameters, redis_arguments, password
+    )
+    command.extend(
+        [
+            "--cluster-enabled",
+            "yes",
+            "--cluster-config-file",
+            "nodes-{}.conf".format(port),
+            "--cluster-node-timeout",
+            "5000",
+        ]
+    )
+    return command
+
+
+def _default_start_redis_container(
+    command_str, db_cpuset_cpus, docker_client, mnt_point, redis_containers,
+    run_image, temporary_dir,
+):
+    """Default container start function used when no custom one is provided."""
+    volumes = {}
+    if mnt_point:
+        volumes = {temporary_dir: {"bind": mnt_point, "mode": "rw"}}
+    container = docker_client.containers.run(
+        image=run_image,
+        volumes=volumes,
+        auto_remove=True,
+        privileged=True,
+        working_dir=mnt_point if mnt_point else "/",
+        command=command_str,
+        network_mode="host",
+        detach=True,
+        cpuset_cpus=db_cpuset_cpus,
+        pid_mode="host",
+    )
+    time.sleep(5)
+    redis_containers.append(container)
+    return container
+
+
+def spin_docker_cluster_redis(
+    primary_count,
+    ceil_db_cpu_limit,
+    current_cpu_pos,
+    docker_client,
+    redis_configuration_parameters,
+    redis_containers,
+    redis_proc_start_port,
+    run_image,
+    temporary_dir,
+    start_redis_container_fn=None,
+    mnt_point="/mnt/redis/",
+    redis_arguments="",
+    password=None,
+):
+    """Start N Redis instances in cluster mode and form a cluster.
+
+    Returns:
+        tuple: (cluster_conns, cluster_pids, current_cpu_pos)
+    """
+    if start_redis_container_fn is None:
+        start_redis_container_fn = _default_start_redis_container
+    per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
+    cluster_conns = []
+    cluster_pids = []
+
+    # Start each cluster node
+    for i in range(primary_count):
+        node_port = redis_proc_start_port + i
+        node_redis_arguments = redis_arguments
+        # Per-node filenames to avoid conflicts
+        if i > 0:
+            node_redis_arguments = (
+                "{} --dbfilename cluster-node-{}-dump.rdb"
+                " --appendfilename cluster-node-{}-appendonly.aof"
+                " --logfile cluster-node-{}-redis.log"
+            ).format(redis_arguments, node_port, node_port, node_port).strip()
+        command = generate_cluster_redis_server_args(
+            "{}redis-server".format(mnt_point) if mnt_point else "redis-server",
+            node_port,
+            mnt_point if mnt_point else "",
+            redis_configuration_parameters,
+            node_redis_arguments,
+            password,
+        )
+        command_str = " ".join(command)
+        db_cpuset_cpus, current_cpu_pos = generate_cpuset_cpus(
+            per_node_cpu, current_cpu_pos
+        )
+        logging.info(
+            "Starting cluster node {}/{} on port {} (cpuset={})".format(
+                i + 1, primary_count, node_port, db_cpuset_cpus
+            )
+        )
+        start_redis_container_fn(
+            command_str,
+            db_cpuset_cpus,
+            docker_client,
+            mnt_point,
+            redis_containers,
+            run_image,
+            temporary_dir,
+        )
+        r = redis.StrictRedis(port=node_port, password=password)
+        r.ping()
+        cluster_conns.append(r)
+        node_info = r.info()
+        node_pid = node_info.get("process_id")
+        if node_pid is not None:
+            cluster_pids.append(node_pid)
+
+    # CLUSTER MEET: make all nodes aware of each other via node 0
+    first = cluster_conns[0]
+    for i in range(1, primary_count):
+        node_port = redis_proc_start_port + i
+        first.execute_command("CLUSTER", "MEET", "127.0.0.1", str(node_port))
+        logging.info("CLUSTER MEET 127.0.0.1 {}".format(node_port))
+
+    # Distribute 16384 slots evenly across primaries
+    slots_per_node = 16384 // primary_count
+    for i, conn in enumerate(cluster_conns):
+        start_slot = i * slots_per_node
+        end_slot = ((i + 1) * slots_per_node - 1) if i < primary_count - 1 else 16383
+        # Batch ADDSLOTS in groups of 500 to avoid arg-length limits
+        batch_size = 500
+        slot = start_slot
+        while slot <= end_slot:
+            batch_end = min(slot + batch_size - 1, end_slot)
+            slot_args = [str(s) for s in range(slot, batch_end + 1)]
+            conn.execute_command("CLUSTER", "ADDSLOTS", *slot_args)
+            slot = batch_end + 1
+        logging.info(
+            "Assigned slots [{}-{}] to node {} (port {})".format(
+                start_slot, end_slot, i, redis_proc_start_port + i
+            )
+        )
+
+    # Wait for cluster_state:ok
+    timeout = 60
+    poll_interval = 0.5
+    start = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= timeout:
+            raise RuntimeError(
+                "Cluster did not reach 'ok' state within {}s".format(timeout)
+            )
+        cluster_info = first.execute_command("CLUSTER", "INFO")
+        if isinstance(cluster_info, bytes):
+            cluster_info = cluster_info.decode()
+        if "cluster_state:ok" in cluster_info:
+            logging.info(
+                "Cluster is ready (cluster_state:ok) after {:.1f}s".format(elapsed)
+            )
+            break
+        time.sleep(poll_interval)
+
+    return cluster_conns, cluster_pids, current_cpu_pos
+
+
 def spin_up_redis_replicas(
     replica_count,
     primary_port,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -216,14 +216,13 @@ def spin_docker_cluster_redis(
     """Start N Redis instances in cluster mode and form a cluster.
 
     Returns:
-        tuple: (cluster_conns, cluster_pids, current_cpu_pos)
+        tuple: (cluster_conns, current_cpu_pos)
     """
     if start_redis_container_fn is None:
         start_redis_container_fn = _default_start_redis_container
     executable = "{}{}-server".format(mnt_point, server_name)
     per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
     cluster_conns = []
-    cluster_pids = []
 
     # Start each cluster node
     for i in range(primary_count):
@@ -269,10 +268,6 @@ def spin_docker_cluster_redis(
         r = redis.StrictRedis(port=node_port, password=password)
         r.ping()
         cluster_conns.append(r)
-        node_info = r.info()
-        node_pid = node_info.get("process_id")
-        if node_pid is not None:
-            cluster_pids.append(node_pid)
 
     # CLUSTER MEET: make all nodes aware of each other via node 0
     first = cluster_conns[0]
@@ -320,7 +315,7 @@ def spin_docker_cluster_redis(
             break
         time.sleep(poll_interval)
 
-    return cluster_conns, cluster_pids, current_cpu_pos
+    return cluster_conns, current_cpu_pos
 
 
 def spin_up_redis_replicas(
@@ -343,14 +338,13 @@ def spin_up_redis_replicas(
     """Start replica Redis containers and configure replication to the primary.
 
     Returns:
-        tuple: (replica_conns, replica_pids, current_cpu_pos, sync_times_seconds)
+        tuple: (replica_conns, current_cpu_pos, sync_times_seconds)
 
     sync_times_seconds is a list of float seconds, one per replica, measuring
     the wall-clock time from container start to master_link_status=up.
     Use this as a benchmark metric for full-sync performance testing.
     """
     replica_conns = []
-    replica_pids = []
     sync_times_seconds = []
     for i in range(1, replica_count + 1):
         replica_port = primary_port + i
@@ -427,9 +421,5 @@ def spin_up_redis_replicas(
             )
             sync_seconds = float(replication_sync_timeout)
         sync_times_seconds.append(sync_seconds)
-        replica_info = replica_r.info()
-        replica_pid = replica_info.get("process_id")
-        if replica_pid is not None:
-            replica_pids.append(replica_pid)
         replica_conns.append(replica_r)
-    return replica_conns, replica_pids, current_cpu_pos, sync_times_seconds
+    return replica_conns, current_cpu_pos, sync_times_seconds

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -211,6 +211,7 @@ def spin_docker_cluster_redis(
     mnt_point="/mnt/redis/",
     redis_arguments="",
     password=None,
+    server_name="redis",
 ):
     """Start N Redis instances in cluster mode and form a cluster.
 
@@ -219,6 +220,7 @@ def spin_docker_cluster_redis(
     """
     if start_redis_container_fn is None:
         start_redis_container_fn = _default_start_redis_container
+    executable = "{}{}-server".format(mnt_point, server_name)
     per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
     cluster_conns = []
     cluster_pids = []
@@ -239,7 +241,7 @@ def spin_docker_cluster_redis(
                 .strip()
             )
         command = generate_cluster_redis_server_args(
-            "{}redis-server".format(mnt_point) if mnt_point else "redis-server",
+            executable,
             node_port,
             mnt_point if mnt_point else "",
             redis_configuration_parameters,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -187,17 +187,15 @@ def start_redis_container(
         )
     )
     volumes = {}
-    working_dir = "/"
-    if mnt_point:
+    if mnt_point != "":
         volumes = {temporary_dir: {"bind": mnt_point, "mode": "rw"}}
         logging.info(f"setting volume as follow: {volumes}. working_dir={mnt_point}")
-        working_dir = mnt_point
     container = docker_client.containers.run(
         image=run_image,
         volumes=volumes,
         auto_remove=auto_remove,
         privileged=True,
-        working_dir=working_dir,
+        working_dir=mnt_point,
         command=command_str,
         network_mode="host",
         detach=True,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -168,8 +168,13 @@ def generate_cluster_redis_server_args(
 
 
 def _default_start_redis_container(
-    command_str, db_cpuset_cpus, docker_client, mnt_point, redis_containers,
-    run_image, temporary_dir,
+    command_str,
+    db_cpuset_cpus,
+    docker_client,
+    mnt_point,
+    redis_containers,
+    run_image,
+    temporary_dir,
 ):
     """Default container start function used when no custom one is provided."""
     volumes = {}
@@ -225,10 +230,14 @@ def spin_docker_cluster_redis(
         # Per-node filenames to avoid conflicts
         if i > 0:
             node_redis_arguments = (
-                "{} --dbfilename cluster-node-{}-dump.rdb"
-                " --appendfilename cluster-node-{}-appendonly.aof"
-                " --logfile cluster-node-{}-redis.log"
-            ).format(redis_arguments, node_port, node_port, node_port).strip()
+                (
+                    "{} --dbfilename cluster-node-{}-dump.rdb"
+                    " --appendfilename cluster-node-{}-appendonly.aof"
+                    " --logfile cluster-node-{}-redis.log"
+                )
+                .format(redis_arguments, node_port, node_port, node_port)
+                .strip()
+            )
         command = generate_cluster_redis_server_args(
             "{}redis-server".format(mnt_point) if mnt_point else "redis-server",
             node_port,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/prepopulation.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/prepopulation.py
@@ -24,6 +24,7 @@ def data_prepopulation_step(
     temporary_dir,
     test_name,
     redis_password,
+    oss_cluster_api_enabled=False,
 ):
     # setup the benchmark
     (
@@ -53,7 +54,7 @@ def data_prepopulation_step(
             port,
             "localhost",
             local_benchmark_output_filename,
-            False,
+            oss_cluster_api_enabled,
             redis_password,
         )
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -489,7 +489,7 @@ def process_self_contained_coordinator_stream(
                                     redis_proc_start_port,
                                     "localhost",
                                     local_benchmark_output_filename,
-                                    benchmark_tool_workdir,
+                                    setup_type == "oss-cluster",
                                     redis_password,
                                 )
                             elif "vector_db_benchmark" in benchmark_tool:

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -72,7 +72,7 @@ from redis_benchmarks_specification.__self_contained_coordinator__.cpuset import
 from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     spin_docker_standalone_redis,
     spin_docker_cluster_redis,
-    _default_start_redis_container,
+    start_redis_container,
     teardown_containers,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.prepopulation import (
@@ -384,7 +384,7 @@ def process_self_contained_coordinator_stream(
                                     redis_proc_start_port,
                                     run_image,
                                     temporary_dir,
-                                    _default_start_redis_container,
+                                    start_redis_container,
                                     mnt_point="/mnt/redis/",
                                     password=redis_password,
                                 )

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -72,7 +72,6 @@ from redis_benchmarks_specification.__self_contained_coordinator__.cpuset import
 from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     spin_docker_standalone_redis,
     spin_docker_cluster_redis,
-    start_redis_container,
     teardown_containers,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.prepopulation import (
@@ -384,7 +383,6 @@ def process_self_contained_coordinator_stream(
                                     redis_proc_start_port,
                                     run_image,
                                     temporary_dir,
-                                    start_redis_container,
                                     mnt_point="/mnt/redis/",
                                     password=redis_password,
                                 )

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -360,6 +360,8 @@ def process_self_contained_coordinator_stream(
                                         collection_summary_str
                                     )
                                 )
+                            primary_conns = []
+
                             if setup_type == "oss-cluster":
                                 primary_count = extract_primary_count(
                                     topologies_map, topology_spec_name
@@ -371,7 +373,6 @@ def process_self_contained_coordinator_stream(
                                 )
                                 (
                                     cluster_conns,
-                                    cluster_pids,
                                     current_cpu_pos,
                                 ) = spin_docker_cluster_redis(
                                     primary_count,
@@ -387,8 +388,7 @@ def process_self_contained_coordinator_stream(
                                     mnt_point="/mnt/redis/",
                                     password=redis_password,
                                 )
-                                redis_conns = cluster_conns
-                                redis_pids = cluster_pids
+                                primary_conns.extend(cluster_conns)
                             else:
                                 current_cpu_pos = spin_docker_standalone_redis(
                                     ceil_db_cpu_limit,
@@ -406,16 +406,22 @@ def process_self_contained_coordinator_stream(
                                     password=redis_password,
                                 )
                                 conn.ping()
-                                redis_conns = [conn]
-                                redis_pids = []
-                                redis_info = conn.info()
-                                first_redis_pid = redis_info.get("process_id")
-                                if first_redis_pid is not None:
-                                    redis_pids.append(first_redis_pid)
-                                else:
-                                    logging.warning(
-                                        "Redis process_id not found in INFO command"
+                                primary_conns.append(conn)
+
+                            redis_conns = primary_conns
+                            redis_pids = []
+                            for conn in redis_conns:
+                                try:
+                                    redis_pids.append(
+                                        conn.info().get("process_id", "unknown")
                                     )
+                                except Exception as e:
+                                    logging.warning(
+                                        "An error occurred while trying to fetch redis process id: {}. Skipping it.".format(
+                                            e
+                                        )
+                                    )
+
                             ceil_client_cpu_limit = extract_client_cpu_limit(
                                 benchmark_config
                             )

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -387,7 +387,6 @@ def process_self_contained_coordinator_stream(
                                     mnt_point="/mnt/redis/",
                                     password=redis_password,
                                 )
-                                r = cluster_conns[0]
                                 redis_conns = cluster_conns
                                 redis_pids = cluster_pids
                             else:
@@ -402,14 +401,14 @@ def process_self_contained_coordinator_stream(
                                     temporary_dir,
                                     redis_password,
                                 )
-                                r = redis.StrictRedis(
+                                conn = redis.StrictRedis(
                                     port=redis_proc_start_port,
                                     password=redis_password,
                                 )
-                                r.ping()
-                                redis_conns = [r]
+                                conn.ping()
+                                redis_conns = [conn]
                                 redis_pids = []
-                                redis_info = r.info()
+                                redis_info = conn.info()
                                 first_redis_pid = redis_info.get("process_id")
                                 if first_redis_pid is not None:
                                     redis_pids.append(first_redis_pid)
@@ -577,7 +576,11 @@ def process_self_contained_coordinator_stream(
                                 logging.info(
                                     "output {}".format(client_container_stdout)
                                 )
-                            r.shutdown(save=False)
+                            for conn in redis_conns:
+                                try:
+                                    conn.shutdown(save=False)
+                                except redis.exceptions.ConnectionError:
+                                    pass
 
                             (
                                 _,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -401,19 +401,19 @@ def process_self_contained_coordinator_stream(
                                     temporary_dir,
                                     redis_password,
                                 )
-                                conn = redis.StrictRedis(
+                                redis_conn = redis.StrictRedis(
                                     port=redis_proc_start_port,
                                     password=redis_password,
                                 )
-                                conn.ping()
-                                primary_conns.append(conn)
+                                redis_conn.ping()
+                                primary_conns.append(redis_conn)
 
                             redis_conns = primary_conns
                             redis_pids = []
-                            for conn in redis_conns:
+                            for redis_conn in redis_conns:
                                 try:
                                     redis_pids.append(
-                                        conn.info().get("process_id", "unknown")
+                                        redis_conn.info().get("process_id", "unknown")
                                     )
                                 except Exception as e:
                                     logging.warning(
@@ -582,9 +582,9 @@ def process_self_contained_coordinator_stream(
                                 logging.info(
                                     "output {}".format(client_container_stdout)
                                 )
-                            for conn in redis_conns:
+                            for redis_conn in redis_conns:
                                 try:
-                                    conn.shutdown(save=False)
+                                    redis_conn.shutdown(save=False)
                                 except redis.exceptions.ConnectionError:
                                     pass
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -388,6 +388,7 @@ def process_self_contained_coordinator_stream(
                                     password=redis_password,
                                 )
                                 r = cluster_conns[0]
+                                redis_conns = cluster_conns
                                 redis_pids = cluster_pids
                             else:
                                 current_cpu_pos = spin_docker_standalone_redis(
@@ -406,6 +407,7 @@ def process_self_contained_coordinator_stream(
                                     password=redis_password,
                                 )
                                 r.ping()
+                                redis_conns = [r]
                                 redis_pids = []
                                 redis_info = r.info()
                                 first_redis_pid = redis_info.get("process_id")
@@ -446,7 +448,7 @@ def process_self_contained_coordinator_stream(
                             )
                             dbconfig_keyspacelen_check(
                                 benchmark_config,
-                                [r],
+                                redis_conns,
                             )
 
                             benchmark_tool = extract_client_tool(benchmark_config)

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -7,7 +7,6 @@ import tempfile
 import traceback
 
 import redis
-from redisbench_admin.environments.oss_cluster import generate_cluster_redis_server_args
 
 from redisbench_admin.utils.local import check_dataset_local_requirements
 
@@ -53,6 +52,7 @@ from redis_benchmarks_specification.__common__.spec import (
     extract_client_cpu_limit,
     extract_client_tool,
     extract_client_container_image,
+    extract_primary_count,
     extract_redis_dbconfig_parameters,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.artifacts import (
@@ -71,6 +71,7 @@ from redis_benchmarks_specification.__self_contained_coordinator__.cpuset import
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     spin_docker_standalone_redis,
+    spin_docker_cluster_redis,
     teardown_containers,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.prepopulation import (
@@ -302,6 +303,11 @@ def process_self_contained_coordinator_stream(
                             tf_github_org = "redis"
                             tf_github_repo = "redis"
                             setup_name = topology_spec_name
+                            setup_type = "oss-standalone"
+                            if topology_spec_name in topologies_map:
+                                setup_type = topologies_map[topology_spec_name].get(
+                                    "type", "oss-standalone"
+                                )
                             tf_triggering_env = "ci"
                             github_actor = "{}-{}".format(
                                 tf_triggering_env, running_platform
@@ -353,7 +359,36 @@ def process_self_contained_coordinator_stream(
                                         collection_summary_str
                                     )
                                 )
-                            if setup_name == "oss-standalone":
+                            if setup_type == "oss-cluster":
+                                primary_count = extract_primary_count(
+                                    topologies_map, topology_spec_name
+                                )
+                                logging.info(
+                                    "Starting cluster with {} primaries for topology {}".format(
+                                        primary_count, topology_spec_name
+                                    )
+                                )
+                                (
+                                    cluster_conns,
+                                    cluster_pids,
+                                    current_cpu_pos,
+                                ) = spin_docker_cluster_redis(
+                                    primary_count,
+                                    ceil_db_cpu_limit,
+                                    current_cpu_pos,
+                                    docker_client,
+                                    redis_configuration_parameters,
+                                    redis_containers,
+                                    redis_proc_start_port,
+                                    run_image,
+                                    temporary_dir,
+                                    spin_docker_standalone_redis,
+                                    mnt_point="/mnt/redis/",
+                                    password=redis_password,
+                                )
+                                r = cluster_conns[0]
+                                redis_pids = cluster_pids
+                            else:
                                 current_cpu_pos = spin_docker_standalone_redis(
                                     ceil_db_cpu_limit,
                                     current_cpu_pos,
@@ -365,49 +400,20 @@ def process_self_contained_coordinator_stream(
                                     temporary_dir,
                                     redis_password,
                                 )
-                            else:
-                                shard_count = 1
-                                start_port = redis_proc_start_port
-                                dbdir_folder = None
-                                server_private_ip = "127.0.0.1"
-                                for master_shard_id in range(1, shard_count + 1):
-                                    shard_port = master_shard_id + start_port - 1
-
-                                    (
-                                        command,
-                                        logfile,
-                                    ) = generate_cluster_redis_server_args(
-                                        "redis-server",
-                                        dbdir_folder,
-                                        None,
-                                        server_private_ip,
-                                        shard_port,
-                                        redis_configuration_parameters,
-                                        "yes",
-                                        None,
-                                        "",
-                                        "yes",
-                                        False,
-                                    )
-                                    logging.error(
-                                        "Remote primary shard {} command: {}".format(
-                                            master_shard_id, " ".join(command)
-                                        )
-                                    )
-
-                            r = redis.StrictRedis(
-                                port=redis_proc_start_port, password=redis_password
-                            )
-                            r.ping()
-                            redis_pids = []
-                            redis_info = r.info()
-                            first_redis_pid = redis_info.get("process_id")
-                            if first_redis_pid is not None:
-                                redis_pids.append(first_redis_pid)
-                            else:
-                                logging.warning(
-                                    "Redis process_id not found in INFO command"
+                                r = redis.StrictRedis(
+                                    port=redis_proc_start_port,
+                                    password=redis_password,
                                 )
+                                r.ping()
+                                redis_pids = []
+                                redis_info = r.info()
+                                first_redis_pid = redis_info.get("process_id")
+                                if first_redis_pid is not None:
+                                    redis_pids.append(first_redis_pid)
+                                else:
+                                    logging.warning(
+                                        "Redis process_id not found in INFO command"
+                                    )
                             ceil_client_cpu_limit = extract_client_cpu_limit(
                                 benchmark_config
                             )

--- a/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/runners.py
@@ -72,6 +72,7 @@ from redis_benchmarks_specification.__self_contained_coordinator__.cpuset import
 from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     spin_docker_standalone_redis,
     spin_docker_cluster_redis,
+    _default_start_redis_container,
     teardown_containers,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.prepopulation import (
@@ -382,7 +383,7 @@ def process_self_contained_coordinator_stream(
                                     redis_proc_start_port,
                                     run_image,
                                     temporary_dir,
-                                    spin_docker_standalone_redis,
+                                    _default_start_redis_container,
                                     mnt_point="/mnt/redis/",
                                     password=redis_password,
                                 )
@@ -437,6 +438,7 @@ def process_self_contained_coordinator_stream(
                                     temporary_dir,
                                     test_name,
                                     redis_password,
+                                    oss_cluster_api_enabled=setup_type == "oss-cluster",
                                 )
 
                             logging.info(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -616,6 +616,7 @@ from redis_benchmarks_specification.__self_contained_coordinator__.docker import
     inject_replication_sync_metrics,
     spin_up_redis_replicas,
     spin_docker_cluster_redis,
+    start_redis_container,
 )
 
 
@@ -2772,50 +2773,6 @@ def process_self_contained_coordinator_stream(
         print("-" * 60)
         overall_result = False
     return stream_id, overall_result, total_test_suite_runs
-
-
-def start_redis_container(
-    command_str,
-    db_cpuset_cpus,
-    docker_client,
-    mnt_point,
-    redis_containers,
-    run_image,
-    temporary_dir,
-    auto_remove=False,
-):
-    logging.info(
-        "Running redis-server on docker image {} (cpuset={}) with the following args: {}".format(
-            run_image, db_cpuset_cpus, command_str
-        )
-    )
-    volumes = {}
-    working_dir = "/"
-    if mnt_point != "":
-        volumes = {
-            temporary_dir: {
-                "bind": mnt_point,
-                "mode": "rw",
-            },
-        }
-        logging.info(f"setting volume as follow: {volumes}. working_dir={mnt_point}")
-        working_dir = mnt_point
-    redis_container = docker_client.containers.run(
-        image=run_image,
-        volumes=volumes,
-        auto_remove=auto_remove,
-        privileged=True,
-        working_dir=mnt_point,
-        command=command_str,
-        network_mode="host",
-        detach=True,
-        cpuset_cpus=db_cpuset_cpus,
-        pid_mode="host",
-        publish_all_ports=True,
-    )
-    time.sleep(5)
-    redis_containers.append(redis_container)
-    return redis_container
 
 
 def filter_test_files(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1754,12 +1754,12 @@ def process_self_contained_coordinator_stream(
                                         temporary_dir,
                                     )
 
-                                    conn = redis.StrictRedis(
+                                    redis_conn = redis.StrictRedis(
                                         port=redis_proc_start_port,
                                         password=redis_password,
                                     )
-                                    conn.ping()
-                                    primary_conns.append(conn)
+                                    redis_conn.ping()
+                                    primary_conns.append(redis_conn)
 
                                 # Allocate the client cpuset up front so that
                                 # preload can optionally run BEFORE the replica
@@ -1847,9 +1847,9 @@ def process_self_contained_coordinator_stream(
                                 redis_conns = primary_conns + replica_conns
                                 redis_pids = []
                                 redis_info = {}
-                                for conn in redis_conns:
+                                for redis_conn in redis_conns:
                                     try:
-                                        info = conn.info()
+                                        info = redis_conn.info()
                                         if not redis_info:
                                             redis_info = info
                                         redis_pids.append(info["process_id"])
@@ -1886,9 +1886,9 @@ def process_self_contained_coordinator_stream(
                                 # additional full syncs at runtime. Note: sync_full lives
                                 # in the "stats" section, not "replication".
                                 sync_full_initial = 0
-                                for conn in primary_conns:
+                                for redis_conn in primary_conns:
                                     try:
-                                        stats_info = conn.info("stats")
+                                        stats_info = redis_conn.info("stats")
                                         sync_full_initial += int(
                                             stats_info.get("sync_full", 0)
                                         )
@@ -1913,10 +1913,10 @@ def process_self_contained_coordinator_stream(
                                         == "oss-cluster",
                                     )
 
-                                for conn in primary_conns:
+                                for redis_conn in primary_conns:
                                     execute_init_commands(
                                         benchmark_config,
-                                        conn,
+                                        redis_conn,
                                         dbconfig_keyname="dbconfig",
                                     )
 
@@ -2379,9 +2379,9 @@ def process_self_contained_coordinator_stream(
                                 # may trigger multiple full syncs at runtime. Note:
                                 # sync_full is in the "stats" section, not "replication".
                                 sync_full_after = 0
-                                for conn in primary_conns:
+                                for redis_conn in primary_conns:
                                     try:
-                                        stats_info_after = conn.info("stats")
+                                        stats_info_after = redis_conn.info("stats")
                                         sync_full_after += int(
                                             stats_info_after.get("sync_full", 0)
                                         )
@@ -2438,9 +2438,9 @@ def process_self_contained_coordinator_stream(
                                     )
 
                                     # Shut down all nodes in reverse order: replicas, then primary (idx 0)
-                                    for conn in reversed(redis_conns):
+                                    for redis_conn in reversed(redis_conns):
                                         try:
-                                            conn.shutdown(save=False)
+                                            redis_conn.shutdown(save=False)
                                         except redis.exceptions.ConnectionError:
                                             pass
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1761,28 +1761,6 @@ def process_self_contained_coordinator_stream(
                                     conn.ping()
                                     primary_conns.append(conn)
 
-                                redis_info = primary_conns[0].info()
-
-                                if git_hash is None and "redis_git_sha1" in redis_info:
-                                    git_hash = redis_info["redis_git_sha1"]
-                                    if (
-                                        git_hash == "" or git_hash == 0
-                                    ) and "redis_build_id" in redis_info:
-                                        git_hash = redis_info["redis_build_id"]
-                                    logging.info(
-                                        f"Given git_hash was None, we've collected that info from the server reply. git_hash={git_hash}"
-                                    )
-
-                                server_version_keyname = f"{server_name}_version"
-                                if (
-                                    git_version is None
-                                    and server_version_keyname in redis_info
-                                ):
-                                    git_version = redis_info[server_version_keyname]
-                                    logging.info(
-                                        f"Given git_version was None, we've collected that info from the server reply key named {server_version_keyname}. git_version={git_version}"
-                                    )
-
                                 # Allocate the client cpuset up front so that
                                 # preload can optionally run BEFORE the replica
                                 # spin-up (see preload_before_replica below).
@@ -1868,11 +1846,13 @@ def process_self_contained_coordinator_stream(
 
                                 redis_conns = primary_conns + replica_conns
                                 redis_pids = []
+                                redis_info = {}
                                 for conn in redis_conns:
                                     try:
-                                        redis_pids.append(
-                                            conn.info().get("process_id", "unknown")
-                                        )
+                                        info = conn.info()
+                                        if not redis_info:
+                                            redis_info = info
+                                        redis_pids.append(info["process_id"])
                                     except Exception as e:
                                         logging.warning(
                                             "An error occurred while trying to fetch redis process id: {}. Skipping it.".format(
@@ -1880,6 +1860,26 @@ def process_self_contained_coordinator_stream(
                                             )
                                         )
                                 reset_commandstats(redis_conns)
+
+                                if git_hash is None and "redis_git_sha1" in redis_info:
+                                    git_hash = redis_info["redis_git_sha1"]
+                                    if (
+                                        git_hash == "" or git_hash == 0
+                                    ) and "redis_build_id" in redis_info:
+                                        git_hash = redis_info["redis_build_id"]
+                                    logging.info(
+                                        f"Given git_hash was None, we've collected that info from the server reply. git_hash={git_hash}"
+                                    )
+
+                                server_version_keyname = f"{server_name}_version"
+                                if (
+                                    git_version is None
+                                    and server_version_keyname in redis_info
+                                ):
+                                    git_version = redis_info[server_version_keyname]
+                                    logging.info(
+                                        f"Given git_version was None, we've collected that info from the server reply key named {server_version_keyname}. git_version={git_version}"
+                                    )
                                 # Capture initial sync_full count from master so we can
                                 # compute the delta after the benchmark runs. Write-heavy
                                 # benchmarks with a small replication backlog will trigger

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1791,7 +1791,8 @@ def process_self_contained_coordinator_stream(
                                     logging.info(
                                         f"Given git_version was None, we've collected that info from the server reply key named {server_version_keyname}. git_version={git_version}"
                                     )
-                                redis_pids.append(first_redis_pid)
+                                if setup_type != "oss-cluster":
+                                    redis_pids.append(first_redis_pid)
 
                                 # Allocate the client cpuset up front so that
                                 # preload can optionally run BEFORE the replica

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -113,6 +113,7 @@ from redis_benchmarks_specification.__common__.spec import (
     extract_redis_dbconfig_parameters,
     extract_redis_configuration_from_topology,
     extract_replica_count,
+    extract_primary_count,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.artifacts import (
     restore_build_artifacts_from_test_details,
@@ -614,6 +615,7 @@ from redis_benchmarks_specification.__self_contained_coordinator__.docker import
     generate_standalone_redis_server_args,
     inject_replication_sync_metrics,
     spin_up_redis_replicas,
+    spin_docker_cluster_redis,
 )
 
 
@@ -1693,42 +1695,83 @@ def process_self_contained_coordinator_stream(
                                         testDetails,
                                     )
 
-                                command = generate_standalone_redis_server_args(
-                                    executable,
-                                    redis_proc_start_port,
-                                    mnt_point,
-                                    redis_configuration_parameters,
-                                    redis_arguments,
-                                    redis_password,
-                                )
-                                command_str = " ".join(command)
-                                db_cpuset_cpus, current_cpu_pos = generate_cpuset_cpus(
-                                    primary_cpu_limit, current_cpu_pos
-                                )
-                                redis_container = start_redis_container(
-                                    command_str,
-                                    db_cpuset_cpus,
-                                    docker_client,
-                                    mnt_point,
-                                    redis_containers,
-                                    run_image,
-                                    temporary_dir,
-                                )
-
-                                r = redis.StrictRedis(
-                                    port=redis_proc_start_port, password=redis_password
-                                )
-                                r.ping()
-                                redis_conns = [r]
-                                reset_commandstats(redis_conns)
-                                redis_pids = []
-                                redis_info = r.info()
-                                first_redis_pid = redis_info.get("process_id")
-                                if first_redis_pid is None:
-                                    logging.warning(
-                                        "Redis process_id not found in INFO command"
+                                if setup_type == "oss-cluster":
+                                    primary_count = extract_primary_count(
+                                        topologies_map, topology_spec_name
                                     )
-                                    first_redis_pid = "unknown"
+                                    logging.info(
+                                        "Starting cluster with {} primaries for topology {}".format(
+                                            primary_count, topology_spec_name
+                                        )
+                                    )
+                                    (
+                                        cluster_conns,
+                                        cluster_pids,
+                                        current_cpu_pos,
+                                    ) = spin_docker_cluster_redis(
+                                        primary_count,
+                                        ceil_db_cpu_limit,
+                                        current_cpu_pos,
+                                        docker_client,
+                                        redis_configuration_parameters,
+                                        redis_containers,
+                                        redis_proc_start_port,
+                                        run_image,
+                                        temporary_dir,
+                                        start_redis_container,
+                                        mnt_point=mnt_point,
+                                        redis_arguments=redis_arguments,
+                                        password=redis_password,
+                                    )
+                                    r = cluster_conns[0]
+                                    redis_conns = cluster_conns
+                                    reset_commandstats(redis_conns)
+                                    redis_pids = cluster_pids
+                                    redis_info = r.info()
+                                    first_redis_pid = redis_info.get(
+                                        "process_id", "unknown"
+                                    )
+                                else:
+                                    command = generate_standalone_redis_server_args(
+                                        executable,
+                                        redis_proc_start_port,
+                                        mnt_point,
+                                        redis_configuration_parameters,
+                                        redis_arguments,
+                                        redis_password,
+                                    )
+                                    command_str = " ".join(command)
+                                    db_cpuset_cpus, current_cpu_pos = (
+                                        generate_cpuset_cpus(
+                                            primary_cpu_limit, current_cpu_pos
+                                        )
+                                    )
+                                    redis_container = start_redis_container(
+                                        command_str,
+                                        db_cpuset_cpus,
+                                        docker_client,
+                                        mnt_point,
+                                        redis_containers,
+                                        run_image,
+                                        temporary_dir,
+                                    )
+
+                                    r = redis.StrictRedis(
+                                        port=redis_proc_start_port,
+                                        password=redis_password,
+                                    )
+                                    r.ping()
+                                    redis_conns = [r]
+                                    reset_commandstats(redis_conns)
+                                    redis_pids = []
+                                    redis_info = r.info()
+                                    first_redis_pid = redis_info.get("process_id")
+                                    if first_redis_pid is None:
+                                        logging.warning(
+                                            "Redis process_id not found in INFO command"
+                                        )
+                                        first_redis_pid = "unknown"
+
                                 if git_hash is None and "redis_git_sha1" in redis_info:
                                     git_hash = redis_info["redis_git_sha1"]
                                     if (
@@ -1798,6 +1841,8 @@ def process_self_contained_coordinator_stream(
                                         temporary_dir,
                                         test_name,
                                         redis_password,
+                                        oss_cluster_api_enabled=setup_type
+                                        == "oss-cluster",
                                     )
                                     preload_already_done = True
 
@@ -1860,6 +1905,8 @@ def process_self_contained_coordinator_stream(
                                         temporary_dir,
                                         test_name,
                                         redis_password,
+                                        oss_cluster_api_enabled=setup_type
+                                        == "oss-cluster",
                                     )
 
                                 execute_init_commands(
@@ -1909,7 +1956,7 @@ def process_self_contained_coordinator_stream(
                                         "localhost",
                                         redis_password,
                                         local_benchmark_output_filename,
-                                        False,
+                                        setup_type == "oss-cluster",
                                         False,
                                         False,
                                         None,
@@ -2908,6 +2955,7 @@ def data_prepopulation_step(
     temporary_dir,
     test_name,
     redis_password,
+    oss_cluster_api_enabled=False,
 ):
     # setup the benchmark
     (
@@ -2939,7 +2987,7 @@ def data_prepopulation_step(
             "localhost",
             redis_password,
             local_benchmark_output_filename,
-            False,
+            oss_cluster_api_enabled,
         )
 
         logging.info(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1722,7 +1722,6 @@ def process_self_contained_coordinator_stream(
                                         redis_proc_start_port,
                                         run_image,
                                         temporary_dir,
-                                        start_redis_container,
                                         mnt_point=mnt_point,
                                         redis_arguments=redis_arguments,
                                         password=redis_password,
@@ -1838,7 +1837,6 @@ def process_self_contained_coordinator_stream(
                                         redis_configuration_parameters,
                                         redis_arguments,
                                         redis_password,
-                                        start_redis_container,
                                         server_name=server_name,
                                     )
                                     replica_conns.extend(new_replica_conns)

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1695,7 +1695,11 @@ def process_self_contained_coordinator_stream(
                                         testDetails,
                                     )
 
+                                primary_conns = []
+                                replica_conns = []
+
                                 if setup_type == "oss-cluster":
+                                    # Cluster mode
                                     primary_count = extract_primary_count(
                                         topologies_map, topology_spec_name
                                     )
@@ -1706,7 +1710,6 @@ def process_self_contained_coordinator_stream(
                                     )
                                     (
                                         cluster_conns,
-                                        cluster_pids,
                                         current_cpu_pos,
                                     ) = spin_docker_cluster_redis(
                                         primary_count,
@@ -1724,15 +1727,9 @@ def process_self_contained_coordinator_stream(
                                         password=redis_password,
                                         server_name=server_name,
                                     )
-                                    r = cluster_conns[0]
-                                    redis_conns = cluster_conns
-                                    reset_commandstats(redis_conns)
-                                    redis_pids = cluster_pids
-                                    redis_info = r.info()
-                                    first_redis_pid = redis_info.get(
-                                        "process_id", "unknown"
-                                    )
+                                    primary_conns.extend(cluster_conns)
                                 else:
+                                    # Standalone mode
                                     command = generate_standalone_redis_server_args(
                                         executable,
                                         redis_proc_start_port,
@@ -1757,21 +1754,14 @@ def process_self_contained_coordinator_stream(
                                         temporary_dir,
                                     )
 
-                                    r = redis.StrictRedis(
+                                    conn = redis.StrictRedis(
                                         port=redis_proc_start_port,
                                         password=redis_password,
                                     )
-                                    r.ping()
-                                    redis_conns = [r]
-                                    reset_commandstats(redis_conns)
-                                    redis_pids = []
-                                    redis_info = r.info()
-                                    first_redis_pid = redis_info.get("process_id")
-                                    if first_redis_pid is None:
-                                        logging.warning(
-                                            "Redis process_id not found in INFO command"
-                                        )
-                                        first_redis_pid = "unknown"
+                                    conn.ping()
+                                    primary_conns.append(conn)
+
+                                redis_info = primary_conns[0].info()
 
                                 if git_hash is None and "redis_git_sha1" in redis_info:
                                     git_hash = redis_info["redis_git_sha1"]
@@ -1792,8 +1782,6 @@ def process_self_contained_coordinator_stream(
                                     logging.info(
                                         f"Given git_version was None, we've collected that info from the server reply key named {server_version_keyname}. git_version={git_version}"
                                     )
-                                if setup_type != "oss-cluster":
-                                    redis_pids.append(first_redis_pid)
 
                                 # Allocate the client cpuset up front so that
                                 # preload can optionally run BEFORE the replica
@@ -1855,8 +1843,7 @@ def process_self_contained_coordinator_stream(
                                         )
                                     )
                                     (
-                                        replica_conns,
-                                        replica_pids,
+                                        new_replica_conns,
                                         current_cpu_pos,
                                         replica_sync_times_seconds,
                                     ) = spin_up_redis_replicas(
@@ -1875,23 +1862,38 @@ def process_self_contained_coordinator_stream(
                                         start_redis_container,
                                         server_name=server_name,
                                     )
-                                    redis_conns.extend(replica_conns)
-                                    reset_commandstats(replica_conns)
+                                    replica_conns.extend(new_replica_conns)
                                 else:
                                     replica_sync_times_seconds = []
+
+                                redis_conns = primary_conns + replica_conns
+                                redis_pids = []
+                                for conn in redis_conns:
+                                    try:
+                                        redis_pids.append(
+                                            conn.info().get("process_id", "unknown")
+                                        )
+                                    except Exception as e:
+                                        logging.warning(
+                                            "An error occurred while trying to fetch redis process id: {}. Skipping it.".format(
+                                                e
+                                            )
+                                        )
+                                reset_commandstats(redis_conns)
                                 # Capture initial sync_full count from master so we can
                                 # compute the delta after the benchmark runs. Write-heavy
                                 # benchmarks with a small replication backlog will trigger
                                 # additional full syncs at runtime. Note: sync_full lives
                                 # in the "stats" section, not "replication".
                                 sync_full_initial = 0
-                                try:
-                                    stats_info = r.info("stats")
-                                    sync_full_initial = int(
-                                        stats_info.get("sync_full", 0)
-                                    )
-                                except Exception:
-                                    pass
+                                for conn in primary_conns:
+                                    try:
+                                        stats_info = conn.info("stats")
+                                        sync_full_initial += int(
+                                            stats_info.get("sync_full", 0)
+                                        )
+                                    except Exception:
+                                        pass
 
                                 if (
                                     not preload_already_done
@@ -1911,9 +1913,12 @@ def process_self_contained_coordinator_stream(
                                         == "oss-cluster",
                                     )
 
-                                execute_init_commands(
-                                    benchmark_config, r, dbconfig_keyname="dbconfig"
-                                )
+                                for conn in primary_conns:
+                                    execute_init_commands(
+                                        benchmark_config,
+                                        conn,
+                                        dbconfig_keyname="dbconfig",
+                                    )
 
                                 benchmark_tool = extract_client_tool(benchmark_config)
                                 # backwards compatible
@@ -2373,17 +2378,18 @@ def process_self_contained_coordinator_stream(
                                 # Write-heavy benchmarks with small replication backlogs
                                 # may trigger multiple full syncs at runtime. Note:
                                 # sync_full is in the "stats" section, not "replication".
-                                sync_full_during_benchmark = 0
-                                try:
-                                    stats_info_after = r.info("stats")
-                                    sync_full_after = int(
-                                        stats_info_after.get("sync_full", 0)
-                                    )
-                                    sync_full_during_benchmark = (
-                                        sync_full_after - sync_full_initial
-                                    )
-                                except Exception:
-                                    pass
+                                sync_full_after = 0
+                                for conn in primary_conns:
+                                    try:
+                                        stats_info_after = conn.info("stats")
+                                        sync_full_after += int(
+                                            stats_info_after.get("sync_full", 0)
+                                        )
+                                    except Exception:
+                                        pass
+                                sync_full_during_benchmark = (
+                                    sync_full_after - sync_full_initial
+                                )
 
                                 # Inject replication full-sync metrics into results_dict
                                 # so they get pushed to TimeSeries alongside ops/sec.
@@ -2430,13 +2436,13 @@ def process_self_contained_coordinator_stream(
                                         default_metrics,
                                         git_hash,
                                     )
-                                    # Shut down replicas before primary
-                                    for replica_conn in redis_conns[1:]:
+
+                                    # Shut down all nodes in reverse order: replicas, then primary (idx 0)
+                                    for conn in reversed(redis_conns):
                                         try:
-                                            replica_conn.shutdown(nosave=True)
+                                            conn.shutdown(save=False)
                                         except redis.exceptions.ConnectionError:
                                             pass
-                                    r.shutdown(save=False)
 
                                 except redis.exceptions.ConnectionError as e:
                                     logging.critical(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1722,6 +1722,7 @@ def process_self_contained_coordinator_stream(
                                         mnt_point=mnt_point,
                                         redis_arguments=redis_arguments,
                                         password=redis_password,
+                                        server_name=server_name,
                                     )
                                     r = cluster_conns[0]
                                     redis_conns = cluster_conns

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -2034,7 +2034,12 @@ def process_self_contained_coordinator_stream(
                                     # ARM perf stat --topdown only supports L1;
                                     # Intel supports up to L6. Auto-select.
                                     import platform
-                                    topdown_level = 1 if platform.machine() in ("aarch64", "arm64") else 4
+
+                                    topdown_level = (
+                                        1
+                                        if platform.machine() in ("aarch64", "arm64")
+                                        else 4
+                                    )
                                     topdown_collector = TopdownCollector(
                                         process_name=executable.split("/")[-1],
                                         duration_seconds=topdown_duration,

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-get-set-1-10-512B-cluster.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-get-set-1-10-512B-cluster.yml
@@ -10,7 +10,7 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '"--data-size" "512" "--key-pattern" "P:P" "--key-minimum" "1" "--key-maximum"
       "10000000" "--ratio" "1:0" "--pipeline" "30" "--clients" "50" "--threads" "30"
-      "-n" "allkeys" "--hide-histogram" "--cluster-mode"'
+      "-n" "allkeys" "--hide-histogram"'
   resources:
     requests:
       memory: 12g
@@ -30,8 +30,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: '"--data-size" "512" "--ratio" "1:10" "--key-pattern" "R:R" "--key-minimum"
-    "1" "--key-maximum" "10000000" "--test-time" "180" "-c" "50" "-t" "4" "--hide-histogram"
-    "--cluster-mode"'
+    "1" "--key-maximum" "10000000" "--test-time" "180" "-c" "50" "-t" "4" "--hide-histogram"'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-get-set-1-10-512B-cluster.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-get-set-1-10-512B-cluster.yml
@@ -1,0 +1,41 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-string-get-set-1-10-512B-cluster
+description: Runs memtier_benchmark on a 3-primary Redis cluster with 10M keys of
+  512 Bytes each (~5GB). Workload is a 1:10 SET:GET ratio for 180 seconds.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "512" "--key-pattern" "P:P" "--key-minimum" "1" "--key-maximum"
+      "10000000" "--ratio" "1:0" "--pipeline" "30" "--clients" "50" "--threads" "30"
+      "-n" "allkeys" "--hide-histogram" "--cluster-mode"'
+  resources:
+    requests:
+      memory: 12g
+  dataset_name: 10Mkeys-string-512B-size-cluster
+  dataset_description: This dataset contains 10 million string keys, each with a data
+    size of 512 bytes, distributed across a 3-primary cluster.
+tested-commands:
+- set
+- get
+redis-topologies:
+- oss-cluster-3-primaries
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "512" "--ratio" "1:10" "--key-pattern" "R:R" "--key-minimum"
+    "1" "--key-maximum" "10000000" "--test-time" "180" "-c" "50" "-t" "4" "--hide-histogram"
+    "--cluster-mode"'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-cluster.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-cluster.yml
@@ -1,0 +1,31 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-load-string-with-10B-values-cluster
+description: Runs memtier_benchmark, for a keyspace length of 1M keys loading string
+  values of 10 Bytes on a 3-primary Redis cluster.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 3g
+tested-commands:
+- set
+redis-topologies:
+- oss-cluster-3-primaries
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50"
+    "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n"
+    "allkeys" --pipeline 50'
+  resources:
+    requests:
+      cpus: '10'
+      memory: 2g
+tested-groups:
+- string
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-cluster.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-cluster.yml
@@ -10,7 +10,7 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50"
       "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n"
-      "allkeys" --pipeline 50 --cluster-mode'
+      "allkeys" --pipeline 50'
   resources:
     requests:
       memory: 3g

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-cluster.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-cluster.yml
@@ -1,0 +1,39 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-get-10B-cluster
+description: Runs memtier_benchmark, for a keyspace length of 1M keys with a data
+  size of 10 Bytes for each key on a 3-primary Redis cluster.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50"
+      "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n"
+      "allkeys" --pipeline 50 --cluster-mode'
+  resources:
+    requests:
+      memory: 3g
+  dataset_name: 1Mkeys-string-10B-size-cluster
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 10 bytes, distributed across a 3-primary cluster.
+tested-commands:
+- get
+redis-topologies:
+- oss-cluster-3-primaries
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "10" --distinct-client-seed --ratio 0:1 --key-pattern
+    R:R -c 10 -t 10 --hide-histogram --test-time 120'
+  resources:
+    requests:
+      cpus: '10'
+      memory: 2g
+tested-groups:
+- string
+priority: 50

--- a/utils/tests/test_data/test-suites/test-memtier-dockerhub-cluster.yml
+++ b/utils/tests/test_data/test-suites/test-memtier-dockerhub-cluster.yml
@@ -1,0 +1,29 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-load-string-with-10B-values-cluster
+description: Runs memtier_benchmark, for a keyspace length of 1M keys loading STRINGs in which the value has a data size of 10 Bytes on a 3-primary cluster.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 1g
+tested-commands:
+- set
+redis-topologies:
+- oss-cluster-3-primaries
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "10" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 10 -c 50 -t 4 --hide-histogram --cluster-mode'
+  resources:
+    requests:
+      cpus: "1"
+      memory: "2g"
+
+tested-groups:
+- string
+priority: 17

--- a/utils/tests/test_data/test-suites/test-memtier-dockerhub-cluster.yml
+++ b/utils/tests/test_data/test-suites/test-memtier-dockerhub-cluster.yml
@@ -18,7 +18,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "10" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 10 -c 50 -t 4 --hide-histogram --cluster-mode'
+  arguments: '"--data-size" "10" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 10 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: "1"

--- a/utils/tests/test_runner.py
+++ b/utils/tests/test_runner.py
@@ -1489,7 +1489,7 @@ def test_extract_testsuites():
         ]
     )
     tests = extract_testsuites(args)
-    assert len(tests) == 9
+    assert len(tests) == 10
 
     args = parser.parse_args(
         args=[
@@ -1500,7 +1500,7 @@ def test_extract_testsuites():
         ]
     )
     tests = extract_testsuites(args)
-    assert len(tests) == 9
+    assert len(tests) == 10
 
     args = parser.parse_args(
         args=[

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -493,7 +493,6 @@ def test_spin_up_redis_replicas():
         # Start 1 replica
         (
             replica_conns,
-            replica_pids,
             current_cpu_pos,
             sync_times_seconds,
         ) = spin_up_redis_replicas(
@@ -763,7 +762,6 @@ def test_spin_docker_cluster_redis():
     try:
         (
             cluster_conns,
-            cluster_pids,
             current_cpu_pos,
         ) = spin_docker_cluster_redis(
             primary_count,

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -510,7 +510,6 @@ def test_spin_up_redis_replicas():
             redis_configuration_parameters,
             redis_arguments,
             redis_password,
-            start_redis_container,
         )
         assert len(replica_conns) == 1
         replica_info = replica_conns[0].info("replication")
@@ -775,7 +774,6 @@ def test_spin_docker_cluster_redis():
             primary_port,
             run_image,
             temporary_dir,
-            start_redis_container,
             mnt_point=mnt_point,
             redis_arguments="",
             password=redis_password,

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -35,8 +35,10 @@ from utils.tests.test_data.api_builder_common import flow_1_and_2_api_builder_ch
 
 from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     generate_standalone_redis_server_args,
+    generate_cluster_redis_server_args,
     inject_replication_sync_metrics,
     spin_up_redis_replicas,
+    spin_docker_cluster_redis,
 )
 
 
@@ -548,6 +550,190 @@ def test_spin_up_redis_replicas():
         r.shutdown(nosave=True)
     except Exception:
         # Print logs on failure
+        for c in redis_containers:
+            try:
+                logs = c.logs().decode("utf-8")
+                logging.error(f"Container logs: {logs}")
+            except Exception:
+                pass
+        raise
+    finally:
+        for c in redis_containers:
+            try:
+                c.stop()
+                c.remove()
+            except Exception:
+                pass
+
+
+def test_generate_cluster_redis_server_args():
+    """Cluster server args must include --cluster-enabled yes and a unique
+    nodes config file per port."""
+    command = generate_cluster_redis_server_args(
+        "/mnt/redis/redis-server",
+        6379,
+        "/mnt/redis/",
+        None,
+        "",
+        None,
+    )
+    assert "/mnt/redis/redis-server" in command
+    assert "--cluster-enabled" in command
+    idx = command.index("--cluster-enabled")
+    assert command[idx + 1] == "yes"
+    assert "--cluster-config-file" in command
+    idx2 = command.index("--cluster-config-file")
+    assert command[idx2 + 1] == "nodes-6379.conf"
+    assert "--cluster-node-timeout" in command
+    idx3 = command.index("--cluster-node-timeout")
+    assert command[idx3 + 1] == "5000"
+    # Must also contain the standalone args (port, dir)
+    assert "--port" in command
+    port_idx = command.index("--port")
+    assert command[port_idx + 1] == "6379"
+
+
+def test_generate_cluster_redis_server_args_with_password():
+    """Cluster args with a password must include --requirepass."""
+    command = generate_cluster_redis_server_args(
+        "redis-server",
+        6380,
+        "",
+        None,
+        "",
+        "secret123",
+    )
+    assert "--cluster-enabled" in command
+    assert "--requirepass" in command
+    pw_idx = command.index("--requirepass")
+    assert command[pw_idx + 1] == "secret123"
+    cfg_idx = command.index("--cluster-config-file")
+    assert command[cfg_idx + 1] == "nodes-6380.conf"
+
+
+def test_generate_cluster_redis_server_args_unique_per_port():
+    """Each port must get a unique cluster config filename."""
+    ports = [6379, 6380, 6381]
+    config_files = []
+    for port in ports:
+        cmd = generate_cluster_redis_server_args(
+            "redis-server", port, "", None, "", None
+        )
+        idx = cmd.index("--cluster-config-file")
+        config_files.append(cmd[idx + 1])
+    # All config files must be unique
+    assert len(set(config_files)) == len(ports)
+    assert config_files == ["nodes-6379.conf", "nodes-6380.conf", "nodes-6381.conf"]
+
+
+def test_cluster_yaml_spec_get():
+    """The cluster GET test suite YAML must reference the correct topology."""
+    spec_path = (
+        "./redis_benchmarks_specification/test-suites/"
+        "memtier_benchmark-1Mkeys-string-get-10B-cluster.yml"
+    )
+    with open(spec_path, "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+    assert "oss-cluster-3-primaries" in benchmark_config["redis-topologies"]
+    assert "get" in benchmark_config["tested-commands"]
+    assert benchmark_config["clientconfig"]["tool"] == "memtier_benchmark"
+    # Preload tool should use cluster mode
+    assert "--cluster-mode" in benchmark_config["dbconfig"]["preload_tool"]["arguments"]
+
+
+def test_cluster_yaml_spec_set():
+    """The cluster SET test suite YAML must reference the correct topology
+    and should NOT have a preload tool (it IS the preload)."""
+    spec_path = (
+        "./redis_benchmarks_specification/test-suites/"
+        "memtier_benchmark-1Mkeys-load-string-with-10B-values-cluster.yml"
+    )
+    with open(spec_path, "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+    assert "oss-cluster-3-primaries" in benchmark_config["redis-topologies"]
+    assert "set" in benchmark_config["tested-commands"]
+    assert benchmark_config["clientconfig"]["tool"] == "memtier_benchmark"
+    # SET workload doesn't need preload
+    assert "preload_tool" not in benchmark_config.get("dbconfig", {})
+
+
+def test_spin_docker_cluster_redis():
+    """Integration test: spin up a 3-primary Redis cluster using Docker,
+    verify cluster_state:ok, slot coverage, and CLUSTER MEET."""
+    run_image = "redis:8.0"
+    mnt_point = ""
+    primary_port = 7379
+    current_cpu_pos = 0
+    ceil_db_cpu_limit = 3
+    redis_configuration_parameters = None
+    redis_containers = []
+    redis_password = None
+    temporary_dir = ""
+    primary_count = 3
+    docker_client = docker.from_env()
+
+    try:
+        (
+            cluster_conns,
+            cluster_pids,
+            current_cpu_pos,
+        ) = spin_docker_cluster_redis(
+            primary_count,
+            ceil_db_cpu_limit,
+            current_cpu_pos,
+            docker_client,
+            redis_configuration_parameters,
+            redis_containers,
+            primary_port,
+            run_image,
+            temporary_dir,
+            start_redis_container,
+            mnt_point=mnt_point,
+            redis_arguments="",
+            password=redis_password,
+        )
+
+        # Should have 3 connections
+        assert len(cluster_conns) == 3
+
+        # All nodes should be reachable
+        for conn in cluster_conns:
+            conn.ping()
+
+        # Check cluster_state:ok on all nodes
+        for i, conn in enumerate(cluster_conns):
+            cluster_info = conn.execute_command("CLUSTER", "INFO")
+            if isinstance(cluster_info, bytes):
+                cluster_info = cluster_info.decode()
+            assert "cluster_state:ok" in cluster_info, (
+                f"Node {i} (port {primary_port + i}) not in cluster_state:ok"
+            )
+
+        # Verify all 16384 slots are covered
+        cluster_info = cluster_conns[0].execute_command("CLUSTER", "INFO")
+        if isinstance(cluster_info, bytes):
+            cluster_info = cluster_info.decode()
+        assert "cluster_slots_ok:16384" in cluster_info
+
+        # Verify each node knows about all 3 nodes
+        nodes_raw = cluster_conns[0].execute_command("CLUSTER", "NODES")
+        if isinstance(nodes_raw, bytes):
+            nodes_raw = nodes_raw.decode()
+        node_lines = [l for l in nodes_raw.strip().split("\n") if l.strip()]
+        assert len(node_lines) == 3, (
+            f"Expected 3 nodes in CLUSTER NODES, got {len(node_lines)}"
+        )
+
+        # Verify we can write a key (it should route to the right shard)
+        cluster_conns[0].set("test_cluster_key", "value")
+
+        # Shutdown all nodes
+        for conn in cluster_conns:
+            try:
+                conn.shutdown(nosave=True)
+            except redis.exceptions.ConnectionError:
+                pass
+    except Exception:
         for c in redis_containers:
             try:
                 logs = c.logs().decode("utf-8")

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -637,8 +637,11 @@ def test_cluster_yaml_spec_get():
     assert "oss-cluster-3-primaries" in benchmark_config["redis-topologies"]
     assert "get" in benchmark_config["tested-commands"]
     assert benchmark_config["clientconfig"]["tool"] == "memtier_benchmark"
-    # Preload tool should use cluster mode
-    assert "--cluster-mode" in benchmark_config["dbconfig"]["preload_tool"]["arguments"]
+    # --cluster-mode is injected programmatically, not in the YAML arguments
+    assert (
+        "--cluster-mode"
+        not in benchmark_config["dbconfig"]["preload_tool"]["arguments"]
+    )
 
 
 def test_cluster_yaml_spec_set():
@@ -655,6 +658,91 @@ def test_cluster_yaml_spec_set():
     assert benchmark_config["clientconfig"]["tool"] == "memtier_benchmark"
     # SET workload doesn't need preload
     assert "preload_tool" not in benchmark_config.get("dbconfig", {})
+
+
+def test_cluster_mode_injected_programmatically():
+    """--cluster-mode must NOT be in cluster YAML arguments but MUST be
+    injected by prepare_memtier_benchmark_parameters when
+    oss_cluster_api_enabled is True."""
+    from redis_benchmarks_specification.__self_contained_coordinator__.clients import (
+        prepare_memtier_benchmark_parameters,
+    )
+
+    cluster_specs = [
+        "./redis_benchmarks_specification/test-suites/"
+        "memtier_benchmark-1Mkeys-string-get-10B-cluster.yml",
+        "./redis_benchmarks_specification/test-suites/"
+        "memtier_benchmark-10Mkeys-string-get-set-1-10-512B-cluster.yml",
+    ]
+    for spec_path in cluster_specs:
+        with open(spec_path, "r") as yml_file:
+            benchmark_config = yaml.safe_load(yml_file)
+
+        # YAML must not contain --cluster-mode (neither client nor preload)
+        client_args = benchmark_config["clientconfig"].get("arguments", "")
+        assert (
+            "--cluster-mode" not in client_args
+        ), f"--cluster-mode should not be in clientconfig.arguments of {spec_path}"
+        preload_args = (
+            benchmark_config.get("dbconfig", {})
+            .get("preload_tool", {})
+            .get("arguments", "")
+        )
+        assert (
+            "--cluster-mode" not in preload_args
+        ), f"--cluster-mode should not be in preload_tool.arguments of {spec_path}"
+
+        # When oss_cluster_api_enabled=True, --cluster-mode IS added
+        _, cmd_str = prepare_memtier_benchmark_parameters(
+            benchmark_config["clientconfig"],
+            "memtier_benchmark",
+            6379,
+            "localhost",
+            "out.json",
+            True,
+        )
+        assert "--cluster-mode" in cmd_str, (
+            f"--cluster-mode must be injected when oss_cluster_api_enabled=True "
+            f"for {spec_path}"
+        )
+
+        # When oss_cluster_api_enabled=False, --cluster-mode is NOT added
+        _, cmd_str = prepare_memtier_benchmark_parameters(
+            benchmark_config["clientconfig"],
+            "memtier_benchmark",
+            6379,
+            "localhost",
+            "out.json",
+            False,
+        )
+        assert "--cluster-mode" not in cmd_str, (
+            f"--cluster-mode must NOT be injected when oss_cluster_api_enabled=False "
+            f"for {spec_path}"
+        )
+
+
+def test_standalone_mode_no_cluster_flag():
+    """Standalone test suites must never get --cluster-mode injected."""
+    from redis_benchmarks_specification.__self_contained_coordinator__.clients import (
+        prepare_memtier_benchmark_parameters,
+    )
+
+    spec_path = (
+        "./redis_benchmarks_specification/test-suites/"
+        "memtier_benchmark-1Mkeys-100B-expire-use-case.yml"
+    )
+    with open(spec_path, "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+
+    _, cmd_str = prepare_memtier_benchmark_parameters(
+        benchmark_config["clientconfig"],
+        "memtier_benchmark",
+        6379,
+        "localhost",
+        "out.json",
+        False,
+    )
+    assert "--cluster-mode" not in cmd_str
 
 
 def test_spin_docker_cluster_redis():

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -19,6 +19,8 @@ from redis_benchmarks_specification.__common__.spec import (
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator import (
     self_contained_coordinator_blocking_read,
+)
+from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     start_redis_container,
 )
 

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -705,9 +705,9 @@ def test_spin_docker_cluster_redis():
             cluster_info = conn.execute_command("CLUSTER", "INFO")
             if isinstance(cluster_info, bytes):
                 cluster_info = cluster_info.decode()
-            assert "cluster_state:ok" in cluster_info, (
-                f"Node {i} (port {primary_port + i}) not in cluster_state:ok"
-            )
+            assert (
+                "cluster_state:ok" in cluster_info
+            ), f"Node {i} (port {primary_port + i}) not in cluster_state:ok"
 
         # Verify all 16384 slots are covered
         cluster_info = cluster_conns[0].execute_command("CLUSTER", "INFO")
@@ -720,9 +720,9 @@ def test_spin_docker_cluster_redis():
         if isinstance(nodes_raw, bytes):
             nodes_raw = nodes_raw.decode()
         node_lines = [l for l in nodes_raw.strip().split("\n") if l.strip()]
-        assert len(node_lines) == 3, (
-            f"Expected 3 nodes in CLUSTER NODES, got {len(node_lines)}"
-        )
+        assert (
+            len(node_lines) == 3
+        ), f"Expected 3 nodes in CLUSTER NODES, got {len(node_lines)}"
 
         # Verify we can write a key (it should route to the right shard)
         cluster_conns[0].set("test_cluster_key", "value")

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -724,8 +724,13 @@ def test_spin_docker_cluster_redis():
             len(node_lines) == 3
         ), f"Expected 3 nodes in CLUSTER NODES, got {len(node_lines)}"
 
-        # Verify we can write a key (it should route to the right shard)
-        cluster_conns[0].set("test_cluster_key", "value")
+        # Verify we can write a key using a cluster-aware client
+        rc = redis.RedisCluster(
+            host="localhost", port=primary_port, password=redis_password
+        )
+        rc.set("test_cluster_key", "value")
+        assert rc.get("test_cluster_key") == b"value"
+        rc.close()
 
         # Shutdown all nodes
         for conn in cluster_conns:

--- a/utils/tests/test_self_contained_coordinator_memtier.py
+++ b/utils/tests/test_self_contained_coordinator_memtier.py
@@ -1453,7 +1453,6 @@ def test_self_contained_coordinator_duplicated_ts():
         pass
 
 
-
 def test_self_contained_coordinator_dockerhub_cluster():
     """End-to-end test: spin up a 3-primary Redis cluster via the coordinator
     and run a memtier_benchmark SET workload with --cluster-mode."""
@@ -1562,16 +1561,12 @@ def test_self_contained_coordinator_dockerhub_cluster():
 
             # Verify cluster-specific deployment name in TimeSeries keys
             all_keys = datasink_conn.keys("*")
-            cluster_keys = [
-                k.decode() for k in all_keys if b"oss-cluster" in k
-            ]
+            cluster_keys = [k.decode() for k in all_keys if b"oss-cluster" in k]
             assert len(cluster_keys) > 0, (
                 "Expected TimeSeries keys with 'oss-cluster' deployment, "
                 f"but found none. All keys: {[k.decode() for k in all_keys]}"
             )
-            logging.info(
-                "Found {} cluster TimeSeries keys".format(len(cluster_keys))
-            )
+            logging.info("Found {} cluster TimeSeries keys".format(len(cluster_keys)))
 
     except redis.exceptions.ConnectionError:
         pass

--- a/utils/tests/test_self_contained_coordinator_memtier.py
+++ b/utils/tests/test_self_contained_coordinator_memtier.py
@@ -1451,3 +1451,127 @@ def test_self_contained_coordinator_duplicated_ts():
 
     except redis.exceptions.ConnectionError:
         pass
+
+
+
+def test_self_contained_coordinator_dockerhub_cluster():
+    """End-to-end test: spin up a 3-primary Redis cluster via the coordinator
+    and run a memtier_benchmark SET workload with --cluster-mode."""
+    try:
+        if run_coordinator_tests_dockerhub():
+            db_port = int(os.getenv("DATASINK_PORT", "6379"))
+            conn = redis.StrictRedis(port=db_port)
+            conn.ping()
+            conn.flushall()
+
+            id = "dockerhub"
+            redis_version = "8.0.0"
+            run_image = f"redis:{redis_version}"
+            build_arch = "amd64"
+            testDetails = {}
+            build_os = "test_build_os"
+            build_stream_fields, result = generate_benchmark_stream_request(
+                id,
+                conn,
+                run_image,
+                build_arch,
+                testDetails,
+                build_os,
+                git_version=redis_version,
+            )
+            build_stream_fields["mnt_point"] = ""
+            if result is True:
+                arch_specific_stream = get_arch_specific_stream_name(build_arch)
+                benchmark_stream_id = conn.xadd(
+                    arch_specific_stream, build_stream_fields
+                )
+                logging.info(
+                    "Successfully requested a new cluster run {}. Stream id: {}".format(
+                        build_stream_fields, benchmark_stream_id
+                    )
+                )
+
+            build_variant_name = "gcc:15.2.0-amd64-debian-bookworm-default"
+            expected_datapoint_ts = None
+
+            arch_specific_stream = get_arch_specific_stream_name(build_arch)
+            assert conn.exists(arch_specific_stream)
+            assert conn.xlen(arch_specific_stream) > 0
+            running_platform = "fco-ThinkPad-T490"
+
+            build_runners_consumer_group_create(
+                conn, running_platform, arch=build_arch, id="0"
+            )
+            datasink_conn = redis.StrictRedis(port=db_port)
+            docker_client = docker.from_env()
+            home = str(Path.home())
+            stream_id = ">"
+            topologies_map = get_topologies(
+                "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+            )
+            testsuite_spec_files = [
+                "./utils/tests/test_data/test-suites/test-memtier-dockerhub-cluster.yml"
+            ]
+            defaults_filename = "./utils/tests/test_data/test-suites/defaults.yml"
+            (
+                _,
+                _,
+                default_metrics,
+                _,
+                _,
+                _,
+            ) = get_defaults(defaults_filename)
+
+            (
+                result,
+                stream_id,
+                number_processed_streams,
+                num_process_test_suites,
+            ) = self_contained_coordinator_blocking_read(
+                conn,
+                True,
+                docker_client,
+                home,
+                stream_id,
+                datasink_conn,
+                testsuite_spec_files,
+                topologies_map,
+                running_platform,
+                False,
+                [],
+                "",
+                0,
+                7379,  # Use port 7379 to avoid conflicts with datasink
+                1,
+                False,
+                5,
+                default_metrics,
+                "amd64",
+                None,
+                0,
+                10000,
+                "unstable",
+                "",
+                True,
+                False,
+            )
+
+            assert result == True
+            assert number_processed_streams == 1
+            assert num_process_test_suites == 1
+
+            # Verify cluster-specific deployment name in TimeSeries keys
+            all_keys = datasink_conn.keys("*")
+            cluster_keys = [
+                k.decode() for k in all_keys if b"oss-cluster" in k
+            ]
+            assert len(cluster_keys) > 0, (
+                "Expected TimeSeries keys with 'oss-cluster' deployment, "
+                f"but found none. All keys: {[k.decode() for k in all_keys]}"
+            )
+            logging.info(
+                "Found {} cluster TimeSeries keys".format(len(cluster_keys))
+            )
+
+    except redis.exceptions.ConnectionError:
+        pass

--- a/utils/tests/test_topologies.py
+++ b/utils/tests/test_topologies.py
@@ -74,8 +74,8 @@ def test_cluster_topologies_have_type_oss_cluster():
     )
     for name, spec in topologies_map.items():
         if name.startswith("oss-cluster-"):
-            assert spec["type"] == "oss-cluster", (
-                f"Topology {name} should have type 'oss-cluster', got '{spec['type']}'"
-            )
+            assert (
+                spec["type"] == "oss-cluster"
+            ), f"Topology {name} should have type 'oss-cluster', got '{spec['type']}'"
             assert extract_primary_count(topologies_map, name) >= 3
             assert extract_replica_count(topologies_map, name) == 0

--- a/utils/tests/test_topologies.py
+++ b/utils/tests/test_topologies.py
@@ -1,6 +1,7 @@
 from redis_benchmarks_specification.__common__.spec import (
     extract_redis_configuration_from_topology,
     extract_replica_count,
+    extract_primary_count,
 )
 from redis_benchmarks_specification.__setups__.topologies import get_topologies
 
@@ -44,3 +45,37 @@ def test_extract_replica_count_with_io_threads():
         )
         == 1
     )
+
+
+def test_extract_primary_count():
+    topologies_map = get_topologies(
+        "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+    )
+    assert extract_primary_count(topologies_map, "oss-standalone") == 1
+    assert extract_primary_count(topologies_map, "oss-cluster-3-primaries") == 3
+    assert extract_primary_count(topologies_map, "oss-cluster-5-primaries") == 5
+    assert extract_primary_count(topologies_map, "oss-cluster-9-primaries") == 9
+    assert extract_primary_count(topologies_map, "oss-cluster-15-primaries") == 15
+    assert extract_primary_count(topologies_map, "oss-cluster-30-primaries") == 30
+
+
+def test_extract_primary_count_defaults_to_one():
+    """If redis_topology or primaries key is missing, default to 1."""
+    topologies_map = {
+        "custom-topo": {"type": "oss-standalone", "resources": {}},
+    }
+    assert extract_primary_count(topologies_map, "custom-topo") == 1
+
+
+def test_cluster_topologies_have_type_oss_cluster():
+    """All oss-cluster-* topologies must have type 'oss-cluster'."""
+    topologies_map = get_topologies(
+        "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+    )
+    for name, spec in topologies_map.items():
+        if name.startswith("oss-cluster-"):
+            assert spec["type"] == "oss-cluster", (
+                f"Topology {name} should have type 'oss-cluster', got '{spec['type']}'"
+            )
+            assert extract_primary_count(topologies_map, name) >= 3
+            assert extract_replica_count(topologies_map, name) == 0


### PR DESCRIPTION
- Add extract_primary_count() to spec.py
- Add spin_docker_cluster_redis() to docker.py: starts N Redis instances with cluster-enabled, CLUSTER MEET, distributes 16384 slots in batches of 500, polls cluster_state:ok with 60s timeout
- Branch on setup_type=='oss-cluster' in self_contained_coordinator.py for server startup and pass cluster mode to memtier
- Accept oss_cluster_api_enabled in data_prepopulation_step() so preload runs with --cluster-mode
- Fix dead cluster branch in runners.py with working spin_docker_cluster_redis
- Add cluster test suite YAMLs for GET and SET workloads
- Add unit tests for extract_primary_count, generate_cluster_redis_server_args, cluster YAML validation, and Docker integration test for 3-primary cluster
- Add end-to-end coordinator test: dockerhub cluster benchmark

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core benchmark orchestration (container lifecycle, Redis startup, and client command generation) and adds multi-node cluster coordination, which could cause flaky runs or resource/port conflicts if edge cases aren’t covered.
> 
> **Overview**
> Adds support for running benchmarks against *OSS Redis Cluster* topologies by introducing `extract_primary_count` and a new Docker orchestration path (`spin_docker_cluster_redis`) that boots multiple primaries, performs `CLUSTER MEET`, assigns slots, and waits for `cluster_state:ok`.
> 
> Updates both `self_contained_coordinator.py` and `runners.py` to branch on topology `type: oss-cluster`, run preload/benchmark clients with memtier `--cluster-mode`, and adjust shutdown/PID/replication-metric collection to handle multiple primaries. Adds new cluster memtier test-suite YAMLs plus expanded unit/integration/E2E tests, and bumps package version to `0.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adde750530f5670500092ff6c9c86a4026907a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->