### PR TITLE
feat(test-suites): add string command coverage (GETSET, SETNX, GETEX, GETRANGE, DECRBY, STRLEN)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decrby.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-decrby.yml
@@ -1,0 +1,41 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-decrby
+description: 'Runs memtier_benchmark for a keyspace of 1M string keys using
+  integer-encoded values and issuing DECRBY by a fixed amount.
+  Encoding: INT (integer-parsable value stored as a shared/long encoding).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: ' --command "SET __key__ 9223372036854775807" --command-key-pattern="P"
+      -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-int-size
+  dataset_description: This dataset contains 1 million integer-encoded string keys.
+tested-commands:
+- decrby
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 180 --command "DECRBY __key__ 1" --command-key-pattern="R"
+    --key-minimum=1 --key-maximum 1000000 -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 115

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-getex-ttl-100B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-getex-ttl-100B.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-getex-ttl-100B
+description: 'Runs memtier_benchmark benchmarking GETEX with an expiration update
+  (GETEX key EX 100), exercising the read path plus the expire-set path without
+  deleting the key. Keyspace of 1M string keys, each value 100 bytes.
+  Encoding: RAW (100B > 44B embstr threshold).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "SET __key__ __data__" --command-key-pattern="P"
+      -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1Mkeys-string-100B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 100 bytes.
+tested-commands:
+- getex
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--test-time 180 --command "GETEX __key__ EX 100" --command-key-pattern="R"
+    --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 93

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-getrange-1KiB.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-getrange-1KiB.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-getrange-1KiB
+description: 'Runs memtier_benchmark benchmarking GETRANGE (sub-range extraction).
+  Preloads 1M string keys with 1000-byte values and reads a 100-byte window
+  (GETRANGE key 0 99). Keyspace of 1M keys.
+  Encoding: RAW (1000B > 44B embstr threshold).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "1000" --command "SET __key__ __data__" --command-key-pattern="P"
+      -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1Mkeys-string-1000B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 1000 bytes.
+tested-commands:
+- getrange
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--test-time 180 --command "GETRANGE __key__ 0 99" --command-key-pattern="R"
+    --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 131

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-getset-100B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-getset-100B.yml
@@ -1,0 +1,42 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-getset-100B
+description: 'Runs memtier_benchmark for a keyspace of 1M string keys, benchmarking
+  GETSET (atomically set a new value and return the old one). Each value is 100 bytes.
+  Encoding: RAW (100B > 44B embstr threshold).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "SET __key__ __data__" --command-key-pattern="P"
+      -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1Mkeys-string-100B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 100 bytes.
+tested-commands:
+- getset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--test-time 180 "--data-size" "100" --command "GETSET __key__ __data__"
+    --command-key-pattern="R" --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 47

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setnx-10B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-setnx-10B.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-setnx-10B
+description: 'Runs memtier_benchmark benchmarking SETNX. Preloads 1M string keys, then
+  issues SETNX over a 2M key range so roughly 50% of calls hit an existing key (no-op
+  reject path) and 50% create a new key (write path). Each value is 10 bytes.
+  Encoding: EMBSTR (10B <= 44B embstr threshold).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" --command "SET __key__ __data__" --command-key-pattern="P"
+      -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-10B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 10 bytes.
+tested-commands:
+- setnx
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--test-time 180 "--data-size" "10" --command "SETNX __key__ __data__"
+    --command-key-pattern="R" --key-minimum=1 --key-maximum 2000000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 77

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-strlen-raw-1KiB.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-strlen-raw-1KiB.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-string-strlen-raw-1KiB
+description: 'Runs memtier_benchmark benchmarking STRLEN on RAW-encoded values.
+  Preloads 1M string keys with 1000-byte values and reads their length. Complements
+  the existing INT-encoded STRLEN coverage by exercising the sdslen path on RAW values.
+  Encoding: RAW (1000B > 44B embstr threshold).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "1000" --command "SET __key__ __data__" --command-key-pattern="P"
+      -n 5000 --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1Mkeys-string-1000B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data
+    size of 1000 bytes.
+tested-commands:
+- strlen
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '--test-time 180 --command "STRLEN __key__" --command-key-pattern="R"
+    --key-minimum=1 --key-maximum 1000000 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- string
+priority: 136


### PR DESCRIPTION
Adds benchmark coverage for several core string commands that had no dedicated suite. All follow the existing 1M-key string convention (preload `-n 5000 -c 50 -t 4 --pipeline 50`) and note the exercised encoding in the `description`.

| suite | command | encoding | priority |
|---|---|---|---|
| `1Mkeys-string-getset-100B` | GETSET | RAW (100B) | 47 |
| `1Mkeys-string-setnx-10B` | SETNX | EMBSTR (10B) | 77 |
| `1Mkeys-string-getex-ttl-100B` | GETEX … EX 100 | RAW (100B) | 93 |
| `1Mkeys-string-getrange-1KiB` | GETRANGE 0 99 | RAW (1000B) | 131 |
| `1Mkeys-string-decrby` | DECRBY | INT | 115 |
| `1Mkeys-string-strlen-raw-1KiB` | STRLEN | RAW (1000B) | 136 |

Notes:
- **SETNX** runs over a 2M key range against a 1M-key preload so ~50% of calls hit an existing key (no-op reject) and ~50% create — exercising both branches.
- **STRLEN (RAW)** complements the existing INT-encoded STRLEN coverage, exercising the `sdslen` path.
- Only **non-destructive** workloads were added, so the preloaded keyspace is not drained mid-run (GETDEL/SPOP-style destructive commands were deliberately left for a follow-up that handles re-population).

All commands resolve to the `string` group; the suites pass `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` (exit 0). Command semantics verified locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark specification YAML only; no runtime or product code changes, though CI may run additional benchmark jobs.
> 
> **Overview**
> Adds **six new memtier_benchmark test suites** under `redis_benchmarks_specification/test-suites` for string commands that previously lacked dedicated 1M-key coverage: **GETSET**, **SETNX**, **GETEX** (`EX 100`), **GETRANGE**, **DECRBY**, and **STRLEN** on RAW 1KiB values.
> 
> Each suite follows the existing **1M-key string** pattern (preload with pipelined `SET`, `oss-standalone`, gcc/dockerhub build variants, `tested-groups: string`) and documents the **value encoding** exercised (EMBSTR, RAW, or INT). Workloads are **non-destructive** so the preloaded keyspace stays stable for the 180s run.
> 
> Notable workload choices: **SETNX** uses a **2M key range** against a 1M preload (~50% reject vs create); **STRLEN (RAW)** complements existing INT-encoded STRLEN suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb529717c903fe6a5d9b921d0cc65f418a4aa339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->