### PR TITLE
Add BITOP XOR coverage for short-tail (50B values × 10 source keys, pipeline 10)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10keys-bitmap-50B-bitop-xor-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10keys-bitmap-50B-bitop-xor-pipeline-10.yml
@@ -1,0 +1,62 @@
+version: 0.4
+name: memtier_benchmark-10keys-bitmap-50B-bitop-xor-pipeline-10
+description: >
+  Runs memtier_benchmark BITOP XOR over 10 short (50-byte) string source keys with pipeline 10.
+  Each source key (key:1..key:10) is pre-loaded with a 50-byte string value (not a 32-byte
+  multiple — leaves an 18-byte scalar tail after the first AVX2 block). The benchmark
+  repeatedly issues `BITOP XOR tmp key:1 key:2 ... key:10`, exercising the BITOP short-tail
+  path that combines one AVX2 vector iteration with the rewritten scalar tail loop in
+  bitopCommandAVX. Scopes redis/redis#15289 reproduction (-5.4% RPS on 391e3452 -> 8dfb823,
+  10 source keys × 50-byte values × XOR × pipeline 10) into a registered spec so we can
+  bisect and track parity on the AVX2 fleet.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: >
+      --command "SET __key__ __data__"
+      --command-key-pattern P
+      --data-size 50
+      --key-prefix "key:"
+      --key-minimum 1
+      --key-maximum 10
+      -n 10
+      -c 1
+      -t 1
+      --hide-histogram
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 10keys-bitmap-50B-strings
+  dataset_description: 10 string keys (key:1..key:10), each holding a 50-byte value (32-byte
+    AVX2 block + 18-byte scalar tail).
+tested-commands:
+- bitop
+tested-groups:
+- bitmap
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --command "BITOP XOR tmp key:1 key:2 key:3 key:4 key:5 key:6 key:7 key:8 key:9 key:10"
+    --command-key-pattern R
+    --hide-histogram
+    --test-time 180
+    --pipeline 10
+    -c 1
+    -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 67


### PR DESCRIPTION
## Why

redis/redis#15289 reports a -5.41% RPS / +5.93% avg-latency regression on `BITOP XOR` (and -3.42% / +3.77% on `BITOP OR`) between `391e3452` and `8dfb823` (PR #13898 — _Implement DIFF, DIFF1, ANDOR and ONE for BITOP_), specifically when source values are short enough to leave a non-32B-multiple scalar tail (50B is the headline length: one AVX2 block + 18B tail).

The currently registered BITOP spec — `memtier_benchmark-2keys-bitmap-100M-bits-bitop-and` — exercises the long-buffer SIMD path (12.5MB src1/src2), which is exactly the path where 8dfb823 is a win. It cannot reproduce the short-tail loss.

## What

This PR adds a new spec, `memtier_benchmark-10keys-bitmap-50B-bitop-xor-pipeline-10`, that mirrors the reporter's repro:

| field | value |
| --- | --- |
| preload | 10 keys (`key:1`..`key:10`), each holding a 50-byte string (32B AVX2 block + 18B scalar tail) |
| benchmark | `BITOP XOR tmp key:1 key:2 ... key:10`, pipeline 10, 1 client, 1 thread, test-time 180s |
| build-variants | bookworm gcc 15.2.0 amd64 + arm64 + dockerhub |
| tested-groups | bitmap |
| priority | 67 (regression-coverage spec, not high-priority release gate) |

The XOR variant carries the strongest signal in the issue's table (-5.41% RPS, p ≈ 7e-9); a follow-up OR variant can be added if useful, but XOR alone is enough to bisect/track this regression on the AVX2 fleet.

## Notes

- Same shape as PR #401 (listpack ZINCRBY coverage for redis/redis#15288) — opens the spec, then the corresponding bisect can run on the registered name without further plumbing.
- Spec name encodes the workload shape (`10keys-bitmap-50B-bitop-xor-pipeline-10`) so the AVX2 short-tail bench is self-describing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark registry YAML only; no Redis runtime or production code changes.
> 
> **Overview**
> Registers a new memtier benchmark spec **`memtier_benchmark-10keys-bitmap-50B-bitop-xor-pipeline-10`** so CI can bisect and track the **BITOP XOR short-tail** regression from redis/redis#15289 (50-byte values → one AVX2 block plus 18-byte scalar tail), which the existing large-bitmap **BITOP AND** spec does not hit.
> 
> The spec preloads **10** string keys with **50B** values, then runs **`BITOP XOR`** across all ten with **pipeline 10** (180s, 1 client/thread), on **oss-standalone** with bookworm gcc **amd64/arm64** and **dockerhub** build variants, at **priority 67** as regression coverage rather than a release gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd4c58102c9e3a01019c9d5b16a866570a78b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->