### PR TITLE
Add two EMBSTR-layout validation specs (APPEND conversion, mixed-encoding GET)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.4"
+version = "0.3.5"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata
+description: "Append-path benchmark used to validate the EMBSTR -> RAW conversion
+  cost introduced when robj layout changes (e.g. Valkey PR 2516, and any Redis
+  equivalent that packs small values into the robj itself). Preloads 1M keys as
+  10B EMBSTR (well under the 44B threshold), then runs APPEND ops that push each
+  key over the threshold on first touch, forcing the encoding conversion. Uses
+  --random-data to exercise realistic allocator behaviour rather than all-zero
+  pages."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 10 --random-data --ratio 1:0 --key-pattern P:P --key-minimum=1
+      --key-maximum 1000000 --test-time 60 -c 4 -t 1 --hide-histogram
+    timeout: 600
+  resources:
+    requests:
+      memory: 1g
+tested-commands:
+- append
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--command "APPEND __key__ __data__" --command-key-pattern R --data-size
+    40 --random-data --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50
+    -t 4 --hide-histogram'
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
@@ -21,10 +21,10 @@ dbconfig:
   resources:
     requests:
       memory: 1g
+tested-groups:
+- string
 tested-commands:
 - append
-test-groups:
-- string
 redis-topologies:
 - oss-standalone
 build-variants:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
@@ -23,6 +23,8 @@ dbconfig:
       memory: 1g
 tested-commands:
 - append
+test-groups:
+- string
 redis-topologies:
 - oss-standalone
 build-variants:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
@@ -25,6 +25,8 @@ dbconfig:
       memory: 1g
 tested-commands:
 - get
+test-groups:
+- string
 redis-topologies:
 - oss-standalone
 build-variants:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
@@ -1,0 +1,39 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata
+description: "High-pipeline GET benchmark against a DB with mixed EMBSTR/RAW
+  encodings. Preload uses --data-size-range 10-200 with --data-size-pattern R
+  so value sizes are uniformly random, producing ~17% EMBSTR (values <=44B)
+  and ~83% RAW. Exercises the common-case read path across both encodings so
+  that any EMBSTR-layout change (e.g. Valkey-style robj ptr reuse) can be
+  checked for regressions on the dominant RAW path and on the hot GET dispatch
+  branch. --random-data is used so allocator behaviour reflects realistic byte
+  patterns rather than all-zero pages."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size-range 10-200 --data-size-pattern R --random-data --ratio
+      1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 90
+      -c 4 -t 1 --hide-histogram
+    timeout: 600
+  resources:
+    requests:
+      memory: 1g
+tested-commands:
+- get
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 1000000
+    --test-time 180 -c 50 -t 4 --pipeline 100 --random-data --hide-histogram
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
@@ -23,10 +23,10 @@ dbconfig:
   resources:
     requests:
       memory: 1g
+tested-groups:
+- string
 tested-commands:
 - get
-test-groups:
-- string
 redis-topologies:
 - oss-standalone
 build-variants:


### PR DESCRIPTION
## Summary

Adds two benchmark specs that exercise code paths the plain 10B load test doesn't cover when validating a robj-layout change that packs small values into the robj header (see e.g. Valkey PR #2516).

### 1. `memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata`

Preloads 1M keys as 10B EMBSTR (well under the 44B threshold), then runs APPEND 40B per op. First APPEND to each key pushes the total over the threshold and forces `OBJ_ENCODING_EMBSTR → OBJ_ENCODING_RAW` encoding conversion (`zmalloc + memcpy + zfree`). Subsequent APPENDs on the same key just extend the RAW buffer. The benchmark therefore measures a realistic mix of **conversion cost + non-conversion extension cost** — exactly what a layout-change PR needs to be validated against.

### 2. `memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata`

Preloads 1M keys with values in the 10–200B range (uniform random size via `--data-size-range 10-200 --data-size-pattern R`), producing ~17% EMBSTR and ~83% RAW. Then runs high-pipeline GET over random keys. Exercises the common-case read path **across both encodings** so any EMBSTR-only layout change can be checked for regressions on the dominant RAW path and on the GET encoding-dispatch branch.

### Design notes

- Both specs pass `--random-data` so allocator behaviour reflects realistic byte patterns rather than all-zero pages.
- Topology: `oss-standalone` only — these measure encoding-specific behaviour, not IO-thread interaction.
- Priority 50, same as the rest of the 10B / 100B string load suite.

### Also
Bumps version to 0.3.5.

## Test plan
- [x] YAML lint / parse check.
- [ ] Deploy to fleet. Run vs Valkey `9f7cfc771` (pre-#2516) and `0ee4234506` (post-#2516) on `x86-aws-m8i.24xlarge` + `arm-aws-m8g.metal-24xl`, 3dp per side. If memory reduction holds AND no APPEND / RAW-GET regression, we greenlight a scoped Redis-side PoC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new benchmark suite YAMLs and bumps the package version, with no changes to runtime logic or APIs.
> 
> **Overview**
> Adds two new `memtier_benchmark` test-suite specs targeting string encoding edge cases: an `APPEND` workload that forces **EMBSTR→RAW** conversion when values cross the 44B threshold, and a high-pipeline `GET` workload over a mixed EMBSTR/RAW dataset (both using `--random-data`).
> 
> Bumps the project version in `pyproject.toml` from `0.3.4` to `0.3.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abccc1c11b23fdce092851e85356168e0c351a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->