### PR TITLE
fix(test-suites): add missing --pipeline 10 to mget-1KiB-5keys-pipeline-10 (v0.3.18)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,18 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.18"
+version = "0.3.23"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"
+# Ship in-package data files. These are needed because the blanket `*.json` rule in
+# .gitignore makes them untracked -> invisible to Poetry's git-based file discovery,
+# so they must be force-tracked (see .gitignore negation) AND listed here to land in
+# the wheel. The dict `format=` form needs poetry-core >= 1.1; the build-system below
+# pins >= 1.5.0 for safety.
+include = [
+    { path = "redis_benchmarks_specification/__common__/files-to-groups.json", format = ["sdist", "wheel"] },
+    { path = "redis_benchmarks_specification/__common__/core-specs.json", format = ["sdist", "wheel"] },
+]
 
 [tool.poetry.dependencies]
 python = "^3.10.0"
@@ -54,7 +63,9 @@ docker = ">=7.1.0"
 docker = "^7.1.0"
 
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+# >=1.5.0: the dict-form `include` with `format=[...]` (used to ship in-package json
+# data files into the wheel) is only honored by poetry-core >= 1.1; pin higher for safety.
+requires = ["poetry_core>=1.5.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.17"
+version = "0.3.18"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mget-1KiB-5keys-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mget-1KiB-5keys-pipeline-10.yml
@@ -28,7 +28,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments:  --key-minimum 1 --key-maximum 5000000 --command "MGET __key__ __key__ __key__ __key__ __key__" -c 50 -t 8 --hide-histogram --test-time 120
+  arguments: --pipeline 10 --key-minimum 1 --key-maximum 5000000 --command "MGET __key__ __key__ __key__ __key__ __key__" -c 50 -t 8 --hide-histogram --test-time 120
   resources:
     requests:
       cpus: '8'


### PR DESCRIPTION
## Summary

`memtier_benchmark-5Mkeys-string-mget-1KiB-5keys-pipeline-10.yml` was missing `--pipeline 10` in its `clientconfig.arguments`. Every sibling pipeline-10 MGET spec on the same matrix (100B, 512B, 1KiB-* with various key counts) ships the flag — this one was the only outlier.

Without the flag, memtier_benchmark defaults to pipeline=1, so the test was running un-pipelined despite the name advertising pipeline-10.

## Why it matters

A recent regression-investigation run on redis/redis#14907 (per-IO-thread stat counters) flagged `mget-1KiB-5keys-pipeline-10` as the only σ-confirmed regression in the io-threads=8 string suite (−12.6 %). Every other pipeline-10 MGET sibling on the same axis (+1.5 % to +6.5 %) moved the opposite direction, which didn't fit any false-sharing-fix mechanism. Spec inspection showed the `--pipeline 10` was missing — the regression was being measured at effective pipeline=1.

## Changes

- Add `--pipeline 10` to the `clientconfig.arguments` line.
- Bump to v0.3.18.

## Test plan

- [ ] Re-run `mget-1KiB-5keys-pipeline-10` against PR head + unstable baseline on `oss-standalone-08-io-threads`; confirm both numbers shift up to the pipelined operating point and the PR delta no longer shows the spurious −12 %.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-spec correction and packaging metadata only; no runtime application logic changes.
> 
> **Overview**
> Aligns **`memtier_benchmark-5Mkeys-string-mget-1KiB-5keys-pipeline-10`** with other pipeline-10 MGET specs by adding **`--pipeline 10`** to `clientconfig.arguments`. Without it, memtier ran at pipeline=1, so benchmark deltas (e.g. spurious regressions on io-threads suites) did not match the intended pipelined workload.
> 
> **`pyproject.toml`** bumps the package to **0.3.23**, explicitly **`include`**s `files-to-groups.json` and `core-specs.json` in sdist/wheel, and raises **`poetry_core`** to **>=1.5.0** so dict-form `include` with `format` is honored at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d2f038d31206053f1289c2d07c16c398ba1af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->