### PR TITLE
fix(coordinator): wrap per-test PR comment update in try/except

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.2"
+version = "0.3.3"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -2652,26 +2652,42 @@ def process_self_contained_coordinator_stream(
                         benchmark_suite_duration.total_seconds()
                     )
 
-                    # update on github if needed
+                    # update on github if needed.
+                    # Wrap the whole block in try/except so a transient GitHub
+                    # API failure (rate limit, network, token expiry) does not
+                    # abort the per-test for-loop — a prior version propagated
+                    # the exception all the way up to the outer stream handler
+                    # at line ~2802, which treated the entire stream as failed
+                    # and left all remaining tests stuck in the "pending" list
+                    # forever. PR-comment updates are best-effort observability;
+                    # the benchmark results themselves are already pushed to
+                    # RedisTimeSeries at this point.
                     if is_actionable_pr:
-                        comment_body = generate_benchmark_started_pr_comment(
-                            stream_id,
-                            pending_tests,
-                            len(filtered_test_files),
-                            failed_tests,
-                            benchmark_suite_start_datetime,
-                            benchmark_suite_duration_secs,
-                        )
-                        update_comment_if_needed(
-                            auto_approve_github,
-                            comment_body,
-                            old_benchmark_run_comment_body,
-                            benchmark_run_comment,
-                            verbose,
-                        )
-                        logging.info(
-                            f"Updated github comment with latest test info {benchmark_run_comment.html_url}"
-                        )
+                        try:
+                            comment_body = generate_benchmark_started_pr_comment(
+                                stream_id,
+                                pending_tests,
+                                len(filtered_test_files),
+                                failed_tests,
+                                benchmark_suite_start_datetime,
+                                benchmark_suite_duration_secs,
+                            )
+                            update_comment_if_needed(
+                                auto_approve_github,
+                                comment_body,
+                                old_benchmark_run_comment_body,
+                                benchmark_run_comment,
+                                verbose,
+                            )
+                            logging.info(
+                                f"Updated github comment with latest test info {benchmark_run_comment.html_url}"
+                            )
+                        except Exception as e:
+                            logging.warning(
+                                "Failed to update per-test PR comment for stream {} test {}: {}. Continuing with remaining tests.".format(
+                                    stream_id, test_name, e
+                                )
+                            )
 
                         ###########################
                         # regression part


### PR DESCRIPTION
## Summary

When processing a benchmark stream for a PR, the coordinator's outer per-test loop updates the GitHub PR comment after each test completes (`self_contained_coordinator.py` ~L2665). The call to `update_comment_if_needed()` was **unwrapped**, so any transient GitHub API failure (rate limit, DNS, token expiry, intermittent 5xx) would:

1. escape the `for test_file in filtered_test_files:` loop;
2. be caught by the outer handler at L2802 which logs *"Some unexpected exception was caught during local work on stream … Failing test…"* and sets `overall_result=False`;
3. ACK the stream as fully processed with remaining tests still on the `tests_pending` / `topologies_pending` lists — **stuck forever.**

## Reproduction (2026-04-22, `x86-aws-m7i.metal-24xl`)

| Stream | Args | Tests done | Note |
|---|---|---|---|
| PR #14934 (sundb:reply_bytes_ref) | `--pull-request 14934` | **1 of 6** | 5 tests never ran |
| PR #15018 (hw-clock) | `--pull-request 15018` | **1 of 7** | 6 tests never ran |
| PR #14934 **base** `c77d60d6b8` | no `--pull-request` | **6 of 6** ✅ | reference run, GitHub path skipped |

Signal is clean: only streams where `is_actionable_pr=True` (which gates the comment-update branch) exhibit the bug. Streams with no attached PR ran to completion.

Sundb had been re-triggering the full 355-test suite repeatedly (5+ runs in 1 hour, all stuck at 1/355) for this reason.

## Fix

Wrap the entire `if is_actionable_pr:` block around `update_comment_if_needed()` in try/except that logs a `WARNING` and continues to the next test. PR-comment updates are **best-effort observability** — the benchmark results themselves are already in RedisTimeSeries by the time this block runs, so suppressing the exception does not lose data.

The sibling `prepare_regression_comment()` path a few lines below was already wrapped in try/except (L2761) presumably for the same reason. This commit brings the `update_comment_if_needed()` path into line with that convention.

## Companion to #376
The builder-side analogue (`container.remove()` 409 → silent "filtered/skipped" ACK) was fixed in #376 / v0.3.1. This is the same class of bug on the coordinator side: unwrapped external-API call inside a per-item loop → entire stream gets nuked when the first call fails.

## Also
Bumps version to 0.3.3.

## Test plan
- [x] Existing `test_self_contained_coordinator.py` suite passes (3/3 unit tests including `stop_and_remove_container_safe_*` ).
- [x] Syntax check on modified file passes.
- [ ] Deploy to fleet after merge; re-trigger PR #14934 and #15018 scoped benchmarks to verify they run to completion (vs. bailing at 1/N).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinator control flow to swallow exceptions from GitHub PR comment updates; low code churn but it affects stream/test execution reliability and could hide failures if logging is missed.
> 
> **Overview**
> Prevents benchmark streams from getting prematurely marked failed (leaving remaining tests stuck pending) by wrapping the per-test GitHub PR comment update (`update_comment_if_needed`) in a `try/except` and continuing execution on failure.
> 
> Also bumps the Poetry package version from `0.3.2` to `0.3.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a28ce1c2c18fdf6a033f6be47cb240494d12c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->