### PR TITLE
fix(common): tolerate deleted/inaccessible PR comment on update (#252)

### DIFF
--- a/redis_benchmarks_specification/__common__/github.py
+++ b/redis_benchmarks_specification/__common__/github.py
@@ -1,5 +1,6 @@
 import logging
 from github import Github
+from github.GithubException import GithubException
 
 
 def check_regression_comment(comments):
@@ -191,6 +192,11 @@ def update_comment_if_needed(
             print(DF)
             print("---------------------")
     if same_comment is False:
+        if regression_comment is None:
+            logging.warning(
+                "No regression comment object available to update; skipping edit."
+            )
+            return
         if auto_approve:
             print("auto approving...")
         else:
@@ -200,10 +206,19 @@ def update_comment_if_needed(
                 )
             )
         if user_input.lower() == "y" or auto_approve:
-            html_url = regression_comment.html_url
-            print("Updating comment {}".format(html_url))
-            regression_comment.edit(comment_body)
-            print("Updated comment. Access it via {}".format(html_url))
+            try:
+                html_url = regression_comment.html_url
+                print("Updating comment {}".format(html_url))
+                regression_comment.edit(comment_body)
+                print("Updated comment. Access it via {}".format(html_url))
+            except GithubException as e:
+                # The comment may have been deleted between fetch and edit, or
+                # the token may lack permissions. Don't abort the whole run for
+                # a single comment update -- log and move on. (issue #252)
+                logging.warning(
+                    "Failed to update github comment (it may have been "
+                    "deleted or be inaccessible): {}. Skipping update.".format(e)
+                )
 
 
 def check_benchmark_build_comment(comments):

--- a/utils/tests/test_github_comment.py
+++ b/utils/tests/test_github_comment.py
@@ -1,0 +1,73 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+
+from unittest.mock import MagicMock
+
+from github.GithubException import GithubException
+
+from redis_benchmarks_specification.__common__.github import (
+    update_comment_if_needed,
+)
+
+
+def test_update_comment_if_needed_handles_deleted_comment():
+    """issue #252: a comment deleted (or inaccessible) between fetch and edit
+    must not abort the run. update_comment_if_needed should swallow the
+    GithubException and continue."""
+    regression_comment = MagicMock()
+    regression_comment.html_url = "https://example.com/c/1"
+    regression_comment.edit.side_effect = GithubException(
+        404, {"message": "Not Found"}, None
+    )
+
+    # Should NOT raise even though .edit() blows up with a 404.
+    update_comment_if_needed(
+        auto_approve=True,
+        comment_body="new body",
+        old_regression_comment_body="old body",
+        regression_comment=regression_comment,
+        verbose=False,
+    )
+    regression_comment.edit.assert_called_once()
+
+
+def test_update_comment_if_needed_handles_missing_comment_object():
+    """A None regression_comment (nothing to edit) must be a no-op, not an
+    AttributeError."""
+    update_comment_if_needed(
+        auto_approve=True,
+        comment_body="new body",
+        old_regression_comment_body="old body",
+        regression_comment=None,
+        verbose=False,
+    )
+
+
+def test_update_comment_if_needed_noop_when_unchanged():
+    """When the body is identical the function must not attempt an edit."""
+    regression_comment = MagicMock()
+    update_comment_if_needed(
+        auto_approve=True,
+        comment_body="same body",
+        old_regression_comment_body="same body",
+        regression_comment=regression_comment,
+        verbose=False,
+    )
+    regression_comment.edit.assert_not_called()
+
+
+def test_update_comment_if_needed_edits_on_change():
+    """Happy path: a changed body triggers a single edit() call."""
+    regression_comment = MagicMock()
+    regression_comment.html_url = "https://example.com/c/2"
+    update_comment_if_needed(
+        auto_approve=True,
+        comment_body="new body",
+        old_regression_comment_body="old body",
+        regression_comment=regression_comment,
+        verbose=False,
+    )
+    regression_comment.edit.assert_called_once_with("new body")


### PR DESCRIPTION
Fixes #252.

`update_comment_if_needed()` called `regression_comment.edit()` with no error handling. If the comment was deleted between fetch and edit, or the token lacks permission, PyGithub raises `GithubException` (e.g. 404) which propagated up and aborted the coordinator's per-stream work for that run.

This wraps the edit (and `html_url` access) in `try/except GithubException`, logs a warning and continues; it also guards against a `None` comment object. The public signature is unchanged, so existing callers (builder, coordinator, compare, cli) are unaffected.

Adds `utils/tests/test_github_comment.py` covering:
- deleted comment → `GithubException(404)` is swallowed, run continues
- `None` comment object → no-op (no `AttributeError`)
- identical body → no edit attempted
- changed body → exactly one `edit()` call

All four tests pass locally; `black --check` is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error handling around GitHub comment edits in automation tooling; no auth, data, or API contract changes for callers.
> 
> **Overview**
> **`update_comment_if_needed`** no longer fails the whole benchmark/coordinator run when a GitHub PR comment cannot be updated. If **`regression_comment`** is **`None`**, it logs a warning and returns instead of touching **`html_url`** / **`edit()`**. When the body changed and an update is approved, **`edit()`** (and URL access) is wrapped in **`try/except GithubException`** so 404s, permission errors, or comments deleted after fetch only produce a warning (issue #252).
> 
> Adds **`utils/tests/test_github_comment.py`** with unit tests for swallowed 404 on edit, **`None`** comment no-op, unchanged body skipping edit, and successful single **`edit()`** on change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485ad7bd165181636dafe16d2e019ae19d2da0dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->