### PR TITLE
fix(coordinator): correct compute_regression_table args + wrap in try/except

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.3"
+version = "0.3.4"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -2732,44 +2732,77 @@ def process_self_contained_coordinator_stream(
                         to_ts_ms = None
                         from_ts_ms = None
 
-                        (
-                            detected_regressions,
-                            table_output,
-                            improvement_list,
-                            regressions_list,
-                            total_stable,
-                            total_unstable,
-                            total_comparison_points,
-                        ) = compute_regression_table(
-                            datasink_conn,
-                            tf_github_org,
-                            tf_github_repo,
-                            tf_triggering_env,
-                            metric_name,
-                            comparison_branch,
-                            baseline_branch,
-                            None,  # we only compare by branch on CI automation
-                            None,  # we only compare by branch on CI automation
-                            baseline_deployment_name,
-                            comparison_deployment_name,
-                            print_improvements_only,
-                            print_regressions_only,
-                            skip_unstable,
-                            regressions_percent_lower_limit,
-                            simplify_table,
-                            test,
-                            testname_regex,
-                            verbose,
-                            last_n_baseline,
-                            last_n_comparison,
-                            metric_mode,
-                            from_date,
-                            from_ts_ms,
-                            to_date,
-                            to_ts_ms,
-                            use_metric_context_path,
-                            running_platform,
-                        )
+                        # Use keyword arguments — the function signature has
+                        # `tf_triggering_env_baseline` and `tf_triggering_env_comparison`
+                        # as two separate required positional args (no defaults),
+                        # and a long list of mostly-default args after. Passing
+                        # by position is error-prone: a prior version of this
+                        # call was off-by-one from position 5 onwards, which
+                        # routed `to_date` (a datetime) into the `from_ts_ms`
+                        # slot and triggered a TypeError in compare.py:1300
+                        # ("unsupported operand type(s) for /: 'datetime.datetime'
+                        # and 'int'") that aborted the per-test for-loop,
+                        # leaving subsequent tests stuck in `tests_pending`.
+                        #
+                        # Also wrapped in try/except so any future data-shape
+                        # issue in compute_regression_table does not abort the
+                        # outer per-test for-loop — the benchmark results are
+                        # already in RedisTimeSeries at this point, the
+                        # regression comment is best-effort observability.
+                        detected_regressions = []
+                        table_output = ""
+                        improvement_list = []
+                        regressions_list = []
+                        total_stable = 0
+                        total_unstable = 0
+                        total_comparison_points = 0
+                        try:
+                            (
+                                detected_regressions,
+                                table_output,
+                                improvement_list,
+                                regressions_list,
+                                total_stable,
+                                total_unstable,
+                                total_comparison_points,
+                            ) = compute_regression_table(
+                                rts=datasink_conn,
+                                tf_github_org=tf_github_org,
+                                tf_github_repo=tf_github_repo,
+                                tf_triggering_env_baseline=tf_triggering_env,
+                                tf_triggering_env_comparison=tf_triggering_env,
+                                metric_name=metric_name,
+                                comparison_branch=comparison_branch,
+                                baseline_branch=baseline_branch,
+                                baseline_tag=None,  # CI automation compares by branch
+                                comparison_tag=None,  # CI automation compares by branch
+                                baseline_deployment_name=baseline_deployment_name,
+                                comparison_deployment_name=comparison_deployment_name,
+                                print_improvements_only=print_improvements_only,
+                                print_regressions_only=print_regressions_only,
+                                skip_unstable=skip_unstable,
+                                regressions_percent_lower_limit=regressions_percent_lower_limit,
+                                simplify_table=simplify_table,
+                                test=test,
+                                testname_regex=testname_regex,
+                                verbose=verbose,
+                                last_n_baseline=last_n_baseline,
+                                last_n_comparison=last_n_comparison,
+                                metric_mode=metric_mode,
+                                from_date=from_date,
+                                from_ts_ms=from_ts_ms,
+                                to_date=to_date,
+                                to_ts_ms=to_ts_ms,
+                                use_metric_context_path=use_metric_context_path,
+                                running_platform_baseline=running_platform,
+                                running_platform_comparison=running_platform,
+                            )
+                        except Exception as e:
+                            logging.warning(
+                                "compute_regression_table failed for stream {} test {}: {}. Skipping regression comment, continuing with remaining tests.".format(
+                                    stream_id, test_name, e
+                                )
+                            )
                         total_regressions = len(regressions_list)
                         total_improvements = len(improvement_list)
                         auto_approve = True


### PR DESCRIPTION
## Summary

Two compounding bugs on the same code path; either one aborts the per-test for-loop and strands remaining tests in `tests_pending`.

### 1. Positional-argument mismatch in `compute_regression_table`
The function signature (compare.py:1239) has **two** required positional args: `tf_triggering_env_baseline` AND `tf_triggering_env_comparison`. The coordinator was passing only one, shifting every subsequent positional argument by one. That routed `to_date` (a `datetime.datetime`) into the `from_ts_ms` slot, and compare.py:1300 then does:

```python
dt.datetime.utcfromtimestamp(from_ts_ms / 1000)
```

→ `TypeError: unsupported operand type(s) for /: 'datetime.datetime' and 'int'`

The exception propagated out of the per-test `for`-loop, was caught by the outer handler (*"Some unexpected exception was caught during local work on stream … Failing test…"*), and ACK'd the stream with remaining tests stuck.

**Fix:** switch to keyword arguments for the whole call. Self-documenting, and immune to future signature drift.

### 2. `compute_regression_table` is unwrapped
It's an external-dependency-heavy call (RedisTimeSeries, label matching, a long tail of data-shape assumptions). Wrapping it in try/except follows the existing defensive pattern used around `prepare_regression_comment` and (since v0.3.3) `update_comment_if_needed`. Initialize all seven tuple outputs before the try so the downstream `prepare_regression_comment` still has valid state when compute fails.

## Reproduction (2026-04-22, `x86-aws-m7i.metal-24xl`, coordinator v0.3.3)

PR #14934 (sundb:reply_bytes_ref) — first test completed successfully (v0.3.3's `update_comment_if_needed` wrap held), then:

```
2026-04-22 14:37:53 CRITICAL Exception type: TypeError
2026-04-22 14:37:53 CRITICAL Exception message:
  unsupported operand type(s) for /: 'datetime.datetime' and 'int'
  File ".../compare.py", line 1300, in compute_regression_table
    dt.datetime.utcfromtimestamp(from_ts_ms / 1000)
2026-04-22 14:37:53 INFO Successfully acknowledged BENCHMARK variation
                          stream with id 1776868444999-0 (filtered/skipped).
```

→ 1 of 6 tests completed, 5 stuck.

## Companion to #377

#377 (v0.3.3) wrapped `update_comment_if_needed`. #376 (v0.3.1) wrapped `container.remove()`. This PR wraps the third and last unprotected external call on the per-test path: `compute_regression_table`. Same class of bug, same fix pattern.

## Test plan
- [x] Syntax check on modified file passes.
- [x] Existing `test_self_contained_coordinator.py` unit tests pass (3/3).
- [ ] Deploy to fleet. Re-trigger PR #14934 / #15018 scoped benchmarks and confirm full 6-of-6 / 7-of-7 completion (no more 1/N stuck).

Bumps version to **0.3.4**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the self-contained coordinator’s per-test reporting path; while behavior change is localized, it affects CI completion/PR commenting and could mask regressions if the new exception handler is too broad.
> 
> **Overview**
> Fixes the coordinator’s call to `compute_regression_table` by switching from positional to keyword arguments (including the separate `tf_triggering_env_baseline`/`tf_triggering_env_comparison` params) to prevent misrouted values and TypeErrors that could abort the per-test loop.
> 
> Makes regression-table generation *best-effort* by initializing default outputs and wrapping the call in `try/except`, logging a warning and continuing with remaining tests instead of leaving tests stuck in `tests_pending`. Also bumps package version to `0.3.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13da8a9aaaa6d0a59cd441f8c0f5e747b40029e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->