### PR TITLE
add 7 multi-tenant tagged-keyname specs at 10M scale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.11"
+version = "0.3.12"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-generic-expire-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-generic-expire-multitenant-tagged.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-generic-expire-multitenant-tagged
+description: 'EXPIRE on long-keyname multi-tenant tagged keys at 10M scale.
+  Each key is named {T:N}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 (~78-char SDS, RAW
+  encoding) with a unique hash tag per key. Preloaded with 100B random
+  string values via SET, then EXPIRE applied with TTL=7200 (the dominant
+  TTL value seen in tagged rolling-window analytics workloads). Stresses
+  EXPIRE on long-SDS keys (~6x more bytes hashed per dict lookup vs the
+  default memtier-N prefix used by the sister 1Mkeys-generic-expire spec)
+  at 10x the keyspace, exercising the keyspace + TTL hash table combined
+  memory layout.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--data-size 100 --random-data --key-prefix ""
+      --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- generic
+tested-commands:
+- expire
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "EXPIRE {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 7200"
+    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
+    --test-time 180 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml
@@ -3,12 +3,12 @@ name: memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged
 description: 'Mixed INCRBY+EXPIRE workload on long-keyname multi-tenant
   tagged keys at 10M scale. Models the realistic per-event write pair seen
   in tagged rolling-window analytics workloads: a counter increment paired
-  with a TTL refresh on the same keyspace. memtier picks INCRBY or EXPIRE
-  per request (~50/50 by default with two --command flags), so over the
-  test window every key is hit by both command types but not necessarily
-  in pairs on the same key. Stresses the combined dict + TTL hash table
-  paths under long-keyname load. Sister to the standalone INCRBY and
-  EXPIRE specs in this family.'
+  with a TTL refresh on the same keyspace. The INCRBY:EXPIRE command-ratio
+  is set to 9:20 to match observed traffic (INCRBY ~18%, EXPIRE ~40%
+  of total commands). Over the test window every key is hit by both
+  command types but not necessarily in pairs on the same key. Stresses
+  the combined dict + TTL hash table paths under long-keyname load.
+  Sister to the standalone INCRBY and EXPIRE specs in this family.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -41,8 +41,10 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: --command "INCRBY {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 1"
+    --command-ratio 9 --command-key-pattern "R"
     --command "EXPIRE {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 7200"
