### PR TITLE
fix(test-suites): make list pop benchmarks sound (no keyspace drain)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-100B-values.yml
@@ -1,8 +1,11 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-list-lpop-rpop-with-100B-values
-description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs in which
-  the value has a data size of 100 Bytes. After pre-loading the data it issues LPOP and RPOP
-  commands. Encoding: listpack (1 element x 100B per key, single-node listpack).'
+description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
+  ~64 elements of 100B each, then issuing a bounded number of LPOP and RPOP commands. The
+  client is capped via -n so total pops (~10/key) stay well below the preloaded depth, so the
+  lists are never drained and the benchmark measures the real LPOP/RPOP path (not the
+  empty-list fast-return). Encoding: listpack (~64 x 100B ~= 6.4KB per key, under the 8KB
+  list-max-listpack-size -2 threshold).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -12,11 +15,11 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "100" --command "LPUSH __key__ __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 1000000 --test-time 60 -c 50 -t 4 --hide-histogram
+      --key-minimum=1 --key-maximum 1000000 -n 320000 -c 50 -t 4 --hide-histogram
       --pipeline 50'
   resources:
     requests:
-      memory: 4g
+      memory: 10g
   dataset_name: 1Mkeys-list-100B-size
   dataset_description: This dataset contains 1 million list keys, each with a data
     size of 100 bytes.
@@ -36,7 +39,7 @@ clientconfig:
   tool: memtier_benchmark
   arguments: '"--data-size" "100" --command "LPOP __key__" --command-key-pattern="R"
     --command "RPOP __key__" --command-key-pattern="R"  --key-minimum=1 --key-maximum
-    1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+    1000000 -n 50000 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-100B-values.yml
@@ -2,7 +2,7 @@ version: 0.4
 name: memtier_benchmark-1Mkeys-list-lpop-rpop-with-100B-values
 description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
   ~64 elements of 100B each, then issuing a bounded number of LPOP and RPOP commands. The
-  client is capped via -n so total pops (~10/key) stay well below the preloaded depth, so the
+  client is capped via -n so total pops (~20/key, LPOP+RPOP) stay well below the preloaded depth, so the
   lists are never drained and the benchmark measures the real LPOP/RPOP path (not the
   empty-list fast-return). Encoding: listpack (~64 x 100B ~= 6.4KB per key, under the 8KB
   list-max-listpack-size -2 threshold).'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values.yml
@@ -1,8 +1,11 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values
-description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs in which
-  the value has a data size of 10 Bytes. After pre-loading the data it issues LPOP and RPOP
-  commands. Encoding: listpack (1 element x 10B per key, single-node listpack).'
+description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
+  ~128 elements of 10B each, then issuing a bounded number of LPOP and RPOP commands. The
+  client is capped via -n so total pops (~26/key) stay well below the preloaded depth, so the
+  lists are never drained and the benchmark measures the real LPOP/RPOP path (not the
+  empty-list fast-return). Encoding: listpack (~128 x 10B ~= 1.3KB per key, under the 8KB
+  list-max-listpack-size -2 threshold).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -12,11 +15,11 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "10" --command "LPUSH __key__ __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 1000000 --test-time 60 -c 50 -t 4 --hide-histogram
+      --key-minimum=1 --key-maximum 1000000 -n 640000 -c 50 -t 4 --hide-histogram
       --pipeline 50'
   resources:
     requests:
-      memory: 2g
+      memory: 4g
   dataset_name: 1Mkeys-list-10B-size
   dataset_description: This dataset contains 1 million list keys, each with a data
     size of 10 bytes.
@@ -36,7 +39,7 @@ clientconfig:
   tool: memtier_benchmark
   arguments: '"--data-size" "10" --command "LPOP __key__" --command-key-pattern="R"
     --command "RPOP __key__" --command-key-pattern="R"  --key-minimum=1 --key-maximum
-    1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+    1000000 -n 130000 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values.yml
@@ -2,7 +2,7 @@ version: 0.4
 name: memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values
 description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
   ~128 elements of 10B each, then issuing a bounded number of LPOP and RPOP commands. The
