### PR TITLE
chore: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,14 +10,14 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 
-    - uses: docker/setup-docker-action@v4
+    - uses: docker/setup-docker-action@v5
 
     - name: Install Poetry
       run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: "ubuntu-latest"
     name: os ${{ matrix.os }} python ${{ matrix.python-version }} Linting, testing, and compliance
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -43,7 +43,7 @@ jobs:
         tox
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       if: contains(env.USING_COVERAGE, matrix.python-version) && contains(env.USING_COVERAGE_OS, matrix.os)
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: os ${{ matrix.os }} python ${{ matrix.python-version }} Linting, testing, and compliance
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/validate-spec-fields.yml
+++ b/.github/workflows/validate-spec-fields.yml
@@ -12,10 +12,10 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/workflows/validate-spec-fields.yml
+++ b/.github/workflows/validate-spec-fields.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
GitHub is deprecating the **node20** runner for GitHub Actions on **June 16, 2026**. Workflow steps using node20-based action versions will fail after this date.

This PR bumps all affected actions to their latest node24-compatible versions.

**Note:** Initial review flagged `actions/checkout` under-bumped to @v4; corrected to @v6 in all 3 workflow files before opening.

> Reviewed by 3 independent agents (opus/sonnet/haiku) before opening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only workflow changes with no application or secret-handling logic modified; CI behavior should stay the same aside from action runtime updates.
> 
> **Overview**
> Updates three CI workflows (`publish-pypi`, `tox`, `validate-spec-fields`) so core steps use **node24-compatible** GitHub Action releases before the node20 runner deprecation.
> 
> **`actions/checkout`** moves from `@master` to **`@v6`**, and **`actions/setup-python`** from **`@v1`** to **`@v6`** in all three files. **`publish-pypi`** also bumps **`docker/setup-docker-action`** **`@v4` → `@v5`**. **`tox`** bumps **`codecov/codecov-action`** **`@v4` → `@v6`**. Job commands and secrets are unchanged.
> 
> **`validate-spec-fields`** still pins **`docker-practice/actions-setup-docker@master`**; that step was not part of this bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d188694b1fe6dd2058801fc04a451d2026188db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->