-    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
+    --command-ratio 20 --command-key-pattern "R"
+    --key-prefix "" --key-minimum=1 --key-maximum=10000000
     --test-time 180 -c 50 -t 4 --hide-histogram
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml
@@ -1,0 +1,51 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged
+description: 'Mixed INCRBY+EXPIRE workload on long-keyname multi-tenant
+  tagged keys at 10M scale. Models the realistic per-event write pair seen
+  in tagged rolling-window analytics workloads: a counter increment paired
+  with a TTL refresh on the same keyspace. memtier picks INCRBY or EXPIRE
+  per request (~50/50 by default with two --command flags), so over the
+  test window every key is hit by both command types but not necessarily
+  in pairs on the same key. Stresses the combined dict + TTL hash table
+  paths under long-keyname load. Sister to the standalone INCRBY and
+  EXPIRE specs in this family.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--key-prefix ""
+      --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 0"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- string
+- generic
+tested-commands:
+- incrby
+- expire
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "INCRBY {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 1"
+    --command "EXPIRE {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 7200"
+    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
+    --test-time 180 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-1000-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-1000-multitenant-tagged.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-string-incrby-1000-multitenant-tagged
+description: 'INCRBY 1000 on long-keyname multi-tenant tagged sum keys at
+  10M scale. Sister spec to 10Mkeys-string-incrby-multitenant-tagged; differs
+  only in the increment magnitude (1000 vs 1) to model the second mode of
+  the workload distribution: counter keys take INCRBY 1 (~60% of INCRBYs)
+  while sum keys take INCRBY of variable larger values (~40%, range
+  100-10000, median ~1000). Both modes hit the same fast int-encoding
+  code path; the larger value tests the path where the result string
+  representation lengthens over the lifetime of a key.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--key-prefix ""
+      --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 0"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- string
+tested-commands:
+- incrby
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "INCRBY {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 1000"
+    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
+    --test-time 180 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-multitenant-tagged.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-string-incrby-multitenant-tagged
+description: 'INCRBY 1 on long-keyname multi-tenant tagged counter keys at
+  10M scale. Each key is named {T:N}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 (~38-char
+  SDS) with a unique hash tag per key, preloaded to "0" so the value is
+  INT-encoded (OBJ_ENCODING_INT). Test phase issues INCRBY 1 against random
+  keys, exercising the unsigned-long fast path of t_string.c:incrCommand
+  on long-keyname dict lookups. Stresses: (a) long-SDS dict lookup with
+  ~6x more bytes hashed/compared per request vs the default short-prefix
+  sister spec 1Mkeys-string-incrby, (b) 5x larger keyspace.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--key-prefix ""
+      --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 0"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- string
+tested-commands:
+- incrby
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "INCRBY {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 1"
+    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
+    --test-time 180 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
@@ -1,0 +1,85 @@
+version: 0.4
+name: memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged
+description: 'Multi-tenant tagged-keyname MGET shape. 10M flat string keys,
+  each named
+  {T:N}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+  (~78-char SDS, RAW encoding) with a unique hash tag per key. MGET 80
+  keys per call. Models structured long-keyname multi-tenant counter
+  fan-out reads at scale. Stresses: (a) MGET reply aggregation for 80
+  keys, (b) dict lookup with long-SDS keys (~6x more bytes hashed/compared
+  per lookup vs the default memtier-N prefix used by sister 5Mkeys-mget
+  specs), (c) per-key kvobj+keyname memory at 10M scale.
+  Caveat: memtier __key__ rotates per occurrence, so each MGET reads 80
+  keys belonging to 80 different tenants (sequential tenant IDs). For
+  oss-standalone this is equivalent in dict-access cost to per-tenant
+  fan-out; cluster topologies would not model hash-tag slot co-location.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--data-size 100 --random-data --key-prefix ""
+      --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- string
+tested-commands:
+- mget
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "MGET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6"
+    --key-prefix "" --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+    --test-time 180 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
@@ -75,7 +75,14 @@ clientconfig:
     {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
     {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
     {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
-    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6"
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
+    {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6"
     --key-prefix "" --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
     --test-time 180 -c 50 -t 4 --hide-histogram
   resources:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
@@ -83,7 +83,7 @@ clientconfig:
     {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
     {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6
     {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6"
-    --key-prefix "" --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
     --test-time 180 -c 50 -t 4 --hide-histogram
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values.yml
@@ -42,7 +42,7 @@ clientconfig:
   tool: memtier_benchmark
   arguments: --test-time 180 --data-size 10 --random-data --key-prefix ""
     --command "PFADD {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
-    --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
+    --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
     -c 50 -t 4 --hide-histogram
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values.yml
@@ -42,7 +42,7 @@ clientconfig:
   tool: memtier_benchmark
   arguments: --test-time 180 --data-size 10 --random-data --key-prefix ""
     --command "PFADD {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
-    --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+    --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
     -c 50 -t 4 --hide-histogram
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values.yml
@@ -1,0 +1,51 @@
+version: 0.4
+name: memtier_benchmark-multiple-hll-pfadd-10Mkeys-10B-values
+description: '10M HyperLogLog keys, all in sparse encoding (default
+  hll-sparse-max-bytes=3000). Each HLL has a long structured tagged keyname
+  ({T:N}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6,
+  ~78-char SDS) with a unique hash tag per key. Preloads each key with a
+  single 10B random element via PFADD, then runs steady-state PFADD with
+  random 10B elements across the full keyspace. Targets the hllSparseAdd
+  update path on a large multi-tenant keyspace with realistic long
+  keynames (matches p99 of structured analytics workloads). At 10M keys
+  with ~78-char keynames the keyspace exceeds any CPU L3, so every dict
+  lookup pays DRAM latency, and SipHash processes ~6x more bytes per
+  lookup than the default short-prefix sister specs.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--data-size 10 --random-data --key-prefix ""
+      --command "PFADD {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- hyperloglog
+tested-commands:
+- pfadd
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 180 --data-size 10 --random-data --key-prefix ""
+    --command "PFADD {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
+    --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+    -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 61

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfcount-1key-10Mkeys-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfcount-1key-10Mkeys-multitenant-tagged.yml
@@ -1,0 +1,50 @@
+version: 0.4
+name: memtier_benchmark-multiple-hll-pfcount-1key-10Mkeys-multitenant-tagged
+description: 'Single-key PFCOUNT on long-keyname multi-tenant tagged sparse
+  HyperLogLogs at 10M scale. Each HLL is named
+  {T:N}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 (~78-char SDS) with a unique hash tag
+  per key, preloaded with a single 10B random element via PFADD so all
+  HLLs hold sparse encoding (default hll-sparse-max-bytes=3000). Test phase
+  issues PFCOUNT against random keys (single-key form, the dominant shape
+  observed in tagged rolling-window analytics workloads — multi-key
+  PFCOUNT is rare in this access pattern). Stresses the sparse HLL
+  cardinality estimation path on long-keyname dict lookups, complementary
+  to the existing 3-key multiple-hll-pfcount-100B-values spec which
+  exercises the multi-key PFCOUNT merge path on dense HLLs.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '--data-size 10 --random-data --key-prefix ""
+      --command "PFADD {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
+    timeout: 3600
+  resources:
+    requests:
+      memory: 8g
+tested-groups:
+- hyperloglog
+tested-commands:
+- pfcount
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "PFCOUNT {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6"
+    --key-prefix "" --command-key-pattern="R" --key-minimum=1 --key-maximum=10000000
+    --test-time 180 -c 50 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 8g
+priority: 50


### PR DESCRIPTION
## Summary

Adds 7 benchmark specs that exercise a workload pattern not currently covered: each key carries a unique hash-tag prefix plus a long structured suffix, mimicking multi-tenant rolling-window analytics keynames.

Key shape used across all 7 specs:
\`{T:N}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6\` (~78-char SDS, RAW encoding)

This exercises ~6× more bytes hashed/compared per dict lookup than the default short \`memtier-N\` prefix used by sister specs.

## Specs added

| File | Command | Per-key | 10M used_memory |
|---|---|---|---|
| \`multiple-hll-pfadd-10Mkeys-10B-values.yml\` | PFADD (sparse HLL) | 183 B | ~1.7 GB |
| \`10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml\` | MGET 80 keys | 247 B | ~2.3 GB |
| \`10Mkeys-generic-expire-multitenant-tagged.yml\` | EXPIRE 7200 | 246 B | ~2.3 GB |
| \`10Mkeys-string-incrby-multitenant-tagged.yml\` | INCRBY 1 | 135 B | ~1.25 GB |
| \`10Mkeys-string-incrby-1000-multitenant-tagged.yml\` | INCRBY 1000 | 135 B | ~1.25 GB |
| \`10Mkeys-mixed-incrby-expire-multitenant-tagged.yml\` | INCRBY + EXPIRE mix | 135 B | ~1.25 GB |
| \`multiple-hll-pfcount-1key-10Mkeys-multitenant-tagged.yml\` | PFCOUNT (1-key) | 185 B | ~1.7 GB |

All 7 target \`oss-standalone\`, request 8 GB resource headroom, and use the same neutral keyname mask.

## Design notes

- **Preload concurrency:** specs that rely on idempotent population (SET) use multi-client \`-c 50 -t 4 -n allkeys --pipeline 50\` for fast preload. PFADD/PFCOUNT use single-client \`-c 1 -t 1 --pipeline 50\` to populate exactly 1 element per HLL (keeping all keys sparse, avoiding promotion to dense).
- **Off-by-one:** PFADD/PFCOUNT preloads use \`--key-maximum=10000001\` because single-client \`-n allkeys\` produces \`max-min\` requests (keys [1, max-1]). Multi-client preloads use \`--key-maximum=10000000\` (multi-client P walks [1, max] inclusive).
- **MGET caveat:** memtier's \`__key__\` rotates per occurrence, so each MGET reads 80 keys for 80 different sequential tenant IDs (not 80 keys for one tenant). For \`oss-standalone\` this is equivalent in dict-access cost to per-tenant fan-out; cluster topologies would not model hash-tag slot co-location.

## Test plan

- [x] PII scan clean (no payments-domain terms, merchant names, BIN ranges, or PAN-like number patterns)
- [x] YAML syntax valid (all 7 parse cleanly with \`yaml.safe_load\`)
- [x] Preload populates exact \`keyspacelen\` count (validated at 100k scale-down)
- [x] Test-phase commands complete with zero \`failed_calls\` in \`cmdstats\`
- [x] All HLLs stay in sparse encoding (verified \`PFDEBUG ENCODING\` post-test)
- [x] All INCRBY targets remain \`OBJECT ENCODING = int\` after preload
- [x] Memory measured at 100k scale, extrapolated to 10M; all >1 GB, all <8 GB ceiling
- [ ] CI regression run on \`oss-standalone\` x86 + ARM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new benchmark YAML definitions and a version bump only; no production code paths or security-sensitive logic are modified.
> 
> **Overview**
> Adds **7 new `memtier_benchmark` test-suite specs** at 10M-key scale that use long structured *multi-tenant tagged* key names (unique hash tag per key) to stress dict/TTL and reply-aggregation paths under longer key hashing/compare costs.
> 
> The new suites cover `EXPIRE` (TTL=7200), `INCRBY` (1 and 1000), mixed `INCRBY`+`EXPIRE` ratios, `MGET` fan-out (80 keys), and sparse HLL workloads (`PFADD` and single-key `PFCOUNT`) with consistent preload/check/resource settings. Also bumps `pyproject.toml` version from `0.3.11` to `0.3.12`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db6b328238c4ffde4c58dd5c6284243ab069cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->