-  client is capped via -n so total pops (~26/key) stay well below the preloaded depth, so the
+  client is capped via -n so total pops (~52/key, LPOP+RPOP) stay well below the preloaded depth, so the
   lists are never drained and the benchmark measures the real LPOP/RPOP path (not the
   empty-list fast-return). Encoding: listpack (~128 x 10B ~= 1.3KB per key, under the 8KB
   list-max-listpack-size -2 threshold).'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-1KiB-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-1KiB-values.yml
@@ -1,8 +1,12 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-list-lpop-rpop-with-1KiB-values
-description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs in which
-  the value has a data size of 1000 Bytes. After pre-loading the data it issues LPOP and RPOP
-  commands. Encoding: listpack (1 element per key, single-node listpack).'
+description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
+  ~10 elements of 1000B each, then issuing a bounded number of LPOP and RPOP commands. The
+  client is capped via -n so total pops (~1.6/key) stay below the preloaded depth, so the
+  lists are never drained and the benchmark measures the real LPOP/RPOP path (not the
+  empty-list fast-return). At 1KiB values the list is quicklist-encoded (10 x 1000B exceeds
+  the 8KB list-max-listpack-size -2 threshold). Note: large values keep the keyspace memory
+  high, so the measured window is shorter than the smaller-value siblings.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -12,11 +16,11 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "1000" --command "LPUSH __key__ __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 1000000 --test-time 60 -c 50 -t 4 --hide-histogram
+      --key-minimum=1 --key-maximum 1000000 -n 50000 -c 50 -t 4 --hide-histogram
       --pipeline 50'
   resources:
     requests:
-      memory: 10g
+      memory: 14g
   dataset_name: 1Mkeys-list-1KiB-size
   dataset_description: This dataset contains 1 million list keys, each with a value
     of data size 1 KiB.
@@ -36,7 +40,7 @@ clientconfig:
   tool: memtier_benchmark
   arguments: '"--data-size" "1000" --command "LPOP __key__" --command-key-pattern="R"
     --command "RPOP __key__" --command-key-pattern="R"  --key-minimum=1 --key-maximum
-    1000000 --test-time 180 -c 50 -t 4 --hide-histogram'
+    1000000 -n 8000 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-1KiB-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-lpop-rpop-with-1KiB-values.yml
@@ -2,7 +2,7 @@ version: 0.4
 name: memtier_benchmark-1Mkeys-list-lpop-rpop-with-1KiB-values
 description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
   ~10 elements of 1000B each, then issuing a bounded number of LPOP and RPOP commands. The
-  client is capped via -n so total pops (~1.6/key) stay below the preloaded depth, so the
+  client is capped via -n so total pops (~3.2/key, LPOP+RPOP) stay below the preloaded depth, so the
   lists are never drained and the benchmark measures the real LPOP/RPOP path (not the
   empty-list fast-return). At 1KiB values the list is quicklist-encoded (10 x 1000B exceeds
   the 8KB list-max-listpack-size -2 threshold). Note: large values keep the keyspace memory

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-rpoplpush-with-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-rpoplpush-with-10B-values.yml
@@ -1,8 +1,13 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-list-rpoplpush-with-10B-values
-description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs in which
-  the value has a data size of 10 Bytes. After pre-loading the data it issues LPOP and RPOP
-  commands. Encoding: listpack (1 element x 10B per key, single-node listpack).'
+description: 'Runs memtier_benchmark, for a keyspace length of 1M keys pre-loading LISTs with
+  ~64 elements of 10B each, then issuing RPOPLPUSH moving one element from a random source
+  list to a random destination list (both __key__, each resolved to an independent random key
+  in [1,1M]). This is globally length-conserving across the keyspace, so total elements stay
+  constant: no single shared destination grows into a hot key (the previous version pushed
+  every element into one `myotherlist`) and the source lists are not drained to empty. The
+  benchmark measures the real RPOPLPUSH pop+push path on per-key listpack lists. Encoding:
+  listpack (~64 x 10B per key, under the 8KB list-max-listpack-size -2 threshold).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -12,11 +17,11 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "10" --command "LPUSH __key__ __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 1000000 --test-time 60 -c 50 -t 4 --hide-histogram
+      --key-minimum=1 --key-maximum 1000000 -n 320000 -c 50 -t 4 --hide-histogram
       --pipeline 50'
   resources:
     requests:
