### PR TITLE
fix(coordinator): tolerate 409 on container.remove() during teardown

### DIFF
--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -620,6 +620,52 @@ from redis_benchmarks_specification.__self_contained_coordinator__.docker import
 )
 
 
+def stop_and_remove_container_safe(container, label):
+    """Stop and remove a Docker container, tolerating concurrent removal.
+
+    Cluster primaries and replicas (and a few other spin-up helpers) start
+    their containers with ``auto_remove=True`` so Docker cleans them up
+    automatically when they stop. That creates a race with the explicit
+    ``.remove()`` call this teardown makes: if Docker's auto-removal has
+    already begun, the API returns ``409 Conflict`` ("removal of container
+    X is already in progress") and the docker-py client raises
+    ``docker.errors.APIError``. Treat that as a success — the container is
+    being removed anyway.
+
+    ``docker.errors.NotFound`` (404) likewise means the container was
+    already removed (either by auto-remove completing, or by a previous
+    teardown pass) and is also a benign outcome.
+    """
+    try:
+        container.stop()
+        container.remove()
+    except docker.errors.NotFound:
+        logging.info(
+            "When trying to stop {} container with id {} and image {} it was already stopped".format(
+                label, container.id, container.image
+            )
+        )
+    except docker.errors.APIError as e:
+        # Docker returns 409 on a concurrent remove; explicit string match
+        # because docker-py doesn't expose a dedicated subclass for this.
+        msg = str(e)
+        if "already in progress" in msg or "removal of container" in msg:
+            logging.info(
+                "{} container {} (image {}) is already being removed by Docker "
+                "(auto_remove=True). Skipping explicit remove.".format(
+                    label, container.id, container.image
+                )
+            )
+            return
+        # Any other API error: log but don't propagate — teardown must not
+        # abort the stream (we've already ACK'd it).
+        logging.warning(
+            "Unexpected Docker APIError while removing {} container {}: {}".format(
+                label, container.id, e
+            )
+        )
+
+
 def main():
     global _exclusive_hardware, _http_auth_username, _http_auth_password
 
@@ -2490,8 +2536,6 @@ def process_self_contained_coordinator_stream(
                                                 stdout=True, stderr=True
                                             )
                                         )
