### PR TITLE
leaderboard-top-100: cluster-compatible init via init_commands + cluster-aware runner (v0.3.14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.13"
+version = "0.3.14"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -1785,8 +1785,12 @@ def process_self_contained_coordinator_stream(
                             # init_commands / direct redis.call commands are
                             # routed to the correct slot. A plain Redis client
                             # would receive MOVED redirects and fail.
-                            r = redis.cluster.RedisCluster.from_url(args.uri, **redis_params)
-                            logging.info(f"Connected to Redis Cluster using URI: {args.uri}")
+                            r = redis.cluster.RedisCluster.from_url(
+                                args.uri, **redis_params
+                            )
+                            logging.info(
+                                f"Connected to Redis Cluster using URI: {args.uri}"
+                            )
                         else:
                             r = redis.StrictRedis.from_url(args.uri, **redis_params)
                             logging.info(f"Connected to Redis using URI: {args.uri}")

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -1780,8 +1780,16 @@ def process_self_contained_coordinator_stream(
                             if tls_cacert is not None and tls_cacert != "":
                                 redis_params["ssl_ca_certs"] = tls_cacert
 
-                        r = redis.StrictRedis.from_url(args.uri, **redis_params)
-                        logging.info(f"Connected to Redis using URI: {args.uri}")
+                        if args.cluster_mode:
+                            # Cluster-mode URI: use RedisCluster so that
+                            # init_commands / direct redis.call commands are
+                            # routed to the correct slot. A plain Redis client
+                            # would receive MOVED redirects and fail.
+                            r = redis.cluster.RedisCluster.from_url(args.uri, **redis_params)
+                            logging.info(f"Connected to Redis Cluster using URI: {args.uri}")
+                        else:
+                            r = redis.StrictRedis.from_url(args.uri, **redis_params)
+                            logging.info(f"Connected to Redis using URI: {args.uri}")
                     else:
                         # Use individual connection parameters
                         redis_params = {
@@ -1802,10 +1810,19 @@ def process_self_contained_coordinator_stream(
                             if tls_cacert is not None and tls_cacert != "":
                                 redis_params["ssl_ca_certs"] = tls_cacert
 
-                        r = redis.StrictRedis(**redis_params)
-                        logging.info(
-                            f"Connected to Redis using individual parameters: {host}:{port}"
-                        )
+                        if args.cluster_mode:
+                            # Cluster-mode individual params: use RedisCluster
+                            # so that init_commands / direct redis.call commands
+                            # are routed to the correct slot.
+                            r = redis.cluster.RedisCluster(**redis_params)
+                            logging.info(
+                                f"Connected to Redis Cluster using individual parameters: {host}:{port}"
+                            )
+                        else:
+                            r = redis.StrictRedis(**redis_params)
+                            logging.info(
+                                f"Connected to Redis using individual parameters: {host}:{port}"
+                            )
                     setup_name = topology_spec_name
                     r.ping()
 
@@ -1861,7 +1878,14 @@ def process_self_contained_coordinator_stream(
                     if oss_cluster_api_enabled:
                         redis_conns = []
                         logging.info("updating redis connections from cluster slots")
-                        slots = r.cluster("slots")
+                        # RedisCluster (cluster-aware) doesn't have .cluster()
+                        # the same way StrictRedis does; use execute_command on
+                        # the underlying primary node. Falls back to .cluster
+                        # for non-cluster client variants.
+                        if isinstance(r, redis.cluster.RedisCluster):
+                            slots = r.execute_command("CLUSTER", "SLOTS")
+                        else:
+                            slots = r.cluster("slots")
                         for slot in slots:
                             # Master for slot range represented as nested networking information starts at pos 2
                             # example: [0, 5460, [b'127.0.0.1', 30001, b'eccd21c2e7e9b7820434080d2e394cb8f2a7eff2', []]]


### PR DESCRIPTION
## Problem

The `init_lua` block in `memtier_benchmark-playbook-leaderboard-top-100.yml` populates 10,000 ZSETs (keys `"1".."10000"`) via a single `EVAL`. The keys hash to different cluster slots, so on any Redis Cluster deployment the script fails with:

```
ERROR Lua script execution failed: Script attempted to access a non local key in a cluster node script: ...
```

Redis Cluster's contract is **"one EVAL = one slot"** — no flag/version disables it. The test was therefore unrunnable on clustered topologies (Redis Cloud Pro single-endpoint bdbs that route through multiple internal shards, raw OSS Cluster, etc.) without modification, which I discovered while running the spec suite against an RCP 10GB/100K bdb.

## What this PR fixes

This PR has two coordinated changes; both are required for the test to work on raw Redis Cluster:

### 1. YAML: replace `init_lua` with `init_commands` (10,000 explicit ZADDs)

The 10,000 ZADDs were captured **verbatim via `MONITOR`** against a standalone `redis-server v8.6.0` running the original Lua with the deterministic seed (12345). That guarantees byte-identical post-preload state on standalone.

```bash
redis-server --port 6400 --daemonize yes --save ""
redis-cli -p 6400 MONITOR > monitor.raw &
redis-cli -p 6400 FLUSHALL
redis-cli -p 6400 EVAL "<original init_lua>" 0
# stop MONITOR, parse the 10,000 'lua' ZADD lines
```

The spec runner already supports `init_commands` (see `__common__/runner.py::execute_init_commands`), and dispatches each command individually so the client can route per-command to the correct slot.

### 2. Runner: use `redis.cluster.RedisCluster` when `--cluster-mode` is set

`__runner__/runner.py` constructed a plain `redis.StrictRedis` for the test-management connection even when `--cluster-mode` was passed. That client doesn't follow MOVED redirects, so init_commands ZADDs would fail with `MOVED 9842 127.0.0.1:7001` on a raw cluster (RCP works because its DMC proxy routes server-side, but raw OSS Cluster doesn't).

Switched to `redis.cluster.RedisCluster.from_url(...)` / `redis.cluster.RedisCluster(host=, port=, ...)` when `args.cluster_mode` is True. Also updated the `cluster("slots")` enumeration that was failing on `RedisCluster` (it doesn't expose `.cluster()` the same way; use `execute_command("CLUSTER","SLOTS")`).

### 3. Bump version 0.3.13 → 0.3.14

Reflects the YAML + runner changes.

## Equivalence verification

### Standalone — 0 mismatches across all 10,000 keys

Replayed the new `init_commands` into a clean standalone Redis and compared ZSET contents against the Lua-populated DB key-by-key:

```python
for k in range(1, 10001):
    assert lua_db.zrange(str(k), 0, -1, withscores=True) == \
           replay_db.zrange(str(k), 0, -1, withscores=True)
```

Result: **0 mismatches**.

### Raw Redis Cluster (3-master local cluster) — end-to-end ✅

```
$ redis-benchmarks-spec-client-runner --cluster-mode \
    --db_server_host 127.0.0.1 --db_server_port 7000 \
    --tests-regexp 'memtier_benchmark-playbook-leaderboard-top-100[.]yml$' \
    --override-memtier-test-time 30 ...

INFO Connected to Redis Cluster using individual parameters: 127.0.0.1:7000
INFO There are a total of 3 shards
... (10,000 init commands dispatched, distributed across shards)
INFO memtier benchmark completed successfully
INFO Test memtier_benchmark-playbook-leaderboard-top-100 passed metric validation
```

Resulting key distribution: **3334 + 3330 + 3336 = 10,000** keys across the 3 shards.

Bench result: 103,199 ops/sec total (61,945 ZADD + 41,253 ZREVRANGE), p50 5.6 ms, p99 11.7 ms.

## Trade-offs

- **YAML file size**: 12 KB → 77 MB. The 100 `(score, member)` pairs are embedded explicitly for each of 10,000 keys (the original Lua generated them once via `math.random()` and reused them via `score_member_pairs`). PyYAML parses the file in ~1 s.
- **Preload time**: ~3-4 s vs ~2 s on standalone; ~30-60 s on a 3-node cluster (cluster routing per command). Still negligible vs the 180 s bench.
- **YAML diff cleanliness**: only the `init_lua:` block (33 lines) is removed and replaced with 10,001 lines under `init_commands:`; everything else in the YAML is byte-identical.
- **Runner diff**: small (~25 lines) — wraps existing StrictRedis construction with an `if args.cluster_mode` branch, plus the CLUSTER SLOTS enumeration tweak.

## Why not hash-tag the keys instead

Hash-tagging works (single 2-line patch — wrap keys in `{lb}:`) but it changes test semantics: all 10K keys collapse onto one cluster slot, so a clustered deployment only exercises one shard. Users running this test on Redis Cluster wouldn't get a meaningful cluster-wide number.

`init_commands` keeps the keys uniformly distributed across slots, which is the right shape for a cluster benchmark.

## Test plan

- [x] Spec runner parses the updated YAML without errors
- [x] Standalone Redis: `keyspacelen` check still finds 10,000 keys after preload
- [x] Byte-equivalent ZSET state vs the original Lua-based preload on standalone (0/10000 mismatches)
- [x] Raw Redis Cluster (3-master local): preload completes (no cross-slot error), benchmark proceeds, passes metric validation
- [x] Cluster key distribution: 10,000 keys spread across shards (not collapsed to one)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Redis connection construction and cluster slot enumeration in the client runner when `--cluster-mode` is enabled, which could affect connectivity and command routing across standalone vs cluster deployments. Scope is small but touches core runner execution paths.
> 
> **Overview**
> Makes the client runner *cluster-aware* when `--cluster-mode` is set by constructing `redis.cluster.RedisCluster` clients (via `from_url` or host/port params) instead of `redis.StrictRedis`, avoiding `MOVED` redirect failures during initialization and direct command execution.
> 
> Updates cluster shard discovery to use `execute_command("CLUSTER", "SLOTS")` when the management client is a `RedisCluster`, while preserving the previous `r.cluster("slots")` path for non-cluster clients.
> 
> Bumps package version to `0.3.14`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9ee540983552fde846266427055bb269364a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->