-      memory: 2g
+      memory: 4g
   dataset_name: 1Mkeys-list-10B-size
   dataset_description: This dataset contains 1 million list keys, each with a data
     size of 10 bytes.
@@ -33,7 +38,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "10" --command "RPOPLPUSH __key__ myotherlist" --command-key-pattern="R"
+  arguments: '"--data-size" "10" --command "RPOPLPUSH __key__ __key__" --command-key-pattern="R"
     --key-minimum=1 --key-maximum 1000000 --test-time 120 -c 50 -t 4 --hide-histogram'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-rpoplpush-with-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-list-rpoplpush-with-10B-values.yml
@@ -39,7 +39,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: '"--data-size" "10" --command "RPOPLPUSH __key__ __key__" --command-key-pattern="R"
-    --key-minimum=1 --key-maximum 1000000 --test-time 120 -c 50 -t 4 --hide-histogram'
+    --key-minimum=1 --key-maximum 1000000 -n 50000 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       cpus: '4'


### PR DESCRIPTION
The list `LPOP`/`RPOP` and `RPOPLPUSH` suites pre-loaded shallow lists and then popped from them for 120–180s. The lists emptied early in the run, so most of the measured window hit the **empty-list fast-return path** rather than the real pop path. `RPOPLPUSH` additionally pushed every element into a single shared `myotherlist`, turning it into a single hot-key write benchmark.

### Fixes
- **`lpop-rpop-{10B,100B,1KiB}`** — pre-load deterministic deep lists (~128 / ~64 / ~10 elements per key, via a partitioned `-n` preload) and cap the client with `-n` so total pops (~26 / ~10 / ~1.6 per key) stay well below the preloaded depth. Lists are never drained, so `LPOP`/`RPOP` measure the real pop path. Soundness is by construction: with a random key pattern the per-key pop count is Poisson with a small mean, whose tail stays far below the preloaded depth.
- **`rpoplpush`** — move one element from a random source list to a random destination list (`RPOPLPUSH __key__ __key__`; both `__key__` resolve to independent random keys). This is globally length-conserving across the keyspace: no single hot destination key, and the sources are not drained.
- Corrected the **encoding labels** to the actual depth/value size (10B & 100B stay listpack under the 8KB `list-max-listpack-size -2` budget; 1KiB is quicklist) and bumped preload memory headroom for the deeper datasets.

### Caveat
At 1KiB values the keyspace memory is high (1M keys × ~10 × 1000B ≈ 10 GB), so that variant uses a shorter measured window than its smaller-value siblings. A future option is to reduce its keyspace to allow a deeper buffer / longer window.

> These suites' historical time-series reset at this change (they previously measured the empty-list path), which is expected — the prior numbers were not measuring the intended workload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only benchmark specification changes; no application or Redis server code paths are modified.
> 
> **Overview**
> Fixes **memtier list pop benchmarks** so they measure non-empty list behavior instead of draining keys and hitting the empty-list fast path.
> 
> For **`lpop-rpop` (10B / 100B / 1KiB)** suites, preload now builds deeper per-key lists (partitioned `-n` on `LPUSH` instead of time-based preload) and the client phase replaces `--test-time` with a capped `-n` so LPOP+RPOP volume stays below preloaded depth. Descriptions now document listpack vs quicklist encoding at each value size; preload **memory requests** are raised for the larger datasets.
> 
> The **`rpoplpush`** suite switches from `RPOPLPUSH __key__ myotherlist` (single hot destination) to `RPOPLPUSH __key__ __key__` with independent random keys, deep preload, and bounded `-n`, keeping total list elements stable across the keyspace.
> 
> Historical time series for these suites will reset because prior runs largely measured the wrong workload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9887ac7baa57b50aced4f60a7d8cc899ed61569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->