### PR TITLE
Add missing clientconfig.resources to EMBSTR validation specs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.6"
+version = "0.3.7"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata.yml
@@ -34,4 +34,8 @@ clientconfig:
   tool: memtier_benchmark
   arguments: --data-size 10 --random-data --ratio 1:0 --key-pattern P:P --key-minimum=1
     --key-maximum 10000000 --test-time 300 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 4g
 priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
@@ -37,4 +37,8 @@ clientconfig:
   arguments: '--command "APPEND __key__ __data__" --command-key-pattern R --data-size
     40 --random-data --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50
     -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
 priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
@@ -38,4 +38,8 @@ clientconfig:
   tool: memtier_benchmark
   arguments: --ratio 0:1 --key-pattern R:R --key-minimum=1 --key-maximum 1000000
     --test-time 180 -c 50 -t 4 --pipeline 100 --random-data --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
 priority: 50


### PR DESCRIPTION
## Summary

The 3 EMBSTR-layout validation specs added in v0.3.5 / v0.3.6 were missing `resources:` inside `clientconfig`, mirroring what the pre-existing `memtier_benchmark-1Mkeys-load-string-with-10B-values.yml` has. The coordinator at `self_contained_coordinator.py` does `clientconfig['resources']` unconditionally and raises `KeyError: 'resources'`, aborting the benchmark before it can collect data.

Observed in production today on `x86-aws-m8i.24xlarge` with the new 10M spec — every stream for the 3 new specs showed "DONE (1F)" with the coordinator logging:

```
2026-04-23 11:35:24 CRITICAL Exception type: KeyError
2026-04-23 11:35:24 CRITICAL Exception message: 'resources'
2026-04-23 11:35:24 WARNING Test failed. Preserving temporary dirs ...
```

## Fix

Add `resources.requests.cpus/memory` to `clientconfig` for all 3 specs, matching the format used by the long-standing specs.

Memory sized to the workload:
- `append-10B-to-40B-randomdata` (1M) → 2g client
- `get-mixed-embstr-raw-pipeline-100-randomdata` (1M, pipeline 100) → 2g client
- `10Mkeys-load-string-with-10B-values-randomdata` (10M) → 4g client

Bumps version to 0.3.7.

## Test plan
- [x] YAML parses.
- [ ] Deploy to m8i + m8g. Re-trigger the Valkey #2516 BEFORE vs AFTER matrix and confirm the benchmarks complete without the KeyError.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change: adds resource request fields to YAML specs and bumps the version, primarily preventing coordinator crashes and slightly affecting client scheduling/capacity.
> 
> **Overview**
> Updates the benchmark specification package to `0.3.7`.
> 
> Fixes three EMBSTR-focused `memtier_benchmark` test-suite YAMLs by adding `clientconfig.resources.requests` (CPU + memory) so code that reads `clientconfig["resources"]["requests"]["cpus"]` no longer fails at runtime and the benchmarks can execute with explicit client resource sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc316b7bf7567199d6d5eaac0047dff0feb7bc7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->