### PR TITLE
test-suites: add stream-10M-xreadgroup-count-100 custom-ids worst-case variant

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-10M-entries-xreadgroup-count-100-custom-ids.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-10M-entries-xreadgroup-count-100-custom-ids.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-stream-10M-entries-xreadgroup-count-100-custom-ids
+description: "Worst-case cache-miss variant of memtier_benchmark-stream-10M-entries-xreadgroup-count-100. Pre-loads 50M stream entries using XADD with custom IDs of the form 'N-0' (1-0, 2-0, ..., 50000000-0). The ms component varies on every entry while the sequence stays at 0, so every entry has a unique 15-byte rax prefix — defeating the consumer-group PEL's prefix cache and forcing a cache miss on every PEL insertion during XREADGROUP. Drains the backlog with XREADGROUP COUNT 100 for 500K calls (~50M entries consumed). Preload uses a single connection (-c 1 -t 1) with --pipeline 100 to keep IDs monotonic while sustaining throughput. Compare to the auto-ID variant to isolate cache-hit vs cache-miss cost."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key __key__-0 field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum=50000000 --key-prefix="" -n 50000000 -c 1 -t 1 --pipeline 100 --hide-histogram'
+  init_commands:
+    - XGROUP CREATE stream-key test-group 0 MKSTREAM
+  resources:
+    requests:
+      memory: 8g
+  dataset_name: 50M-stream-entries-custom-ids-with-consumer-group
+  dataset_description: This dataset contains 1 stream key with 50M entries inserted using monotonic custom IDs 'N-0' (worst-case cache-miss pattern for the consumer-group PEL), and a consumer group named 'test-group'.
+tested-commands:
+  - xreadgroup
+redis-topologies:
+  - oss-standalone
+build-variants:
+  - gcc:15.2.0-amd64-debian-bookworm-default
+  - gcc:15.2.0-arm64-debian-bookworm-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="XREADGROUP GROUP test-group consumer1 COUNT 100 STREAMS stream-key >" --hide-histogram -n 5000 -c 25 -t 4
+  resources:
+    requests:
+      cpus: "4"
+      memory: 2g
+tested-groups:
+  - stream
+priority: 94


### PR DESCRIPTION
## Summary

Adds `memtier_benchmark-stream-10M-entries-xreadgroup-count-100-custom-ids.yml` — a worst-case cache-miss variant of the existing `memtier_benchmark-stream-10M-entries-xreadgroup-count-100` spec.

The new spec pre-loads 50M stream entries using XADD with **custom monotonic IDs of the form `N-0`** (`1-0`, `2-0`, ..., `50000000-0`) instead of the auto-generated `*` IDs used by the baseline. With this pattern:

- the millisecond component varies on every entry while the sequence stays at `0`,
- so every entry has a unique 15-byte ID prefix,
- which defeats the consumer-group PEL prefix cache and forces a cache miss on every PEL insertion (group PEL, consumer PEL, and `cgroups_ref`) during XREADGROUP.

The auto-ID baseline produces the opposite extreme — clustered IDs sharing the same prefix, hitting the cache on nearly every insertion. Together the two specs bracket the realistic operating range and form a clean A/B for cache-hit vs cache-miss cost in `pelInsert`, which is useful for evaluating Streams PEL-layout changes that target XREADGROUP performance.

## Spec details

- **Preload:** single connection (`-c 1 -t 1`) with `--pipeline 100` to keep IDs strictly monotonic while sustaining throughput.
- **Client / concurrency / COUNT / dataset size:** identical to `memtier_benchmark-stream-10M-entries-xreadgroup-count-100` so the two are directly comparable.
- **Topologies / build variants / priority:** same as the baseline spec.

## Test plan

- [ ] Run the spec end-to-end on the x86 runner and confirm preload completes and the XREADGROUP drain measurement window is stable.
- [ ] Run on the ARM runner.
- [ ] Compare RPS / p99 against `memtier_benchmark-stream-10M-entries-xreadgroup-count-100` (baseline) on the same commit to confirm the expected cache-miss penalty is visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new benchmark spec file only, without changing any runtime code paths; main risk is increased CI/benchmark runtime and resource usage due to the 50M-entry preload.
> 
> **Overview**
> Adds a new `memtier_benchmark-stream-10M-entries-xreadgroup-count-100-custom-ids` test-suite spec that preloads a 50M-entry stream using `XADD` with monotonic custom IDs (`N-0`) and then measures draining via `XREADGROUP COUNT 100`.
> 
> This variant is intended as a **worst-case cache-miss** counterpart to the existing auto-ID spec, while keeping the same client drain workload/topologies/build variants/priority for direct comparability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28cd82b4a310bd5cfdcdb9c788d4775a8b74145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->