### PR TITLE
stream 70-30 benchmark: use --test-time 120 for stable variance

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-aggressive-gc.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-aggressive-gc.yml
@@ -1,12 +1,12 @@
 version: 0.4
-name: memtier_benchmark-stream-50-cgroups-xadd-xtrim-gc
+name: memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-aggressive-gc
 description: >
-  Tests stream GC/compaction overhead with 50 consumer groups.
-  Pre-loads 100K stream entries and creates 50 consumer groups, each reading all entries into their PEL.
-  The benchmark runs 50% XADD, 20% XREADGROUP (advancing min_cgroup_last_id), and 30% XTRIM MAXLEN ~ 50000.
-  XREADGROUP is critical — without it min_cgroup_last_id never advances and streamEntryIsReferenced()
-  short-circuits before reaching the PEL scan. With active consumption, trimmed entries fall through
-  to the O(C) PEL scan across all 50 consumer groups.
+  Tests stream GC cleanup under aggressive trimming with 50 consumer groups and populated PELs.
+  Pre-loads 100K stream entries, creates 50 consumer groups, and reads all entries into
+  each group's PEL. The benchmark runs 50% XADD, 20% XREADGROUP (advancing min_cgroup_last_id),
+  and 30% XTRIM MAXLEN ~ 1000 to force frequent GC compaction.
+  XREADGROUP advances min_cgroup_last_id so trimmed entries fall through to the O(C) PEL scan
+  across all 50 groups — stressing streamEntryIsReferenced() and streamCleanupEntryCGroupRefs().
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -121,7 +121,7 @@ dbconfig:
     requests:
       memory: 4g
   dataset_name: stream-100k-entries-50-consumer-groups-full-pel
-  dataset_description: A stream with 100K entries and 50 consumer groups, each with all 100K entries in their PEL (unacked). Stresses GC compaction PEL scan with many groups.
+  dataset_description: A stream with 100K entries and 50 consumer groups with fully populated PELs (all 100K entries each), designed to stress GC compaction PEL scan with many groups.
 tested-commands:
   - xadd
   - xreadgroup
@@ -141,7 +141,7 @@ clientconfig:
     --data-size 100
     --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=50
     --command="XREADGROUP GROUP cg-01 consumer1 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=20
-    --command="XTRIM stream-key MAXLEN ~ 50000" --command-key-pattern="P" --command-ratio=30
+    --command="XTRIM stream-key MAXLEN ~ 1000" --command-key-pattern="P" --command-ratio=30
     --hide-histogram
     --test-time 120
     -c 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-gc.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-gc.yml
@@ -1,12 +1,12 @@
 version: 0.4
-name: memtier_benchmark-stream-50-cgroups-xadd-xtrim-aggressive-gc
+name: memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-gc
 description: >
-  Tests stream GC cleanup under aggressive trimming with 50 consumer groups and populated PELs.
-  Pre-loads 100K stream entries, creates 50 consumer groups, and reads all entries into
-  each group's PEL. The benchmark runs 50% XADD, 20% XREADGROUP (advancing min_cgroup_last_id),
-  and 30% XTRIM MAXLEN ~ 1000 to force frequent GC compaction.
-  XREADGROUP advances min_cgroup_last_id so trimmed entries fall through to the O(C) PEL scan
-  across all 50 groups — stressing streamEntryIsReferenced() and streamCleanupEntryCGroupRefs().
+  Tests stream GC/compaction overhead with 50 consumer groups.
+  Pre-loads 100K stream entries and creates 50 consumer groups, each reading all entries into their PEL.
+  The benchmark runs 50% XADD, 20% XREADGROUP (advancing min_cgroup_last_id), and 30% XTRIM MAXLEN ~ 50000.
+  XREADGROUP is critical — without it min_cgroup_last_id never advances and streamEntryIsReferenced()
+  short-circuits before reaching the PEL scan. With active consumption, trimmed entries fall through
+  to the O(C) PEL scan across all 50 consumer groups.
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -121,7 +121,7 @@ dbconfig:
     requests:
       memory: 4g
   dataset_name: stream-100k-entries-50-consumer-groups-full-pel
-  dataset_description: A stream with 100K entries and 50 consumer groups with fully populated PELs (all 100K entries each), designed to stress GC compaction PEL scan with many groups.
+  dataset_description: A stream with 100K entries and 50 consumer groups, each with all 100K entries in their PEL (unacked). Stresses GC compaction PEL scan with many groups.
 tested-commands:
   - xadd
   - xreadgroup
@@ -141,7 +141,7 @@ clientconfig:
     --data-size 100
     --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=50
     --command="XREADGROUP GROUP cg-01 consumer1 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=20
-    --command="XTRIM stream-key MAXLEN ~ 1000" --command-key-pattern="P" --command-ratio=30
+    --command="XTRIM stream-key MAXLEN ~ 50000" --command-key-pattern="P" --command-ratio=30
     --hide-histogram
     --test-time 120
     -c 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xtrim-aggressive-gc.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xtrim-aggressive-gc.yml
