### PR TITLE
0.3.13: fix preload-time blowup in 5 multitenant-tagged specs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.12"
+version = "0.3.13"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-generic-expire-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-generic-expire-multitenant-tagged.yml
@@ -19,8 +19,8 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '--data-size 100 --random-data --key-prefix ""
       --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
-      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
     timeout: 3600
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml
@@ -19,8 +19,8 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '--key-prefix ""
       --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 0"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
-      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
     timeout: 3600
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-1000-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-1000-multitenant-tagged.yml
@@ -18,8 +18,8 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '--key-prefix ""
       --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 0"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
-      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
     timeout: 3600
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-incrby-multitenant-tagged.yml
@@ -18,8 +18,8 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '--key-prefix ""
       --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 0"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
-      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
     timeout: 3600
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml
@@ -23,8 +23,8 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '--data-size 100 --random-data --key-prefix ""
       --command "SET {T:__key__}_metric_a_window_b_period_c_segment_d_aggregate_e_v1_v2_v3_v4_v5_v6 __data__"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000000
-      -n allkeys -c 50 -t 4 --pipeline 50 --hide-histogram'
+      --command-key-pattern="P" --key-minimum=1 --key-maximum=10000001
+      -n allkeys -c 1 -t 1 --pipeline 50 --hide-histogram'
     timeout: 3600
   resources:
     requests:


### PR DESCRIPTION
## Summary

Cuts preload time on the 5 SET-based multitenant-tagged specs from **~28 min to ~15 sec** by switching from \`-c 50 -t 4 -n allkeys\` (which fires 2B SET ops) to \`-c 1 -t 1 --pipeline 50\` (exactly 10M ops, 1 per key). Keeps the test phase multi-client.

## Why

The original PR #387 used \`-c 50 -t 4 -n allkeys\` for preload to mirror the existing \`5Mkeys-string-mget-100B-100keys\` pattern. That works for 5M-key SET preload (~14 min) because SET is idempotent — 200 clients × 5M ops = 1B ops, all keys eventually populated. At 10M scale that's 2B ops = ~28 min preload per spec, observed live on m7i-primary running 18+ min with no end in sight.

The other two specs in this family (\`pfadd-10Mkeys-10B-values\` and \`pfcount-1key-10Mkeys-multitenant-tagged\`) already use single-client preload because their semantics required it (1 PFADD per HLL to keep them sparse). Switching SETs to the same pattern is consistent and exactly what's needed.

## Files changed
- \`memtier_benchmark-10Mkeys-string-mget-80keys-100B-multitenant-tagged.yml\`
- \`memtier_benchmark-10Mkeys-generic-expire-multitenant-tagged.yml\`
- \`memtier_benchmark-10Mkeys-string-incrby-multitenant-tagged.yml\`
- \`memtier_benchmark-10Mkeys-string-incrby-1000-multitenant-tagged.yml\`
- \`memtier_benchmark-10Mkeys-mixed-incrby-expire-multitenant-tagged.yml\`

Each preload changed from \`-c 50 -t 4\` to \`-c 1 -t 1\`, and \`--key-maximum=10000000\` to \`10000001\` (to compensate for single-client \`-n allkeys\` off-by-one — produces \`max-min\` requests for keys \`[min, max-1]\`). Test phases unchanged.

## Test plan
- [x] Preload single-client + test multi-client validated at 100k-key scale-down in PR #387 work — 100% hit rate, exact \`keyspacelen\`
- [x] PFADD/PFCOUNT specs already use this pattern in production

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark specification YAMLs and a package version bump; main impact is altered preload behavior which could affect benchmark setup but not production code paths.
> 
> **Overview**
> Bumps the package version to `0.3.13`.
> 
> Updates 5 `10Mkeys` *multitenant-tagged* memtier specs to dramatically reduce preload work by switching the SET preload from multi-client (`-c 50 -t 4`) to single-client (`-c 1 -t 1`) while keeping pipelining, and adjusts `--key-maximum` to `10000001` to ensure the full 10M keyspace is populated. Test-phase client concurrency remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0b25f95a7ee9fa01a822ae0a7f81142dfeb83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->