### PR TITLE
test-suites: add BITPOS-distant spec exercising SIMD skip-word scan path

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant
+description: Runs memtier_benchmark, for a keyspace length of 1 key focusing on BITPOS
+  performance — variant that targets the SKIP-WORD scan loop. The bitmap is a raw-encoded
+  string of 100M bits (~12.5MB) with the only set bit at position 99,999,999 (the very
+  last bit). Every BITPOS call therefore scans the entire bitmap before finding the
+  match — exercising the AVX2/AVX512 vectorized skip-word path proposed in upstream
+  PR #15217 (slice4e:bitpos_vectorize_scan) and the existing scalar word-step loop
+  on ARM / non-SIMD builds.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  init_commands:
+  - '"SETBIT" "users" "100000000" "0"'
+  - '"SETBIT" "users" "99999999" "1"'
+  resources:
+    requests:
+      cpus: '2'
+      memory: 1g
+  dataset_name: 1key-bitmap-100Mbits-bitpos-distant
+  dataset_description: This dataset contains 1 raw-encoded bitmap key of 100M bits
+    (~12.5MB) with a single bit set at position 99,999,999 (the last bit). Workloads
+    issuing "BITPOS users 1" must scan ~12.5MB of zero bytes before finding the match,
+    exercising the SIMD-vectorized skip-word path on x86 (AVX2/AVX512 when available)
+    and the scalar word loop on ARM and non-SIMD builds.
+tested-commands:
+- bitpos
+tested-groups:
+- bitmap
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "BITPOS users 1" -c 50 -t 2 --pipeline 10 --hide-histogram
+    --test-time 120
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 19


### PR DESCRIPTION
## Summary

Adds a new BITPOS spec (`memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant`) that places the only set bit at position 99,999,999 (the very last bit of a 100M-bit / 12.5 MB raw-encoded bitmap), forcing every `BITPOS users 1` call to scan the entire bitmap before finding the match.

## Why

The existing `memtier_benchmark-1key-100M-bits-bitmap-bitpos` spec places the bit at position 31 (first 64-bit word), so the BITPOS skip-word scan loop is never entered — only the final-word bit-search path runs. That spec is a good driver for the `__builtin_clzl()` optimization (#15062, merged) but completely misses the SIMD vectorization work in upstream PR #15217 (slice4e:bitpos_vectorize_scan), which adds AVX2 / AVX-512 vectorized scanning for the skip-word loop.

This new variant exercises:
- the AVX2 / AVX-512 vectorized skip-word path on x86 with SIMD builds (PR #15217)
- the existing scalar word-step loop on ARM and non-SIMD builds (regression control)

## Parameters

Mirrors the existing 1key-100M-bits spec for direct side-by-side comparison:
- 1 key, raw-encoded bitmap, 12,500,001 bytes
- `BITPOS users 1`, pipeline=10, 50c / 2t, test-time 120s
- oss-standalone topology

The two specs differ only in the position of the set bit.

## Test plan

- [x] Spec semantics verified locally via redis-cli (`BITPOS users 1` returns 99999999)
- [ ] Fleet validation across Intel SPR / Intel GNR / AMD Zen 5 / ARM Graviton4 once installed on runners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new benchmark spec file only, with no production code changes; primary risk is increased CI/runtime cost due to a heavier BITPOS workload.
> 
> **Overview**
> Adds a new memtier benchmark suite, `memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml`, that initializes a 100M-bit bitmap with the only set bit at the very end and runs `BITPOS users 1` to force a full-bitmap scan.
> 
> This complements the existing `...-bitpos` spec (bit near the start) to better exercise the skip-word scanning path (SIMD on x86, scalar on ARM/non-SIMD) while keeping the same topology, client args, and resource settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fda86ddaf1798518a7be3876ea332208ebdada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->