### PR TITLE
fix(test-suites): correct suites that benchmark the wrong path

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-load-hash-20-fields-with-1B-values-pipeline-30.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-load-hash-20-fields-with-1B-values-pipeline-30.yml
@@ -1,7 +1,7 @@
 version: 0.4
 name: memtier_benchmark-100Kkeys-load-hash-20-fields-with-1B-values-pipeline-30
 description: 'Runs memtier_benchmark, for a keyspace length of 100K keys loading HASHES with 50
-  fields each. Each field value has a data size of 10 Bytes. Encoding: listpack (20 fields x 1B
+  fields each. Each field value has a data size of 10 Bytes. Encoding: listpack (50 fields x 10B
   values, below hash-max-listpack-entries 128 and hash-max-listpack-value 64).'
 dbconfig:
   configuration-parameters:
@@ -37,6 +37,7 @@ clientconfig:
     field:42 __data__ field:43 __data__ field:44 __data__ field:45 __data__ field:46
     __data__ field:47 __data__ field:48 __data__ field:49 __data__ field:50 __data__"
     --command-key-pattern="R" --key-minimum=1 --key-maximum 100000 -c 50 -t 4 --hide-histogram
+    --pipeline 30
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata.yml
@@ -2,7 +2,8 @@ version: 0.4
 name: memtier_benchmark-10Mkeys-load-string-with-10B-values-randomdata
 description: "Loads 10M string keys with 10B random-data values, all EMBSTR
   encoding. Sister spec to the 1M variant for validating robj-layout changes
-  (e.g. Valkey-#2516-style ptr reuse): at 10M keys the total dataset + robj
+  (e.g. embedding small values in the robj to save a pointer indirection): at
+  10M keys the total dataset + robj
   overhead is ~600MB, so the keyspace no longer fits in any CPU's L3 cache
   and every dict lookup pays DRAM latency. This is where the throughput
   impact of pointer chasing in robj actually surfaces - the 1M variant is

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-bitmap-getbit-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-bitmap-getbit-pipeline-10.yml
@@ -1,7 +1,8 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-bitmap-getbit-pipeline-10
 description: Runs memtier_benchmark, for a keyspace length of 1M keys focusing on
-  EXISTS performance. 50% of the EXIST commands will be on non-existing keys.
+  GETBIT performance. Each key is a 1-bit bitmap preloaded via SETBIT; the client
+  issues GETBIT at offsets 1 and 100 across the keyspace.
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -32,7 +33,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --pipeline 50 --command="GETBIT __key__ 1" --command-key-pattern="R"  --command
+  arguments: --pipeline 10 --command="GETBIT __key__ 1" --command-key-pattern="R"  --command
     "GETBIT __key__ 100" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time
     180
   resources:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hincrby.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hincrby.yml
@@ -34,7 +34,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --test-time 180 --command "HINCRBY __key__ field1 1.0" --command-key-pattern="R"
+  arguments: --test-time 180 --command "HINCRBY __key__ counter 1" --command-key-pattern="R"
     --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hincrbyfloat.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hincrbyfloat.yml
@@ -34,7 +34,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --test-time 180 --command "HINCRBYFLOAT __key__ field1 0.999999" --command-key-pattern="R"
+  arguments: --test-time 180 --command "HINCRBYFLOAT __key__ fcounter 0.999999" --command-key-pattern="R"
     --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata.yml
@@ -1,8 +1,8 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-string-append-10B-to-40B-randomdata
 description: "Append-path benchmark used to validate the EMBSTR -> RAW conversion
-  cost introduced when robj layout changes (e.g. Valkey PR 2516, and any Redis
-  equivalent that packs small values into the robj itself). Preloads 1M keys as
+  cost introduced when robj layout changes (e.g. any change that packs small
+  values into the robj itself). Preloads 1M keys as
   10B EMBSTR (well under the 44B threshold), then runs APPEND ops that push each
   key over the threshold on first touch, forcing the encoding conversion. Uses
   --random-data to exercise realistic allocator behaviour rather than all-zero

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-mixed-embstr-raw-pipeline-100-randomdata.yml
@@ -4,9 +4,10 @@ description: "High-pipeline GET benchmark against a DB with mixed EMBSTR/RAW
   encodings. Preload uses --data-size-range 10-200 with --data-size-pattern R
   so value sizes are uniformly random, producing ~17% EMBSTR (values <=44B)
   and ~83% RAW. Exercises the common-case read path across both encodings so
-  that any EMBSTR-layout change (e.g. Valkey-style robj ptr reuse) can be
-  checked for regressions on the dominant RAW path and on the hot GET dispatch
-  branch. --random-data is used so allocator behaviour reflects realistic byte
+  that any EMBSTR robj-layout change (e.g. embedding small values in the robj
+  to save a pointer indirection) can be checked for regressions on the dominant
+  RAW path and on the hot GET dispatch branch. --random-data is used so
+  allocator behaviour reflects realistic byte
   patterns rather than all-zero pages."
 dbconfig:
   configuration-parameters:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfcount-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfcount-100B-values.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" --random-data --command "PFADD __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 3 -n 30000 -c 1 -t 1 --hide-histogram'
+    arguments: '"--data-size" "100" --random-data --command "PFADD __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 4 -n 30000 -c 1 -t 1 --hide-histogram'
   resources:
     requests:
       memory: 2g

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfmerge-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-multiple-hll-pfmerge-100B-values.yml
@@ -9,7 +9,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "100" --random-data --command "PFADD __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 3 -n 30000 -c 1 -t 1 --hide-histogram'
+    arguments: '"--data-size" "100" --random-data --command "PFADD __key__ __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 4 -n 30000 -c 1 -t 1 --hide-histogram'
   resources:
     requests:
       memory: 2g


### PR DESCRIPTION
Several existing test-suites were not exercising the command they claim to benchmark. Each fix below is arguments/description-only; `tested-commands`/`tested-groups` are unchanged and `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` passes (exit 0).

### Suites that measured the error path
- **`1Mkeys-hash-hincrby` / `1Mkeys-hash-hincrbyfloat`** — the client incremented `field1`, which the preload populates with a 1000-byte random string, so every call returned `value is not an integer/float` and the suite measured the *error* path. Now increment a dedicated numeric field (`counter`/`fcounter`). (`hincrby` additionally passed a float `1.0` to an integer command.) Verified locally: incrementing the preloaded field errors; a fresh field increments correctly.

### Workload / name mismatches
- **`1Mkeys-bitmap-getbit-pipeline-10`** — description was copy-pasted from an EXISTS suite (now describes GETBIT); the client ran at `--pipeline 50` while the name says pipeline-10 → aligned to `--pipeline 10`.
- **`multiple-hll-pfcount-100B-values` / `pfmerge-100B-values`** — preload used `--key-maximum 3` with the sequential pattern, which populates only `memtier-1`/`memtier-2`, so the `keyspacelen: 3` check and the 3-key `PFCOUNT`/`PFMERGE` read an empty `memtier-3`. Bumped to `--key-maximum 4`.
- **`100Kkeys-load-hash-20-fields-with-1B-values-pipeline-30`** — name advertises pipeline-30 but no `--pipeline` flag was set (ran at pipeline 1); added `--pipeline 30` and corrected the encoding note in the description to match the actual 50-field/10B layout.

### Description clarity
- Reworded the benchmark descriptions of three `*-randomdata` string suites for accuracy regarding the robj-layout scenario they validate.

> Note: the `htll` filename typo (the suite correctly runs `HTTL` internally) was intentionally left alone — renaming would reset that suite's time-series history for a cosmetic fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only benchmark spec fixes; no application code, auth, or data handling changes—though corrected workloads may shift reported benchmark numbers versus prior misleading runs.
> 
> **Overview**
> Fixes several **memtier_benchmark** test suites that were not measuring the commands or workloads their names/descriptions claim.
> 
> **HINCRBY / HINCRBYFLOAT** suites now increment dedicated numeric fields (`counter` / `fcounter`) instead of `field1`, which was preloaded with 1000B strings and forced every call down the **error** path; `HINCRBY` also stops passing a float increment.
> 
> **GETBIT pipeline-10** gets an accurate description (replacing copy-pasted EXISTS text) and **`--pipeline 10`** instead of 50. **HyperLogLog PFCOUNT/PFMERGE** preload bumps **`--key-maximum` from 3 to 4** so sequential loading actually fills `memtier-3` for the 3-key client commands. The **100K hash load pipeline-30** suite adds the missing **`--pipeline 30`** and corrects the listpack field/size note in the description.
> 
> Three **randomdata string** suite descriptions are reworded to describe robj-layout validation more generically (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfef38dfd7a92d3a739bf4ee4d41c87244cb0090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->