### PR TITLE
Add listpack ZINCRBY coverage (1M small sorted sets, same-member increment)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10
+description: 'Runs memtier_benchmark over 1,000,000 SORTED SET keys, each holding 16 members,
+  repeatedly updating an existing member with ZINCRBY (same-member increment path in zsetAdd:
+  find -> delete old (member,score) -> reinsert). Encoding: listpack (16 elements per key, within
+  zset-max-listpack-entries 128). Scales the redis/redis#15288 workload (ZINCRBY -P 10 on a small
+  listpack-encoded zset) across 1M keys to reproduce the regression bisected to 391e3452 (#13981)
+  without single-key cache-hot artifacts.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+    zset-max-listpack-entries: '128'
+    zset-max-listpack-value: '64'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command="ZADD __key__ 1 e1 2 e2 3 e3 4 e4 5 e5 6 e6 7 e7 8 e8 9 e9 10 e10 11 e11 12 e12 13 e13 14 e14 15 e15 16 e16"
+      --command-key-pattern=P --key-minimum 1 --key-maximum 1000000 --key-prefix "zset:"
+      -n 1000000 --hide-histogram -t 1 -c 1 --pipeline 50
+  resources:
+    requests:
+      memory: 3g
+  dataset_name: 1Mkeys-zset-16-elements-listpack
+  dataset_description: 1,000,000 sorted-set keys, each listpack-encoded with 16 integer-scored
+    members (e1..e16), well within zset-max-listpack-entries 128.
+tested-groups:
+- sorted-set
+tested-commands:
+- zincrby
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZINCRBY __key__ 1 e8" --command-key-pattern=R --key-minimum 1
+    --key-maximum 1000000 --key-prefix "zset:" --hide-histogram --test-time 180 --pipeline 10 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 67

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10.yml
@@ -17,7 +17,7 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --command="ZADD __key__ 1 e1 2 e2 3 e3 4 e4 5 e5 6 e6 7 e7 8 e8 9 e9 10 e10 11 e11 12 e12 13 e13 14 e14 15 e15 16 e16"
-      --command-key-pattern=P --key-minimum 1 --key-maximum 1000000 --key-prefix "zset:"
+      --command-key-pattern=P --key-minimum 1 --key-maximum 1000001 --key-prefix "zset:"
       -n 1000000 --hide-histogram -t 1 -c 1 --pipeline 50
   resources:
     requests:


### PR DESCRIPTION
Our current ZINCRBY coverage (`memtier_benchmark-1key-zincrby-1M-elements-pipeline-1`) runs against a single 1M-element **skiplist+hashtable**-encoded sorted set. There is no coverage for the **listpack**-encoded small-zset `ZINCRBY` update path — the find → delete old `(member,score)` → reinsert sequence in `zsetAdd()` for sets within `zset-max-listpack-entries`.

This adds `memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10`: 1,000,000 keys, each a 16-member listpack-encoded sorted set, repeatedly `ZINCRBY -P 10` on an existing member. It scales out the small-listpack `ZINCRBY` workload reported in redis/redis#15288 (single-member increment) across 1M keys to avoid single-key cache-hot artifacts, giving server-class coverage for the listpack same-member update path.

Encoding is pinned via `zset-max-listpack-entries 128` / `zset-max-listpack-value 64`; 16 members per key stays comfortably listpack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a benchmark YAML definition; no Redis server or client code changes.
> 
> **Overview**
> Adds a new memtier benchmark spec **`memtier_benchmark-1Mkeys-zincrby-16-elements-listpack-pipeline-10`** so CI can stress **listpack** sorted sets on the **same-member `ZINCRBY`** path in `zsetAdd` (find → delete → reinsert), which existing **`ZINCRBY`** coverage on a single 1M-member skiplist zset does not exercise.
> 
> The suite preloads **1M** keys (`zset:` prefix) with **16** members each, pins listpack via **`zset-max-listpack-entries`** / **`zset-max-listpack-value`**, then runs **`ZINCRBY __key__ 1 e8`** with **`-P 10`** over random keys for 180s—scaled from the redis/redis#15288 / #13981 regression scenario without a single hot key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee0e8eeb69cd6b6d3c0bd810aec8c9f80ececa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->