### PR TITLE
session-caching specs: replace Lua preload with memtier preload_tool + add pipeline=16 variant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.10"
+version = "0.3.11"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-session-caching-hash-100k-sessions-pipeline-16.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-session-caching-hash-100k-sessions-pipeline-16.yml
@@ -1,0 +1,80 @@
+version: 0.4
+name: memtier_benchmark-session-caching-hash-100k-sessions-pipeline-16
+description: 'Runs memtier_benchmark to simulate a session caching workload for a SaaS application,
+  with client-side pipelining of 16. This benchmark focuses exclusively on hash-based session
+  storage, where each session is stored in a Redis hash (`session:<id>`) with fields like user ID,
+  timestamps, device info, and metadata (total ~400–600B). The benchmark models a typical
+  read-heavy cache usage pattern, with an approximate **read:write ratio of 90:10**, reflecting
+  session retrievals and infrequent updates. Command groups: - Session cache reads (`HGETALL`):
+  ~90% - Session cache writes (`HSET`): ~10% To better approximate real-world access patterns, the
+  benchmark uses a **Zipfian key distribution** (`--command-key-pattern=Z`). This simulates
+  **skewed access** where a small subset of sessions (hot keys) receives a majority of reads — a
+  common pattern in production workloads. While Zipfian is technically a power-law distribution, it
+  effectively mimics **Poisson-like behavior** in large-scale systems, where access frequency is
+  uneven but statistically predictable. This access skew mirrors real-life scenarios such as: -
+  Frequently accessed or "sticky" user sessions - Popular user accounts or active devices - Hot
+  caches for trending or recently used resources Using Zipfian distribution allows this benchmark
+  to capture **contention**, **cache pressure**, and **read amplification** effects that occur in
+  real SaaS applications under load. Pipeline=16 amplifies per-call overhead reductions and stresses
+  reply-buffer / output-list paths. Encoding: hashtable (10 fields, metadata field ~200-300B
+  exceeds hash-max-listpack-value 64).'
+
+
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 100000
+  resources:
+    requests:
+      memory: 1g
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--key-prefix "" --command "HSET session:__key__ userId user-id
+      organizationId org-id role member createdAt 0 lastAccessed 0 ipAddress
+      192.168.1.1 device device authMethod password status active metadata
+      __data__" --command-key-pattern="P" --random-data --data-size-range=200-300
+      --key-minimum=1 --key-maximum=100001 -n allkeys -c 1 -t 1 --hide-histogram
+      --pipeline 50'
+
+tested-groups:
+- hash
+
+tested-commands:
+- hgetall
+- hset
+
+redis-topologies:
+- oss-standalone
+
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --key-prefix ""
+    --key-minimum 1
+    --key-maximum 100000
+    --data-size-range=400-600
+    --pipeline=16
+    --print-percentiles=50,90,95,99
+    --run-count=1
+    --test-time=120
+    --command="HGETALL session:__key__"
+    --command-key-pattern=Z
+    --command-ratio=90
+    --command="HSET session:__key__ userId user-__key__ organizationId org-__key__ role admin email user__key__@example.com name \"User __key__\" permissions \"[\\\"read\\\",\\\"write\\\"]\" lastActivity __key__ ipAddress 192.168.1.__key__ userAgent \"Mozilla/5.0\" createdAt __key__"
+    --command-key-pattern=Z
+    --command-ratio=10
+    --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+
+priority: 150

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-session-caching-hash-100k-sessions.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-session-caching-hash-100k-sessions.yml
@@ -21,40 +21,20 @@ description: 'Runs memtier_benchmark to simulate a session caching workload for 
 dbconfig:
   configuration-parameters:
     save: '""'
+  check:
+    keyspacelen: 100000
   resources:
     requests:
       memory: 1g