-                                        redis_container.stop()
-                                        redis_container.remove()
                                     except docker.errors.NotFound:
                                         logging.info(
                                             "When trying to fetch logs from DB container with id {} and image {} it was already stopped".format(
@@ -2499,7 +2543,12 @@ def process_self_contained_coordinator_stream(
                                                 redis_container.image,
                                             )
                                         )
-                                    pass
+                                    # Use the safe helper so Docker's own
+                                    # auto_remove race (409 Conflict) doesn't
+                                    # abort the log-collection path.
+                                    stop_and_remove_container_safe(
+                                        redis_container, "DB"
+                                    )
 
                                     print("-" * 60)
 
@@ -2528,31 +2577,15 @@ def process_self_contained_coordinator_stream(
                             logging.info("Tearing down setup")
                             if docker_keep_env is False:
                                 for redis_container in redis_containers:
-                                    try:
-                                        redis_container.stop()
-                                        redis_container.remove()
-                                    except docker.errors.NotFound:
-                                        logging.info(
-                                            "When trying to stop DB container with id {} and image {} it was already stopped".format(
-                                                redis_container.id,
-                                                redis_container.image,
-                                            )
-                                        )
-                                        pass
+                                    stop_and_remove_container_safe(
+                                        redis_container, "DB"
+                                    )
 
                                 for redis_container in client_containers:
                                     if type(redis_container) == Container:
-                                        try:
-                                            redis_container.stop()
-                                            redis_container.remove()
-                                        except docker.errors.NotFound:
-                                            logging.info(
-                                                "When trying to stop Client container with id {} and image {} it was already stopped".format(
-                                                    redis_container.id,
-                                                    redis_container.image,
-                                                )
-                                            )
-                                            pass
+                                        stop_and_remove_container_safe(
+                                            redis_container, "Client"
+                                        )
 
                                 # Only remove temporary directories if test passed
                                 if test_result:

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -19,6 +19,7 @@ from redis_benchmarks_specification.__common__.spec import (
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator import (
     self_contained_coordinator_blocking_read,
+    stop_and_remove_container_safe,
 )
 from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
     start_redis_container,
@@ -839,3 +840,103 @@ def test_spin_docker_cluster_redis():
                 c.remove()
             except Exception:
                 pass
+
+
+def test_stop_and_remove_container_safe_not_found():
+    """NotFound (container already gone) is treated as success."""
+
+    class FakeContainer:
+        id = "fake-id"
+        image = "fake-image"
+
+        def stop(self):
+            raise docker.errors.NotFound("container gone")
+
+        def remove(self):
+            raise AssertionError("remove() should not be called after NotFound")
+
+    # Must not raise.
+    stop_and_remove_container_safe(FakeContainer(), "Test")
+
+
+def test_stop_and_remove_container_safe_409_already_in_progress():
+    """Regression test for v0.3.0 oss-cluster-3-primaries teardown race.
+
+    When a container is started with ``auto_remove=True`` (which the
+    cluster spin-up helpers do for primaries and replicas), Docker begins
+    removing the container automatically when it stops. The explicit
+    ``.remove()`` call that this coordinator makes a moment later hits a
+    409 Conflict with body "removal of container X is already in
+    progress". docker-py raises ``docker.errors.APIError`` rather than
+    ``NotFound``, and previously this aborted the entire stream
+    processing — the coordinator logged the traceback and silently
+    ACK'd the stream as "filtered/skipped", so 0/N benchmark runs
+    actually produced data.
+
+    The helper must swallow that specific 409 path and let teardown
+    complete.
+    """
+
+    class FakeAPIError(docker.errors.APIError):
+        def __init__(self):
+            super().__init__(
+                "409 Client Error: Conflict",
+                response=None,
+                explanation=(
+                    "removal of container abc123 is already in progress"
+                ),
+            )
+
+        def __str__(self):
+            return (
+                "409 Client Error for http+docker://localhost/v1.47/"
+                "containers/abc123?v=False&link=False&force=False: "
+                'Conflict ("removal of container abc123 is already in '
+                'progress")'
+            )
+
+    calls = {"stop": 0, "remove": 0}
+
+    class FakeContainer:
+        id = "abc123"
+        image = "fake-image"
+
+        def stop(self):
+            calls["stop"] += 1
+
+        def remove(self):
+            calls["remove"] += 1
+            raise FakeAPIError()
+
+    # Must not raise.
+    stop_and_remove_container_safe(FakeContainer(), "DB")
+    assert calls["stop"] == 1
+    assert calls["remove"] == 1
+
+
+def test_stop_and_remove_container_safe_other_api_error_is_swallowed():
+    """Unexpected APIError is logged but not raised — teardown is best-effort."""
+
+    class FakeAPIError(docker.errors.APIError):
+        def __init__(self):
+            super().__init__(
+                "500 Internal Server Error",
+                response=None,
+                explanation="boom",
+            )
+
+        def __str__(self):
+            return "500 Internal Server Error: boom"
+
+    class FakeContainer:
+        id = "zzz"
+        image = "fake-image"
+
+        def stop(self):
+            pass
+
+        def remove(self):
+            raise FakeAPIError()
+
+    # Must not raise — teardown must never abort the stream.
+    stop_and_remove_container_safe(FakeContainer(), "Client")


### PR DESCRIPTION
## Summary

Regression from v0.3.0 (cluster topology PR #373). The cluster spin-up path starts primaries with `auto_remove=True`, so Docker begins removing the container as soon as `.stop()` returns. The explicit `.remove()` call in coordinator teardown then races and gets `409 Conflict` with body *"removal of container X is already in progress"*.

`docker-py` raises `docker.errors.APIError` (not `NotFound`) for that 409, so the existing `except docker.errors.NotFound` didn't catch it. The unhandled exception bubbled up, the coordinator logged the traceback, and silently ACK'd the stream as "filtered/skipped" — **0/N benchmark runs produced any data.**

## Reproduction (from production `oss-builder` / `x86-aws-m7i.metal-24xl`, 2026-04-22)

```
docker.errors.APIError: 409 Client Error for
http+docker://localhost/v1.47/containers/7ded858f.../?...:
Conflict ("removal of container 7ded858f... is already in progress")

2026-04-22 08:21:55 INFO Successfully acknowledged BENCHMARK
variation stream with id 1776845864383-0 (filtered/skipped).
```

The scoped benchmark for PR #15018 (7 string tests) returned `0/7` after 1.6h because every `oss-cluster-3-primaries` topology teardown tripped this path.

## Fix

Introduce `stop_and_remove_container_safe(container, label)` in `self_contained_coordinator.py`:

- `NotFound` → success (as before).
- `APIError` with message containing *"already in progress"* or *"removal of container"* → benign INFO log, return success.
- Any other `APIError` → WARNING log but no re-raise. Teardown is best-effort and must never abort stream processing after we've ACK'd.

Use the helper from both teardown sites — the main teardown loop and the test-failure log-collection block.

## Tests

Three unit tests in `utils/tests/test_self_contained_coordinator.py`, all passing without a Docker daemon:

1. `test_stop_and_remove_container_safe_not_found` — NotFound path still works.
2. `test_stop_and_remove_container_safe_409_already_in_progress` — regression test for this specific bug; `FakeAPIError` subclass reproduces the 409 message shape.
3. `test_stop_and_remove_container_safe_other_api_error_is_swallowed` — unexpected APIError doesn't abort teardown.

Existing builder test suite (6 tests) also passes.

## Test plan
- [x] 3 new unit tests pass locally
- [x] `utils/tests/test_builder.py` suite (6/6) unaffected
- [ ] Deploy to `x86-aws-m7i.metal-24xl` after merge and re-trigger the blocked PR #15018 benchmark scoped to `oss-standalone` (already done as a workaround) and to `oss-cluster-3-primaries` (to verify the 409 path is now tolerated)

## Severity
High for any benchmark that includes a cluster-topology test. Every cluster run aborts on teardown, emits no data, and leaves stale `topologies_running` entries in the admin CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator teardown/error paths around Docker lifecycle; logic is small but affects whether benchmark streams complete and can mask unexpected Docker API issues if message matching is too broad.
> 
> **Overview**
> Adds `stop_and_remove_container_safe()` to treat `docker.errors.NotFound` and the common `409 Conflict` “removal already in progress” `APIError` as benign during teardown, logging and continuing instead of aborting.
> 
> Replaces direct `stop()`/`remove()` calls in failure log-collection and normal teardown loops with the helper, and adds unit tests covering `NotFound`, the 409 regression case, and other `APIError` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75715cfa96e4210320fb8ee193c39a1a307c7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->