### PR TITLE
add 3 string SET-with-GET-option specs (EMBSTR + RAW coverage) — 0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.9"
+version = "0.3.10"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-set-with-get-option-10B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-set-with-get-option-10B.yml
@@ -1,0 +1,42 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-string-set-with-get-option-10B
+description: |
+  Targets the propagation rewrite path of the extended `SET key value GET` form
+  (no expire), exercising setGenericCommand() argv-strip in src/t_string.c that
+  removes trailing GET tokens before the command is propagated as a plain SET.
+  10M keyspace, 10-byte values (encoding ≤ 44 bytes => string OBJ_ENCODING_EMBSTR
+  for both the stored value and the value returned by the GET option). Pipeline
+  16 to maximize per-command overhead sensitivity.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "10000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 10Mkeys-string-10B-size
+  dataset_description: 10 million string keys with 10-byte EMBSTR values.
+tested-commands:
+- set
+tested-groups:
+- string
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--data-size 10 --command "SET __key__ __data__ GET" --command-key-pattern R --key-minimum 1 --key-maximum 10000000 --test-time 180 -c 50 -t 4 --pipeline 16 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-set-with-get-option-100B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-set-with-get-option-100B.yml
@@ -1,0 +1,42 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-set-with-get-option-100B
+description: |
+  Targets the propagation rewrite path of the extended `SET key value GET` form
+  (no expire), exercising setGenericCommand() argv-strip in src/t_string.c that
+  removes trailing GET tokens before the command is propagated as a plain SET.
+  1M keyspace, 100-byte values (encoding > 44 bytes => string OBJ_ENCODING_RAW
+  for both the stored value and the value returned by the GET option). Pipeline
+  16 to maximize per-command overhead sensitivity.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-100B-size
+  dataset_description: 1 million string keys with 100-byte RAW values.
+tested-commands:
+- set
+tested-groups:
+- string
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--data-size 100 --command "SET __key__ __data__ GET" --command-key-pattern R --key-minimum 1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --pipeline 16 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-set-with-get-option-1KB.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-set-with-get-option-1KB.yml
@@ -1,0 +1,45 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-set-with-get-option-1KB
+description: |
+  Targets the propagation rewrite path of the extended `SET key value GET` form
+  (no expire), exercising setGenericCommand() argv-strip in src/t_string.c that
+  removes trailing GET tokens before the command is propagated as a plain SET.
+  1M keyspace, 1000-byte values (encoding > 44 bytes => string OBJ_ENCODING_RAW
+  for both the stored value and the value returned by the GET option). At 1KB
+  the bytes-on-the-wire dominates more, so the per-command argv-strip win is
+  expected to dilute relative to the 10B/100B variants — useful as a
+  large-payload sanity bound. Pipeline 16 to maximize per-command overhead
+  sensitivity.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "1000" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-1KiB-size
+  dataset_description: 1 million string keys with 1 KiB RAW values.
+tested-commands:
+- set
+tested-groups:
+- string
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--data-size 1000 --command "SET __key__ __data__ GET" --command-key-pattern R --key-minimum 1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --pipeline 16 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1


### PR DESCRIPTION
## Summary
- Adds 3 new memtier specs that target the extended ``SET key value GET`` form (no expire), which exercises the propagation argv-strip path in ``setGenericCommand()`` (``src/t_string.c``).
- Existing string benchmarks issue **separate** SET and GET commands — none cover the ``SET ... GET`` option, so this code path was uninstrumented.
- Bumps version to ``0.3.10``.

## Specs added
| File | Keyspace | Value size | Encoding |
|---|---|---|---|
| ``memtier_benchmark-10Mkeys-string-set-with-get-option-10B`` | 10M | 10 B | EMBSTR (≤ 44 B) |
| ``memtier_benchmark-1Mkeys-string-set-with-get-option-100B`` | 1M | 100 B | RAW |
| ``memtier_benchmark-1Mkeys-string-set-with-get-option-1KB`` | 1M | 1 KB | RAW |

All three use ``--command "SET __key__ __data__ GET"`` with pipeline 16 and ``-c 50 -t 4`` to maximize per-command overhead sensitivity. Encoding is documented in each spec's ``description`` field.

## Why now
Validates an upcoming optimization to the ``SET ... GET`` propagation rewrite path in ``setGenericCommand()`` — the existing suite cannot detect a regression or improvement on this path because it was never exercised.

## Test plan
- [x] ``poetry run redis-benchmarks-spec-cli --tool stats --fail-on-required-diff`` passes locally
- [ ] CI: Validate SPEC fields (green required before merge)
- [ ] CI: tox (green required before merge)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only bumps the package version and adds new benchmark-spec YAMLs; main risk is CI/spec validation failures or increased benchmark resource usage.
> 
> **Overview**
> Bumps the spec package version to `0.3.10`.
> 
> Adds three new `memtier_benchmark` string test-suite specs that benchmark the extended `SET __key__ __data__ GET` command to cover the `SET ... GET` propagation/argv-strip path, with variants for 10M keys @ 10B (EMBSTR) and 1M keys @ 100B and 1KB (RAW), using pipelining to emphasize per-command overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1070c1ccd5afe7290b21fea9c6c24dfc12caac18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->