### PR TITLE
fix: correct YAML syntax error in memtier_benchmark bitmap bitpos distant test spec

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml
@@ -1,10 +1,11 @@
 version: 0.4
 name: memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant
-description: Runs memtier_benchmark, for a keyspace length of 1 key focusing on BITPOS
-  performance — variant that targets the SKIP-WORD scan loop. The bitmap is a raw-encoded
+description: >-
+  Runs memtier_benchmark, for a keyspace length of 1 key focusing on BITPOS
+  performance - variant that targets the SKIP-WORD scan loop. The bitmap is a raw-encoded
   string of 100M bits (~12.5MB) with the only set bit at position 99,999,999 (the very
   last bit). Every BITPOS call therefore scans the entire bitmap before finding the
-  match — exercising the AVX2/AVX512 vectorized skip-word path proposed in upstream
+  match - exercising the AVX2/AVX512 vectorized skip-word path proposed in upstream
   PR #15217 (slice4e:bitpos_vectorize_scan) and the existing scalar word-step loop
   on ARM / non-SIMD builds.
 dbconfig:


### PR DESCRIPTION
## Problem

All CI tox jobs fail with a YAML `ParserError` when loading the test-suite spec:

```
yaml.parser.ParserError: while parsing a block mapping
  in ".../memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml", line 1, column 1
expected <block end>, but found '<scalar>'
  in ".../memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml", line 9, column 3
```

## Root cause

The `description` field was written as a plain (unquoted, unfolded) multi-line scalar. It contained two issues:

1. **`PR #15217`** — In YAML, a space followed by `#` starts a comment. So `PR #15217 (slice4e:bitpos_vectorize_scan) and the existing scalar word-step loop` was silently truncated to `PR`, and the continuation line on the next line became an unexpected bare scalar at the block-mapping level, causing the parse error.
2. **Em dashes (`—`, U+2014)** — Unicode characters that are valid in YAML but were unnecessary and non-idiomatic.

## Fix

Changed the `description` value from a plain multi-line scalar to a YAML **folded block scalar** (`>-`). This makes the `#` in `PR #15217` safe (block scalars don't honor inline comments), and also replaces the two em dashes with plain ASCII hyphens for consistency with the rest of the spec files.

No semantic content was changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only YAML syntax fix in one test spec; no runtime, auth, or benchmark logic changes.
> 
> **Overview**
> Fixes a **YAML parse error** in `memtier_benchmark-1key-100M-bits-bitmap-bitpos-distant.yml` that was breaking CI when tox loads test-suite specs.
> 
> The `description` field is rewritten as a **folded block scalar** (`>-`) instead of an unquoted multi-line plain scalar. That keeps `PR #15217` intact (inline `#` no longer starts a comment and truncates the text) and swaps Unicode em dashes for ASCII hyphens. **Benchmark behavior and the rest of the spec are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caee748a5200700103cba11bb3e1401cb35b6e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->