@@ -2,11 +2,11 @@ version: 0.4
 name: memtier_benchmark-stream-50-cgroups-xadd-xtrim-aggressive-gc
 description: >
   Tests stream GC cleanup under aggressive trimming with 50 consumer groups and populated PELs.
-  Pre-loads 100K stream entries, creates 50 consumer groups, and reads 2000 entries into
-  each group's PEL. The benchmark runs 70% XADD and 30% XTRIM MAXLEN ~ 1000 to force
-  frequent GC compaction over entries that are still referenced in PELs.
-  This stresses streamEntryIsReferenced() and streamCleanupEntryCGroupRefs() which must
-  scan all 50 groups' PELs per entry — the key trade-off of removing the cgroups_ref index.
+  Pre-loads 100K stream entries, creates 50 consumer groups, and reads all entries into
+  each group's PEL. The benchmark runs 50% XADD, 20% XREADGROUP (advancing min_cgroup_last_id),
+  and 30% XTRIM MAXLEN ~ 1000 to force frequent GC compaction.
+  XREADGROUP advances min_cgroup_last_id so trimmed entries fall through to the O(C) PEL scan
+  across all 50 groups — stressing streamEntryIsReferenced() and streamCleanupEntryCGroupRefs().
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -67,63 +67,64 @@ dbconfig:
     - XGROUP CREATE stream-key cg-48 0
     - XGROUP CREATE stream-key cg-49 0
     - XGROUP CREATE stream-key cg-50 0
-    - XREADGROUP GROUP cg-01 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-02 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-03 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-04 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-05 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-06 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-07 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-08 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-09 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-10 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-11 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-12 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-13 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-14 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-15 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-16 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-17 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-18 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-19 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-20 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-21 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-22 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-23 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-24 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-25 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-26 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-27 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-28 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-29 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-30 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-31 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-32 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-33 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-34 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-35 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-36 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-37 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-38 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-39 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-40 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-41 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-42 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-43 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-44 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-45 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-46 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-47 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-48 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-49 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-50 consumer1 COUNT 2000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-01 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-02 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-03 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-04 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-05 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-06 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-07 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-08 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-09 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-10 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-11 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-12 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-13 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-14 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-15 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-16 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-17 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-18 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-19 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-20 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-21 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-22 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-23 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-24 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-25 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-26 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-27 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-28 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-29 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-30 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-31 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-32 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-33 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-34 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-35 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-36 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-37 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-38 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-39 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-40 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-41 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-42 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-43 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-44 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-45 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-46 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-47 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-48 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-49 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-50 consumer1 COUNT 100000 STREAMS stream-key >
   resources:
     requests:
       memory: 4g
-  dataset_name: stream-100k-entries-50-consumer-groups
-  dataset_description: A stream with 100K entries and 50 consumer groups with populated PELs (2000 entries each), designed to stress GC compaction with many groups.
+  dataset_name: stream-100k-entries-50-consumer-groups-full-pel
+  dataset_description: A stream with 100K entries and 50 consumer groups with fully populated PELs (all 100K entries each), designed to stress GC compaction PEL scan with many groups.
 tested-commands:
   - xadd
+  - xreadgroup
   - xtrim
 tested-groups:
   - stream
@@ -138,7 +139,8 @@ clientconfig:
   tool: memtier_benchmark
   arguments: >
     --data-size 100
-    --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=70
+    --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=50
+    --command="XREADGROUP GROUP cg-01 consumer1 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=20
     --command="XTRIM stream-key MAXLEN ~ 1000" --command-key-pattern="P" --command-ratio=30
     --hide-histogram
     --test-time 120

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xtrim-gc.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-50-cgroups-xadd-xtrim-gc.yml
@@ -2,10 +2,11 @@ version: 0.4
 name: memtier_benchmark-stream-50-cgroups-xadd-xtrim-gc
 description: >
   Tests stream GC/compaction overhead with 50 consumer groups.
-  Pre-loads 100K stream entries and creates 50 consumer groups, each reading a portion of entries into their PEL.
-  The benchmark then runs 70% XADD (producing new entries) and 30% XTRIM MAXLEN ~ 50000 (triggering GC).
-  This stresses the streamEntryIsReferenced() path which must scan all 50 consumer groups' PELs
-  during compaction — the key trade-off of removing the cgroups_ref index.
+  Pre-loads 100K stream entries and creates 50 consumer groups, each reading all entries into their PEL.
+  The benchmark runs 50% XADD, 20% XREADGROUP (advancing min_cgroup_last_id), and 30% XTRIM MAXLEN ~ 50000.
+  XREADGROUP is critical — without it min_cgroup_last_id never advances and streamEntryIsReferenced()
+  short-circuits before reaching the PEL scan. With active consumption, trimmed entries fall through
+  to the O(C) PEL scan across all 50 consumer groups.
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -66,63 +67,64 @@ dbconfig:
     - XGROUP CREATE stream-key cg-48 0
     - XGROUP CREATE stream-key cg-49 0
     - XGROUP CREATE stream-key cg-50 0
