### PR TITLE
test-suites: add 2 BITPOS specs (1key-100M-bits + 1Mkeys-pipeline-10)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-bitmap-bitpos-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-bitmap-bitpos-pipeline-10.yml
@@ -1,0 +1,49 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-bitmap-bitpos-pipeline-10
+description: Runs memtier_benchmark, for a keyspace length of 1M small bitmap keys
+  focusing on BITPOS performance. Each key is a raw-encoded 64-byte (512-bit) bitmap
+  with a single bit set at position 7. Workload alternates "BITPOS key 1" (returns 7)
+  and "BITPOS key 0" (returns 0), pipelined at 10. Per-call overhead dominates this
+  shape — every BITPOS hits the first-word fast path the PR optimizes by replacing a
+  per-bit shift loop with a single __builtin_clzl().
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --hide-histogram --key-minimum 1 --key-maximum 1000001 -n 1000000
+      --command "SETBIT __key__ 511 0" --command "SETBIT __key__ 7 1" --command-key-pattern
+      "P:P" --pipeline 50 -c 50 -t 2
+  resources:
+    requests:
+      cpus: '2'
+      memory: 1g
+  dataset_name: 1Mkeys-bitmap-512bits-bitpos-target7
+  dataset_description: This dataset contains 1M raw-encoded bitmap keys, each 64 bytes
+    (512 bits), with a single bit set at position 7. Workloads issuing alternating
+    "BITPOS __key__ 1" / "BITPOS __key__ 0" exercise the first-word fast path on
+    every call.
+tested-commands:
+- bitpos
+tested-groups:
+- bitmap
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --pipeline 10 --command "BITPOS __key__ 1" --command-key-pattern "R"
+    --command "BITPOS __key__ 0" --command-key-pattern "R" -c 50 -t 2 --hide-histogram
+    --test-time 120
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 19

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitpos.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitpos.yml
@@ -1,0 +1,44 @@
+version: 0.4
+name: memtier_benchmark-1key-100M-bits-bitmap-bitpos
+description: Runs memtier_benchmark, for a keyspace length of 1 key focusing on BITPOS
+  performance. The bitmap is a raw-encoded string of 100M bits (~12.5MB). A single
+  bit is set at position 31 (first 64-bit word) so every BITPOS call locates the matching
+  word immediately and spends its time in the final-word bit-search path — the same
+  path optimized by replacing a per-bit shift loop with a single __builtin_clzl().
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  init_commands:
+  - '"SETBIT" "users" "100000000" "0"'
+  - '"SETBIT" "users" "31" "1"'
+  resources:
+    requests:
+      cpus: '2'
+      memory: 1g
+  dataset_name: 1key-bitmap-100Mbits-bitpos-target31
+  dataset_description: This dataset contains 1 raw-encoded bitmap key of 100M bits
+    (~12.5MB) with a single bit set at position 31 — workloads issuing "BITPOS users 1"
+    locate the matching word on the first iteration and exercise only the final-word
+    bit-search path.
+tested-commands:
+- bitpos
+tested-groups:
+- bitmap
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "BITPOS users 1" -c 50 -t 2 --pipeline 10 --hide-histogram
+    --test-time 120
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 19


### PR DESCRIPTION
Adds two memtier_benchmark specs that exercise the BITPOS code path. The existing bitmap specs cover BITCOUNT, GETBIT and BITOP — none exercise redisBitpos() directly, leaving any BITPOS-targeted change without a fleet gate.

Both shapes pin the matching bit inside the first 64-bit word so the workload exercises the final-word bit-search path on every call, making the runs sensitive to per-call BITPOS overhead changes.

| Spec | Bitmap shape | Target bit | Workload |
|---|---|---|---|
| 1key-100M-bits-bitmap-bitpos | 1 raw key, 100M bits (~12.5MB) | position 31 (first word) | BITPOS users 1, 50c x 2t, pipeline 10, --test-time 120 |
| 1Mkeys-bitmap-bitpos-pipeline-10 | 1M raw keys, 64 bytes (512 bits) each | position 7 | alternating BITPOS __key__ 1 / BITPOS __key__ 0, 50c x 2t, pipeline 10, --test-time 120 |

Both tagged group: bitmap, command: bitpos, priority 19 (matches the existing bitmap specs).

## Why two shapes
- **Large-bitmap (100M-bits)** — single key, single client target. Minimizes preload/keyspace variance, isolates per-call BITPOS cost in a steady-state high-RPS workload.
- **1M-small-bitmaps pipelined** — many small keys, random distribution, pipelined. Makes per-call overhead the dominant share of total time, so any change to the BITPOS hot path shows up larger here than in the single-key shape.

Together they bracket the realistic BITPOS workload spectrum (one big bitmap scanned often vs. a fleet of small bitmaps probed often).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this PR only adds new benchmark spec YAMLs; the main impact is increased benchmark coverage (and potentially some extra CI/benchmark runtime and resource usage).
> 
> **Overview**
> Adds two new `memtier_benchmark` test-suite specs to gate `BITPOS` performance changes with bitmap-focused workloads.
> 
> One spec benchmarks a single large (~12.5MB) bitmap key (`BITPOS users 1`, pipeline 10), and the other benchmarks 1M small 512-bit bitmap keys with an alternating `BITPOS __key__ 1`/`BITPOS __key__ 0` workload (pipeline 10) including a preload phase to populate the keyspace. Both are tagged `bitmap`/`bitpos` and run on the existing standalone/topology and build variants with priority 19.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1192fea22edb3378af7d29644dbd64edec9ff5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->