### PR TITLE
bump version to 0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.7"
+version = "0.3.8"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
Release 0.3.8 ships the 4 new stream GC coverage specs added in #382 (500 + 5000 CG XTRIM, 50 + 500 CG XADD+XDEL+XREADGROUP). Needed on the runner fleet before we can trigger the scale-gate validation for the remove-cgroups-ref work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change that affects packaging/versioning but not runtime behavior.
> 
> **Overview**
> Updates the project’s Poetry package version in `pyproject.toml` from `0.3.7` to `0.3.8` to cut the `0.3.8` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 034272486aa78477db2baf2b063189cc0b48e68b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->