-    - XREADGROUP GROUP cg-01 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-02 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-03 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-04 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-05 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-06 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-07 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-08 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-09 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-10 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-11 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-12 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-13 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-14 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-15 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-16 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-17 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-18 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-19 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-20 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-21 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-22 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-23 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-24 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-25 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-26 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-27 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-28 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-29 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-30 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-31 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-32 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-33 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-34 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-35 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-36 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-37 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-38 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-39 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-40 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-41 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-42 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-43 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-44 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-45 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-46 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-47 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-48 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-49 consumer1 COUNT 2000 STREAMS stream-key >
-    - XREADGROUP GROUP cg-50 consumer1 COUNT 2000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-01 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-02 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-03 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-04 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-05 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-06 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-07 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-08 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-09 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-10 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-11 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-12 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-13 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-14 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-15 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-16 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-17 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-18 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-19 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-20 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-21 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-22 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-23 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-24 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-25 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-26 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-27 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-28 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-29 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-30 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-31 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-32 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-33 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-34 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-35 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-36 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-37 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-38 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-39 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-40 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-41 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-42 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-43 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-44 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-45 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-46 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-47 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-48 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-49 consumer1 COUNT 100000 STREAMS stream-key >
+    - XREADGROUP GROUP cg-50 consumer1 COUNT 100000 STREAMS stream-key >
   resources:
     requests:
       memory: 4g
-  dataset_name: stream-100k-entries-50-consumer-groups
-  dataset_description: A stream with 100K entries and 50 consumer groups, designed to stress GC compaction with many groups.
+  dataset_name: stream-100k-entries-50-consumer-groups-full-pel
+  dataset_description: A stream with 100K entries and 50 consumer groups, each with all 100K entries in their PEL (unacked). Stresses GC compaction PEL scan with many groups.
 tested-commands:
   - xadd
+  - xreadgroup
   - xtrim
 tested-groups:
   - stream
@@ -137,7 +139,8 @@ clientconfig:
   tool: memtier_benchmark
   arguments: >
     --data-size 100
-    --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=70
+    --command="XADD stream-key * field __data__" --command-key-pattern="P" --command-ratio=50
+    --command="XREADGROUP GROUP cg-01 consumer1 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=20
     --command="XTRIM stream-key MAXLEN ~ 50000" --command-key-pattern="P" --command-ratio=30
     --hide-histogram
     --test-time 120

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30.yml
@@ -2,8 +2,8 @@ version: 0.4
 name: memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30
 description:
   Starting with a pre-loaded stream of 500K entries, the benchmark tests concurrent stream operations with a consumer group for distributed processing.
-  70% of commands produce messages with XADD, while 30% consume with XREADGROUP COUNT 10.
-  500K initial entries plus 200K * 70% minus 200K * 10 * (15% + 15%) ≈ 40K left in the stream at the end.
+  70% of commands produce messages with XADD, while 30% consume with XREADGROUP COUNT 10 (split across 2 consumers).
+  Uses --test-time 120 for steady-state measurement and stable variance.
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -38,7 +38,7 @@ clientconfig:
     --command="XREADGROUP GROUP producer-consumer-group consumer1 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=15
     --command="XREADGROUP GROUP producer-consumer-group consumer2 COUNT 10 STREAMS stream-key >" --command-key-pattern="P" --command-ratio=15
     --hide-histogram
-    -n 1000
+    --test-time 120
     -c 50
     -t 4
   resources:


### PR DESCRIPTION
Replace `-n 1000` with `--test-time 120` to ensure steady-state measurement.

With `-n 1000` (200K total requests at ~127K ops/s), the test finishes in ~1-2 seconds, making it extremely sensitive to startup jitter — observed **99.6% std.dev** across runs on ARM.

The `1k-consumers` variant of this same test already uses `--test-time 120` and achieves **0.1% variance**.

### Change
- `-n 1000` → `--test-time 120` (120-second steady-state run)
- Updated description to reflect the new measurement mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark YAML specifications (no runtime code changes), with primary impact being longer and more stressful benchmark runs that may affect CI/resource usage.
> 
> **Overview**
> Adds two new stream GC-focused memtier benchmark specs (`memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xtrim-{gc,aggressive-gc}.yml`) that fully populate 50 consumer-group PELs and include a 50/20/30 mix of `XADD`/`XREADGROUP`/`XTRIM` to force GC compaction under active consumption.
> 
> Replaces the previous `stream-50-cgroups` `xadd`+`xtrim`-only suites (which only preloaded 2k PEL entries) and updates `memtier_benchmark-stream-concurrent-xadd-xreadgroup-70-30.yml` to run for `--test-time 120` (instead of `-n 1000`) with refreshed description for steadier measurements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5996773712ee1682d9dbc8d4a1b78a7e0abb8338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->