### PR TITLE
0.3.17: fix 1Mkeys-bitmap-bitpos preload (per-command key patterns)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.16"
+version = "0.3.17"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-bitmap-bitpos-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-bitmap-bitpos-pipeline-10.yml
@@ -15,8 +15,8 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --hide-histogram --key-minimum 1 --key-maximum 1000001 -n 1000000
-      --command "SETBIT __key__ 511 0" --command "SETBIT __key__ 7 1" --command-key-pattern
-      "P:P" --pipeline 50 -c 50 -t 2
+      --command "SETBIT __key__ 511 0" --command-key-pattern "P" --command "SETBIT __key__ 7 1"
+      --command-key-pattern "P" --pipeline 50 -c 50 -t 2
   resources:
     requests:
       cpus: '2'


### PR DESCRIPTION
## Summary

The 1Mkeys-bitmap-bitpos-pipeline-10 spec added in #391 (v0.3.16) failed at preload because of an invalid memtier arg syntax: `--command-key-pattern "P:P"`. memtier expects a separate `--command-key-pattern` flag after each `--command`, not a colon-separated list — so it exited with a usage error and the test was marked failed on every fleet run.

## Fix

Replace the single colon-list flag with one `--command-key-pattern "P"` after each of the two preload `--command`s. Mirrors the per-command pattern style already used in `1Mkeys-bitmap-getbit-pipeline-10.yml`.

## Verification

- Preload now matches memtier's documented per-command pattern syntax.
- 1key-100M-bits-bitmap-bitpos (the sibling spec from #391) continues to pass; its preload uses init_commands only and was unaffected.

## Test plan

- [x] Diff confined to the broken preload arg + version bump (0.3.16 → 0.3.17).
- [ ] Validate-SPEC-fields CI to confirm YAML still parses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a benchmark spec’s preload command-line arguments and bumps the package version, with no production code or data-handling logic changes.
> 
> **Overview**
> Bumps the package version from `0.3.16` to `0.3.17`.
> 
> Fixes the `memtier_benchmark-1Mkeys-bitmap-bitpos-pipeline-10` preload configuration by replacing the invalid combined `--command-key-pattern "P:P"` syntax with a separate `--command-key-pattern "P"` after each `SETBIT` `--command`, so preload runs correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a2a1116c98242d9f378437800b0e3c97661533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->