-  init_lua: |
-    local seed = 12345
-    math.randomseed(seed)
-    local now = tonumber(redis.call('TIME')[1])
-    local function rand_str(len)
-      local chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-      local res = ''
-      for i = 1, len do
-        local idx = math.random(#chars)
-        res = res .. chars:sub(idx, idx)
-      end
-      return res
-    end
-    for i = 1, 100000 do
-      local session_id = 'session:' .. i
-      local user_id = 'user-' .. i
-      local org_id = 'org-' .. i
-      redis.call('HSET', session_id,
-        'userId', user_id,
-        'organizationId', org_id,
-        'role', 'member',
-        'createdAt', tostring(now - math.random(3600)),
-        'lastAccessed', tostring(now),
-        'ipAddress', '192.168.1.' .. (i % 255),
-        'device', 'device-' .. rand_str(8),
-        'authMethod', 'password',
-        'status', 'active',
-        'metadata', rand_str(200 + (i % 100))
-      )
-    end
-    return 'OK'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--key-prefix "" --command "HSET session:__key__ userId user-id
+      organizationId org-id role member createdAt 0 lastAccessed 0 ipAddress
+      192.168.1.1 device device authMethod password status active metadata
+      __data__" --command-key-pattern="P" --random-data --data-size-range=200-300
+      --key-minimum=1 --key-maximum=100001 -n allkeys -c 1 -t 1 --hide-histogram
+      --pipeline 50'
 
 tested-groups:
 - hash


### PR DESCRIPTION
## Summary

- Replace the `init_lua` block in `memtier_benchmark-playbook-session-caching-hash-100k-sessions.yml` with a `dbconfig.preload_tool` that uses `memtier_benchmark` with `--random-data` and `--data-size-range=200-300`. This removes the need for a Lua preload step and aligns this spec with the standard memtier-preload idiom used elsewhere (e.g. `memtier_benchmark-1Mkeys-hash-hkeys-10-fields-with-10B-values-with-expiration-pipeline-10.yml`).
- Add a pipeline=16 variation (`memtier_benchmark-playbook-session-caching-hash-100k-sessions-pipeline-16.yml`) to amplify per-call overhead and exercise reply-buffer / output-list paths.
- Add `check.keyspacelen: 100000` sanity gate (previously absent).

## Why

- The Lua-based prepopulation depended on EVAL semantics inside the runner and could not benefit from memtier's connection pipelining; replacing it with `preload_tool` makes the load step roughly an order of magnitude faster (~250k HSET/s observed locally) and keeps the loader the same tool used during the benchmark itself.
- A single pipeline=1 datapoint isn't sufficient to capture per-call overhead reductions in HGETALL/HSET; a pipeline=16 variant lets the spec catch improvements (or regressions) that only show up under batched I/O.

## Notes on the memtier preload command

- `__key__` substitutes the *next* key on every occurrence within a single command, so multi-`__key__` HSET commands fragment writes across the keyspace. The new preload uses `__key__` only once (HSET target) and short literal values for the other 9 fields; only `metadata` carries `__data__` (random 200–300B). This keeps total payload in the documented ~400–600B range and forces hashtable encoding (metadata > 64B).
- `--key-prefix ""` is required so keys land at `session:1..session:100000` (matching the client config), not the default `memtier-` prefix.
- `--key-maximum=100001` with `-n allkeys` is a small off-by-one workaround to ensure exactly 100,000 keys are populated (default `-n allkeys` over `[1, N]` produces `N-1` requests).

## Test plan

- [x] Local preload + `redis-cli dbsize` = 100000, no gaps in `session:1..session:100000`.
- [x] Sampled hashes: `hlen=10`, `object encoding = hashtable`, metadata length 200–300B random.
- [x] Local 10s client run: ~122k ops/sec, 90/10 HGETALL/HSET ratio, DBSIZE stable.
- [x] `black --check` clean, `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` exits 0.
- [ ] CI: Validate SPEC fields + tox tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates benchmark spec YAMLs and a version bump, but it can change benchmark setup/perf characteristics and required keyspace validation behavior.
> 
> **Overview**
> Updates the session-caching hash benchmark spec to **replace Lua-based preloading** with a `dbconfig.preload_tool` that seeds 100k session hashes via `memtier_benchmark` (including `--random-data` payload sizing) and adds a `check.keyspacelen: 100000` sanity gate.
> 
> Adds a new **pipeline=16** variant of the same workload to measure the impact of client-side pipelining on the read-heavy `HGETALL`/`HSET` mix.
> 
> Bumps package version from `0.3.10` to `0.3.11`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 499d94579b67bea4ab37d6c512bbeea8a3ff71b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->