### PR TITLE
add REV variant of 600K → 300K ZRANGESTORE spec (v0.3.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.8"
+version = "0.3.9"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-600K-elements-zrangestore-300K-elements-rev.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-600K-elements-zrangestore-300K-elements-rev.yml
@@ -1,0 +1,45 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-600K-elements-zrangestore-300K-elements-rev
+description: 'ZRANGESTORE REV variant of the 600K → 300K bulk-insert benchmark.
+  Source zset has 600,000 elements with floating-point scores; ZRANGESTORE pulls
+  the top 300,001 by REV and stores them into the destination. Encoding:
+  skiplist+hashtable (300,001 destination elements, exceeds zset-max-listpack-entries
+  128). Exercises the head-prepend bulk-insert fast path (predecessor at every
+  level is always zsl->header).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: -n allkeys "--data-size" "10" --key-prefix "" "--command" "ZADD zset
+      __key__ __key__" "--command-key-pattern" "P" "-c" "1" "-t" "1" "--hide-histogram"
+      "--key-minimum" "1" "--key-maximum" "600001" --pipeline 50
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-600K-elements-float
+  dataset_description: This dataset contains 1 sorted set key with 600,000 elements,
+    each with a floating-point score.
+tested-commands:
+- zrangestore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 -c 1 -t 1 --command "ZRANGESTORE zset1 zset 0 300000 REV"
+    --command-key-pattern="P" --key-minimum=1 --key-maximum 1 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 4g
+tested-groups:
+- sorted-set
+priority: 12


### PR DESCRIPTION
## Summary
- New benchmark spec `memtier_benchmark-1key-zset-600K-elements-zrangestore-300K-elements-rev.yml` that mirrors the existing forward 600K → 300K ZRANGESTORE bench, switching the command argument to `ZRANGESTORE zset1 zset 0 300000 REV`.
- Bumps `pyproject.toml` to `0.3.9` to match the spec addition.

The forward variant exists; this REV variant exercises a different code path: source iteration produces `(score, ele)` tuples in descending order, so the destination zset insert pattern is reversed. Encoding stays `skiplist+hashtable` (300,001 destination elements > `zset-max-listpack-entries 128`). Same `--test-time 120 -c 1 -t 1` setup as the forward spec, only the command differs.

## Test plan
- [x] `poetry run pytest utils/tests/test_spec.py` — 2 passed
- [x] `poetry run redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` — exit 0; no errors flagged for the new spec (only pre-existing `arring`/`arget` errors unrelated to this change)
- [x] Dry-run trigger against `redis/unstable` resolves the regex correctly to 1 distinct test
- [x] Manual fleet trigger end-to-end (m7i-2 + m8g-2) on the new spec verifies the command runs, RTS keys land, and results are stable across 3 dp/cell

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new benchmark spec YAML and bumps the package version, with no changes to runtime code paths beyond selecting the new test in CI/automation.
> 
> **Overview**
> Adds a new memtier benchmark spec for the **REV** variant of the 600K→300K `ZRANGESTORE` workload (same preload/setup as the existing forward spec, but runs `ZRANGESTORE ... REV` to exercise reverse-order bulk insert behavior).
> 
> Bumps the project version in `pyproject.toml` from `0.3.8` to `0.3.9` to reflect the new spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9360287bfc2f643a0ab16baa62016f6fc77660b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->