### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Agent guidelines
+
+Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo.
+
+## Project overview
+
+`redis-benchmarks-specification` defines the cross-language/tools requirements and expectations for Redis performance benchmarking. It is a Python package (Poetry-managed) that publishes benchmark specifications — command lists, encoding coverage, groups — as structured JSON/YAML, and provides a Flask API and tooling for running and comparing benchmarks via `redisbench-admin`.
+
+## Local setup
+
+```bash
+git clone git@github.com:redis/redis-benchmarks-specification.git
+cd redis-benchmarks-specification
+pip install poetry
+poetry install
+```
+
+## Branch naming
+
+Same as human contributors: `<type>/<short-description>` (e.g. `fix/command-spec-encoding`).
+
+## Coding standards
+
+- Match the style already in the file you are editing.
+- Prefer clear, minimal changes over large refactors unless explicitly asked.
+- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not introduce new dependencies without checking with the maintainer.
+- Run `flake8` before declaring a task complete.
+
+## Running tests
+
+```bash
+poetry run tox -e integration-tests
+```
+
+Always run tests before declaring a task complete.
+
+## How to submit changes
+
+1. Create a branch: `git checkout -b <type>/<description>`.
+2. Commit with a clear message focused on *why*, not *what*.
+3. Open a pull request against `main`.
+4. Do **not** push directly to `main`.
+
+## What to avoid
+
+- Do not reformat files unrelated to your change.
+- Do not remove error handling or tests.
+- Do not commit secrets, credentials, or large binary files.
+- Do not amend published commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+```bash
+git clone git@github.com:redis/redis-benchmarks-specification.git
+cd redis-benchmarks-specification
+pip install poetry
+poetry install
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-new-command-spec`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+- Run `flake8` before opening a PR.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+```bash
+poetry run tox -e integration-tests
+```
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.


### PR DESCRIPTION
Adds baseline contribution and agent guidelines per org standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, API, or dependency changes.
> 
> **Overview**
> Adds **`CONTRIBUTING.md`** with human contributor workflow: Poetry setup, branch types (`feat`, `fix`, etc.), focused PRs, `flake8`, integration tests via `poetry run tox -e integration-tests`, and maintainer review with green CI.
> 
> Adds **`AGENTS.md`** with parallel guidance for AI agents: project overview for `redis-benchmarks-specification`, the same setup and test commands, branch naming, coding constraints (minimal diffs, no drive-by reformatting, maintainer approval for new deps), and explicit “what to avoid” (secrets, amending published commits, pushing to `main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35751be9dd850c86f68b108bfecb699d2a45ef04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->