### PR TITLE
Add 10M-keys EMBSTR validation spec (DRAM-bound sibling of 1M)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.5"
+version = "0.3.6"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata.yml
@@ -1,0 +1,37 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata
+description: "Loads 10M string keys with 10B random-data values, all EMBSTR
+  encoding. Sister spec to the 1M variant for validating robj-layout changes
+  (e.g. Valkey-#2516-style ptr reuse): at 10M keys the total dataset + robj
+  overhead is ~600MB, so the keyspace no longer fits in any CPU's L3 cache
+  and every dict lookup pays DRAM latency. This is where the throughput
+  impact of pointer chasing in robj actually surfaces - the 1M variant is
+  L3-resident on large servers (m7i/m8i >= 60MB L3, m8g >= 36MB SLC) and
+  therefore underestimates the cache-miss cost. Memory reduction ratios
+  from the layout change are the same as the 1M variant, but the absolute
+  delta scales 10x. --random-data so allocator behaviour reflects realistic
+  byte patterns rather than all-zero pages."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 0
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- string
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --data-size 10 --random-data --ratio 1:0 --key-pattern P:P --key-minimum=1
+    --key-maximum 10000000 --test-time 300 -c 50 -t 4 --hide-histogram
+priority: 50


### PR DESCRIPTION
## Summary

Adds `memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata`, the DRAM-bound sibling of `memtier_benchmark-1Mkeys-load-string-with-10B-values` for validating robj-layout changes (e.g. Valkey #2516).

## Why

The 1M variant at 10B values produces a dataset of ~32 MB and total `used_memory` of ~66 MB. Large-server L3 caches easily contain this:

| CPU | L3 / SLC | 1M × 10B fits? |
|---|---|---|
| Xeon 8488C (m7i / m8i) | 60–120 MB | **yes, fully** |
| Graviton4 Neoverse V2 (m8g) | ~36 MB SLC | mostly (small spill) |

Throughput on the 1M variant therefore reflects the **L3-resident** case and under-counts the cost of pointer chasing in `robj`. The full cost only surfaces when every dict lookup pays DRAM latency — which is where a robj-layout change (packing inline data into the header) would actually show a throughput delta.

At **10M × 10B**, total `used_memory` scales to ~660 MB — DRAM-bound on every CPU in the fleet. Memory-reduction *ratios* from the layout change are identical to the 1M case; absolute bytes saved are 10×; throughput impact from cache-miss reduction becomes measurable.

## Spec details
- `--data-size 10 --random-data` (matches 1M variant's pattern)
- `--key-maximum 10000000 --test-time 300` (300s for load, vs 180s at 1M — needed so 10× the keyspace actually gets loaded)
- 2g memory requirement on the dbconfig

## Test plan
- [x] YAML parses.
- [ ] Deploy to m8i + m8g (the runners currently hosting the EMBSTR validation study).
- [ ] Run Valkey BEFORE (`9f7cfc771`) vs AFTER (`0ee4234506`) on both arches, 3dp, and compare `used_memory` and `Ops/sec` deltas vs the 1M variant to confirm the DRAM-bound hypothesis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new, much larger memtier benchmark (10M keys, 300s run, higher memory request) which may increase benchmark runtime and infrastructure resource usage. Otherwise changes are isolated to spec data and a patch version bump.
> 
> **Overview**
> Bumps `redis-benchmarks-specification` from `0.3.5` to `0.3.6`.
> 
> Adds a new test-suite YAML, `memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata`, to load **10M** string keys with **10B random-data** values (EMBSTR-focused), increasing the workload (`--key-maximum 10000000`, `--test-time 300`) and setting a higher DB memory request (`2g`) with adjusted priority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cf758791a0ba2f26b95ea57728ff3931f5a961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->