### PR TITLE
feat(runner): bcast-listener tool support + CLIENT TRACKING BCAST fan-out suites

### DIFF
--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -728,6 +728,29 @@ def run_multiple_clients(
                     unix_socket,
                     None,  # username
                 )
+            elif "bcast-listener" in client_tool:
+                (
+                    _,
+                    benchmark_command_str,
+                    arbitrary_command,
+                ) = prepare_bcast_listener_parameters(
+                    client_config,
+                    client_tool,
+                    port,
+                    host,
+                    password,
+                    local_benchmark_output_filename,
+                    oss_cluster_api_enabled,
+                    tls_enabled,
+                    tls_skip_verify,
+                    test_tls_cert,
+                    test_tls_key,
+                    test_tls_cacert,
+                    resp_version,
+                    override_memtier_test_time,
+                    unix_socket,
+                    None,  # username
+                )
             elif "vector-db-benchmark" in client_tool:
                 (
                     _,
@@ -848,6 +871,10 @@ def run_multiple_clients(
                     "client_image": client_image,
                     "benchmark_command_str": benchmark_command_str,
                     "timeout": container_timeout,
+                    # Background helpers (e.g. bcast-listener) never self-exit;
+                    # they are stopped after the measuring clients finish and
+                    # are excluded from metrics aggregation.
+                    "is_background": "bcast-listener" in client_tool,
                 }
             )
 
@@ -859,10 +886,19 @@ def run_multiple_clients(
             # Fail fast on container startup errors
             raise RuntimeError(f"Failed to start client {client_index}: {e}")
 
-    # Wait for all containers to complete
-    logging.info(f"Waiting for {len(containers)} containers to complete...")
+    # Wait for the FOREGROUND (measuring) containers to complete, then stop
+    # any BACKGROUND helpers. Background helpers (e.g. bcast-listener) hold
+    # their connections open until killed and never self-exit, so they must
+    # not be waited on (that would block until the timeout and then fail the
+    # whole run); they are stopped once the measuring clients are done.
+    foreground = [c for c in containers if not c.get("is_background")]
+    background = [c for c in containers if c.get("is_background")]
+    logging.info(
+        f"Waiting for {len(foreground)} foreground container(s) to complete "
+        f"({len(background)} background helper(s) running)..."
+    )
 
-    for container_info in containers:
+    for container_info in foreground:
         container = container_info["container"]
         client_index = container_info["client_index"]
         client_tool = container_info["client_tool"]
@@ -918,7 +954,38 @@ def run_multiple_clients(
             except Exception as cleanup_error:
                 logging.warning(f"Client {client_index} cleanup error: {cleanup_error}")
 
-    logging.info(f"Successfully completed {len(containers)} client configurations")
+    # Stop background helpers (SIGTERM via docker stop) now that the measuring
+    # clients have finished. They emit no benchmark JSON and are never added to
+    # `results`, so they do not enter metrics aggregation.
+    for container_info in background:
+        container = container_info["container"]
+        client_index = container_info["client_index"]
+        client_tool = container_info["client_tool"]
+        try:
+            logging.info(
+                f"Stopping background helper client {client_index} ({client_tool})"
+            )
+            container.stop(timeout=10)  # SIGTERM, then SIGKILL after 10s
+            try:
+                bg_stdout = container.logs().decode("utf-8")
+                logging.info(
+                    f"Background helper {client_index} ({client_tool}) logs:\n{bg_stdout}"
+                )
+            except Exception:
+                pass
+        except docker.errors.NotFound:
+            logging.info(f"Background helper {client_index} already gone")
+        except Exception as e:
+            logging.warning(f"Error stopping background helper {client_index}: {e}")
+        finally:
+            try:
+                container.remove(force=True)
+            except Exception as cleanup_error:
+                logging.warning(
+                    f"Background helper {client_index} cleanup error: {cleanup_error}"
+                )
+
+    logging.info(f"Successfully completed {len(foreground)} measuring client(s)")
 
     # Aggregate results by reading JSON output files
     aggregated_stdout = ""
@@ -1470,6 +1537,90 @@ def prepare_pubsub_sub_bench_parameters(
         logging.info(f"Applied test-time override: {override_test_time}s")
 
     # Add cleaned user arguments
+    if user_arguments.strip():
+        benchmark_command_str = benchmark_command_str + " " + user_arguments.strip()
+
+    return benchmark_command, benchmark_command_str, arbitrary_command
+
+
+def prepare_bcast_listener_parameters(
+    clientconfig,
+    full_benchmark_path,
+    port,
+    server,
+    password,
+    local_benchmark_output_filename,
+    oss_cluster_api_enabled=False,
+    tls_enabled=False,
+    tls_skip_verify=False,
+    tls_cert=None,
+    tls_key=None,
+    tls_cacert=None,
+    resp_version=None,
+    override_test_time=0,
+    unix_socket="",
+    username=None,
+):
+    """
+    Prepare bcast-listener command parameters.
+
+    bcast-listener (image redis/bcast-tracking-bench) is a CLIENT TRACKING
+    BCAST load/helper tool. In "manual" mode it opens N RESP3 BCAST tracking
+    clients, drains invalidation messages, and holds the connections open
+    until it receives SIGTERM. It produces NO benchmark JSON output, so it is
+    launched as a detached BACKGROUND helper alongside memtier and is stopped
+    by the runner once the measuring clients finish (see run_multiple_clients).
+
+    Unlike memtier/pubsub-sub-bench it takes a single --redis-url instead of
+    -h/-p/-a; credentials (if any) are embedded in the URL. The tool's native
+    flags (--listener-count, --tracking-prefix, ...) are taken verbatim from
+    the YAML clientconfig["arguments"], mirroring the pubsub-sub-bench
+    pass-through.
+
+    NOTE: relies on the image ENTRYPOINT being the bcast-listener binary, so
+    the command is `manual --redis-url ...` (no binary prefix), exactly as the
+    pubsub-sub-bench branch relies on its image ENTRYPOINT.
+    """
+    from urllib.parse import quote
+
+    arbitrary_command = False
+
+    if unix_socket != "":
+        logging.warning("bcast-listener doesn't support unix sockets, using host/port")
+
+    # Build redis://[userinfo@]host:port/0 ; percent-encode credentials so
+    # special characters (@ : / etc.) in passwords do not corrupt the URL.
+    userinfo = ""
+    if password:
+        if username:
+            userinfo = f"{quote(username, safe='')}:{quote(password, safe='')}@"
+        else:
+            userinfo = f":{quote(password, safe='')}@"
+    scheme = "rediss" if tls_enabled else "redis"
+    redis_url = f"{scheme}://{userinfo}{server}:{port}/0"
+    if tls_enabled:
+        logging.warning("bcast-listener TLS (rediss) support not verified yet")
+
+    benchmark_command = ["manual", "--redis-url", redis_url]
+    logging.info(
+        "Preparing bcast-listener parameters: manual --redis-url "
+        f"{scheme}://{'<redacted>@' if userinfo else ''}{server}:{port}/0"
+    )
+    benchmark_command_str = " ".join(benchmark_command)
+
+    # bcast-listener has no test-time concept; it is stopped when the
+    # measuring clients finish, so override_test_time does not apply.
+    if override_test_time and override_test_time > 0:
+        logging.info(
+            "bcast-listener has no test-time; override_test_time ignored "
+            "(helper is stopped when measuring clients finish)"
+        )
+
+    # Append user-defined arguments from YAML verbatim
+    # (e.g. --listener-count 64 --tracking-prefix bench:).
+    user_arguments = ""
+    if "arguments" in clientconfig:
+        user_arguments = clientconfig["arguments"]
     if user_arguments.strip():
         benchmark_command_str = benchmark_command_str + " " + user_arguments.strip()
 

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -898,92 +898,92 @@ def run_multiple_clients(
         f"({len(background)} background helper(s) running)..."
     )
 
-    for container_info in foreground:
-        container = container_info["container"]
-        client_index = container_info["client_index"]
-        client_tool = container_info["client_tool"]
-        client_image = container_info["client_image"]
-        benchmark_command_str = container_info["benchmark_command_str"]
+    # A background helper that exits on its own BEFORE we stop it means the
+    # listeners were not active for the full measured window -> the result is
+    # invalid. Tracked here and raised after cleanup.
+    background_failures = []
 
-        try:
-            # Wait for container to complete
-            exit_code = container.wait(timeout=container_info["timeout"])
-            client_stdout = container.logs().decode("utf-8")
+    try:
+        for container_info in foreground:
+            container = container_info["container"]
+            client_index = container_info["client_index"]
+            client_tool = container_info["client_tool"]
+            client_image = container_info["client_image"]
+            benchmark_command_str = container_info["benchmark_command_str"]
 
-            # Check if container succeeded
-            if exit_code.get("StatusCode", 1) != 0:
-                logging.error(
-                    f"Client {client_index} failed with exit code: {exit_code}"
-                )
-                logging.error(f"Client {client_index} stdout/stderr:")
-                logging.error(client_stdout)
-                # Fail fast on container execution errors
-                raise RuntimeError(
-                    f"Client {client_index} ({client_tool}) failed with exit code {exit_code}"
-                )
-
-            logging.info(
-                f"Client {client_index} completed successfully with exit code: {exit_code}"
-            )
-
-            results.append(
-                {
-                    "client_index": client_index,
-                    "stdout": client_stdout,
-                    "config": client_configs[client_index],
-                    "tool": client_tool,
-                    "image": client_image,
-                }
-            )
-
-        except Exception as e:
-            # Get logs even if wait failed
             try:
+                # Wait for container to complete
+                exit_code = container.wait(timeout=container_info["timeout"])
                 client_stdout = container.logs().decode("utf-8")
-                logging.error(f"Client {client_index} logs:")
-                logging.error(client_stdout)
-            except:
-                logging.error(f"Could not retrieve logs for client {client_index}")
 
-            raise RuntimeError(f"Client {client_index} ({client_tool}) failed: {e}")
+                # Check if container succeeded
+                if exit_code.get("StatusCode", 1) != 0:
+                    logging.error(
+                        f"Client {client_index} failed with exit code: {exit_code}"
+                    )
+                    logging.error(f"Client {client_index} stdout/stderr:")
+                    logging.error(client_stdout)
+                    # Fail fast on container execution errors
+                    raise RuntimeError(
+                        f"Client {client_index} ({client_tool}) failed with exit code {exit_code}"
+                    )
 
-        finally:
-            # Clean up container
-            try:
-                container.remove(force=True)
-            except Exception as cleanup_error:
-                logging.warning(f"Client {client_index} cleanup error: {cleanup_error}")
-
-    # Stop background helpers (SIGTERM via docker stop) now that the measuring
-    # clients have finished. They emit no benchmark JSON and are never added to
-    # `results`, so they do not enter metrics aggregation.
-    for container_info in background:
-        container = container_info["container"]
-        client_index = container_info["client_index"]
-        client_tool = container_info["client_tool"]
-        try:
-            logging.info(
-                f"Stopping background helper client {client_index} ({client_tool})"
-            )
-            container.stop(timeout=10)  # SIGTERM, then SIGKILL after 10s
-            try:
-                bg_stdout = container.logs().decode("utf-8")
                 logging.info(
-                    f"Background helper {client_index} ({client_tool}) logs:\n{bg_stdout}"
+                    f"Client {client_index} completed successfully with exit code: {exit_code}"
                 )
-            except Exception:
-                pass
-        except docker.errors.NotFound:
-            logging.info(f"Background helper {client_index} already gone")
-        except Exception as e:
-            logging.warning(f"Error stopping background helper {client_index}: {e}")
-        finally:
-            try:
-                container.remove(force=True)
-            except Exception as cleanup_error:
-                logging.warning(
-                    f"Background helper {client_index} cleanup error: {cleanup_error}"
+
+                results.append(
+                    {
+                        "client_index": client_index,
+                        "stdout": client_stdout,
+                        "config": client_configs[client_index],
+                        "tool": client_tool,
+                        "image": client_image,
+                    }
                 )
+
+            except Exception as e:
+                # Get logs even if wait failed
+                try:
+                    client_stdout = container.logs().decode("utf-8")
+                    logging.error(f"Client {client_index} logs:")
+                    logging.error(client_stdout)
+                except:
+                    logging.error(f"Could not retrieve logs for client {client_index}")
+
+                raise RuntimeError(f"Client {client_index} ({client_tool}) failed: {e}")
+
+            finally:
+                # Clean up container
+                try:
+                    container.remove(force=True)
+                except Exception as cleanup_error:
+                    logging.warning(
+                        f"Client {client_index} cleanup error: {cleanup_error}"
+                    )
+
+    finally:
+        # ALWAYS stop + remove background helpers, even if a measuring client
+        # raised above, so listener containers never leak. Also detect helpers
+        # that exited on their own before we stopped them (auth error, OOM,
+        # crash) -- those invalidate the measurement.
+        for container_info in background:
+            failure = stop_background_helper(container_info)
+            if failure is not None:
+                background_failures.append(failure)
+
+    # If a background helper died before the benchmark finished, abort rather
+    # than report memtier numbers as if the listeners were active. (Only reached
+    # when the foreground loop did not already raise.)
+    if background_failures:
+        details = ", ".join(
+            f"client {i} ({t}) status={s} exit_code={c}"
+            for i, t, s, c in background_failures
+        )
+        raise RuntimeError(
+            f"Background helper(s) exited before the benchmark finished: {details}. "
+            f"Tracking listeners were not active for the full measured window; aborting."
+        )
 
     logging.info(f"Successfully completed {len(foreground)} measuring client(s)")
 
@@ -1625,6 +1625,85 @@ def prepare_bcast_listener_parameters(
         benchmark_command_str = benchmark_command_str + " " + user_arguments.strip()
 
     return benchmark_command, benchmark_command_str, arbitrary_command
+
+
+def stop_background_helper(container_info):
+    """Stop a background-helper container (e.g. bcast-listener) and report
+    whether it had already exited before we stopped it.
+
+    Background helpers hold their connections open until killed, so under
+    normal operation they are still ``running`` when the measuring clients
+    finish and we stop them with SIGTERM. If a helper has exited on its own
+    (auth error, OOM, crash) it means the listeners were NOT active for the
+    full measured window, so the run must fail.
+
+    Always attempts to remove the container (no leak, even on failure).
+
+    Returns a failure tuple ``(client_index, client_tool, status, exit_code)``
+    if the helper exited/disappeared during the run, otherwise ``None``.
+    """
+    container = container_info["container"]
+    client_index = container_info["client_index"]
+    client_tool = container_info["client_tool"]
+    failure = None
+    try:
+        try:
+            container.reload()
+            status = container.status
+        except docker.errors.NotFound:
+            status = "not-found"
+        except Exception as e:
+            logging.warning(
+                f"Could not query background helper {client_index} status: {e}"
+            )
+            status = "unknown"
+
+        if status == "running":
+            logging.info(
+                f"Stopping background helper client {client_index} ({client_tool})"
+            )
+            try:
+                container.stop(timeout=10)  # SIGTERM, then SIGKILL after 10s
+            except docker.errors.NotFound:
+                pass
+        elif status == "not-found":
+            logging.error(
+                f"Background helper {client_index} ({client_tool}) container is "
+                f"gone -- it did not survive the run; results are unreliable."
+            )
+            failure = (client_index, client_tool, status, None)
+        else:
+            # Exited/crashed during the measured window.
+            exit_code = None
+            try:
+                exit_code = container.attrs.get("State", {}).get("ExitCode")
+            except Exception:
+                pass
+            logging.error(
+                f"Background helper {client_index} ({client_tool}) exited early "
+                f"(status={status}, exit_code={exit_code}) -- tracking listeners "
+                f"were NOT active for the full measured window; results are "
+                f"unreliable."
+            )
+            failure = (client_index, client_tool, status, exit_code)
+
+        try:
+            bg_stdout = container.logs().decode("utf-8")
+            logging.info(
+                f"Background helper {client_index} ({client_tool}) logs:\n{bg_stdout}"
+            )
+        except Exception:
+            pass
+    except Exception as e:
+        logging.warning(f"Error handling background helper {client_index}: {e}")
+    finally:
+        try:
+            container.remove(force=True)
+        except Exception as cleanup_error:
+            logging.warning(
+                f"Background helper {client_index} cleanup error: {cleanup_error}"
+            )
+    return failure
 
 
 def enrich_results_with_redis_info(

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-0-listeners.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-0-listeners.yml
@@ -1,0 +1,35 @@
+version: 0.4
+name: memtier_benchmark-set-bcast-tracking-0-listeners
+description: "Baseline for the CLIENT TRACKING BCAST broadcast-fan-out benchmark: a
+  memtier SET workload into the 'bench:' key prefix with NO tracking listeners
+  connected, so no invalidation messages are produced. Compare ops/sec and SET
+  latency against the 100/1000-listener variants to isolate the per-write
+  broadcast fan-out cost. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr
+  threshold)."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- string
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 -d 16 --key-prefix "bench:" --key-minimum 1 --key-maximum
+    1000000 --command "SET __key__ __data__" --command-key-pattern="R" --pipeline 1
+    -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-100-listeners.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-100-listeners.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-set-bcast-tracking-100-listeners
+description: "CLIENT TRACKING BCAST broadcast-fan-out benchmark with 100 tracking
+  listeners. The bcast-listener helper (redis/bcast-tracking-bench) registers 100
+  RESP3 broadcast-tracking clients, while a memtier writer issues SET into the
+  'bench:' prefix; every write fans an invalidation push out to all 100 listeners,
+  exercising the server-side trackingBroadcastInvalidationMessages path. Compare
+  ops/sec and SET latency against the 0-listener baseline to isolate the fan-out
+  cost. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr threshold). NOTE: this
+  measures the UNFILTERED broadcast cost (all listeners are the default user and
+  track all keys); it does NOT by itself demonstrate ACL send-time filtering
+  (PR redis/redis#15122) -- that needs the ACL-user-selectivity variant described
+  in approaches/bcast-tracking-multitool-suite.md (blocked on a helper enhancement)."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- string
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 -d 16 --key-prefix "bench:" --key-minimum 1 --key-maximum
+    1000000 --command "SET __key__ __data__" --command-key-pattern="R" --pipeline 1
+    -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+- run_image: redis/bcast-tracking-bench:latest
+  tool: bcast-listener
+  arguments: "--listener-count 100 --tracking-prefix bench:"
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-100-listeners.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-100-listeners.yml
@@ -9,8 +9,9 @@ description: "CLIENT TRACKING BCAST broadcast-fan-out benchmark with 100 trackin
   cost. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr threshold). NOTE: this
   measures the UNFILTERED broadcast cost (all listeners are the default user and
   track all keys); it does NOT by itself demonstrate ACL send-time filtering
-  (PR redis/redis#15122) -- that needs the ACL-user-selectivity variant described
-  in approaches/bcast-tracking-multitool-suite.md (blocked on a helper enhancement)."
+  (PR redis/redis#15122) -- that needs listeners authenticated as distinct ACL
+  users with restrictive key patterns, while writing a large fraction of
+  non-permitted keys."
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-1000-listeners.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-1000-listeners.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-set-bcast-tracking-1000-listeners
+description: "CLIENT TRACKING BCAST broadcast-fan-out benchmark with 1000 tracking
+  listeners. The bcast-listener helper (redis/bcast-tracking-bench) registers 1000
+  RESP3 broadcast-tracking clients, while a memtier writer issues SET into the
+  'bench:' prefix; every write fans an invalidation push out to all 1000 listeners.
+  Scaling the listener count from 0 -> 100 -> 1000 maps how the per-write fan-out
+  cost grows. Compare ops/sec and SET latency against the 0-listener baseline.
+  Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr threshold). NOTE: this
+  measures the UNFILTERED broadcast cost (all listeners are the default user and
+  track all keys); it does NOT by itself demonstrate ACL send-time filtering
+  (PR redis/redis#15122) -- that needs the ACL-user-selectivity variant described
+  in approaches/bcast-tracking-multitool-suite.md (blocked on a helper enhancement)."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- string
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 -d 16 --key-prefix "bench:" --key-minimum 1 --key-maximum
+    1000000 --command "SET __key__ __data__" --command-key-pattern="R" --pipeline 1
+    -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+- run_image: redis/bcast-tracking-bench:latest
+  tool: bcast-listener
+  arguments: "--listener-count 1000 --tracking-prefix bench:"
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-1000-listeners.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-1000-listeners.yml
@@ -9,8 +9,9 @@ description: "CLIENT TRACKING BCAST broadcast-fan-out benchmark with 1000 tracki
   Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr threshold). NOTE: this
   measures the UNFILTERED broadcast cost (all listeners are the default user and
   track all keys); it does NOT by itself demonstrate ACL send-time filtering
-  (PR redis/redis#15122) -- that needs the ACL-user-selectivity variant described
-  in approaches/bcast-tracking-multitool-suite.md (blocked on a helper enhancement)."
+  (PR redis/redis#15122) -- that needs listeners authenticated as distinct ACL
+  users with restrictive key patterns, while writing a large fraction of
+  non-permitted keys."
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/utils/tests/test_bcast_listener.py
+++ b/utils/tests/test_bcast_listener.py
@@ -1,0 +1,72 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+
+from redis_benchmarks_specification.__runner__.runner import (
+    prepare_bcast_listener_parameters,
+)
+
+
+def _prep(
+    clientconfig,
+    host="127.0.0.1",
+    port=6379,
+    password=None,
+    username=None,
+    tls_enabled=False,
+    override_test_time=0,
+):
+    return prepare_bcast_listener_parameters(
+        clientconfig,
+        "bcast-listener",
+        port,
+        host,
+        password,
+        "benchmark_output_0.json",
+        tls_enabled=tls_enabled,
+        override_test_time=override_test_time,
+        username=username,
+    )
+
+
+def test_bcast_listener_no_auth_builds_manual_url():
+    cfg = {"arguments": "--listener-count 100 --tracking-prefix bench:"}
+    _, cmd, _ = _prep(cfg)
+    assert cmd == (
+        "manual --redis-url redis://127.0.0.1:6379/0 "
+        "--listener-count 100 --tracking-prefix bench:"
+    )
+
+
+def test_bcast_listener_password_only_embeds_in_url():
+    cfg = {"arguments": "--listener-count 64"}
+    _, cmd, _ = _prep(cfg, password="s3cret")
+    assert "redis://:s3cret@127.0.0.1:6379/0" in cmd
+    assert cmd.endswith("--listener-count 64")
+
+
+def test_bcast_listener_acl_user_password():
+    cfg = {"arguments": "--listener-count 1"}
+    _, cmd, _ = _prep(cfg, username="hot", password="pw")
+    assert "redis://hot:pw@127.0.0.1:6379/0" in cmd
+
+
+def test_bcast_listener_percent_encodes_special_chars():
+    cfg = {"arguments": "--listener-count 1"}
+    _, cmd, _ = _prep(cfg, password="p@ss:/word")
+    # @ : / must be percent-encoded so they don't corrupt the URL authority.
+    assert "p%40ss%3A%2Fword" in cmd
+    assert "p@ss:/word" not in cmd
+
+
+def test_bcast_listener_tls_uses_rediss_scheme():
+    cfg = {"arguments": "--listener-count 1"}
+    _, cmd, _ = _prep(cfg, tls_enabled=True)
+    assert cmd.startswith("manual --redis-url rediss://")
+
+
+def test_bcast_listener_no_arguments_key():
+    _, cmd, _ = _prep({})
+    assert cmd == "manual --redis-url redis://127.0.0.1:6379/0"

--- a/utils/tests/test_bcast_listener.py
+++ b/utils/tests/test_bcast_listener.py
@@ -4,9 +4,18 @@
 #  All rights reserved.
 #
 
+from unittest.mock import MagicMock
+
+import docker
+
 from redis_benchmarks_specification.__runner__.runner import (
     prepare_bcast_listener_parameters,
+    stop_background_helper,
 )
+
+
+def _bg(container, index=1, tool="bcast-listener"):
+    return {"container": container, "client_index": index, "client_tool": tool}
 
 
 def _prep(
@@ -70,3 +79,54 @@ def test_bcast_listener_tls_uses_rediss_scheme():
 def test_bcast_listener_no_arguments_key():
     _, cmd, _ = _prep({})
     assert cmd == "manual --redis-url redis://127.0.0.1:6379/0"
+
+
+def test_stop_background_helper_running_is_stopped_no_failure():
+    """A healthy helper (still running at the end) is stopped + removed and
+    reported as no failure."""
+    c = MagicMock()
+    c.status = "running"
+    c.logs.return_value = b"ready: 100 listeners"
+    failure = stop_background_helper(_bg(c))
+    assert failure is None
+    c.stop.assert_called_once()
+    c.remove.assert_called_once_with(force=True)
+
+
+def test_stop_background_helper_exited_is_a_failure():
+    """A helper that exited on its own (crash/OOM/auth) is reported as a
+    failure so the run aborts, and is still removed (no leak)."""
+    c = MagicMock()
+    c.status = "exited"
+    c.attrs = {"State": {"ExitCode": 137}}
+    c.logs.return_value = b"OOM"
+    failure = stop_background_helper(_bg(c, index=2))
+    assert failure is not None
+    idx, tool, status, code = failure
+    assert idx == 2 and status == "exited" and code == 137
+    c.stop.assert_not_called()  # already exited; nothing to stop
+    c.remove.assert_called_once_with(force=True)
+
+
+def test_stop_background_helper_not_found_is_a_failure():
+    """If the container vanished (reload -> NotFound) it's a failure but we
+    still attempt removal."""
+    c = MagicMock()
+    c.reload.side_effect = docker.errors.NotFound("gone")
+    failure = stop_background_helper(_bg(c, index=3))
+    assert failure is not None
+    assert failure[0] == 3 and failure[2] == "not-found"
+    c.stop.assert_not_called()
+    c.remove.assert_called_once_with(force=True)
+
+
+def test_stop_background_helper_always_removes_even_if_stop_raises():
+    """No container leak: remove is attempted even when stop() raises."""
+    c = MagicMock()
+    c.status = "running"
+    c.stop.side_effect = RuntimeError("docker daemon hiccup")
+    c.logs.return_value = b""
+    failure = stop_background_helper(_bg(c))
+    # stop failing is not itself a measurement failure (helper was running)
+    assert failure is None
+    c.remove.assert_called_once_with(force=True)


### PR DESCRIPTION
Adds support for the `bcast-listener` helper (Docker image `redis/bcast-tracking-bench`) as a background tool in a multi-tool `clientconfigs` suite, so a memtier writer can be benchmarked while N RESP3 `CLIENT TRACKING ON BCAST` listeners are connected — to measure invalidation fan-out cost.

### `runner.py`
- New `bcast-listener` dispatch branch in `run_multiple_clients` + `prepare_bcast_listener_parameters()`, mirroring the `pubsub-sub-bench` pass-through. Builds `manual --redis-url redis://[:pass@]host:port/0` (credentials percent-encoded) and appends the YAML tool args verbatim.
- The helper **never self-exits** (it holds tracking connections until killed), so it is launched detached, **excluded from the wait loop**, **stopped via `docker stop`** once the measuring clients finish, and **never added to `results`** — so metrics aggregation uses memtier's JSON only. (Waiting on it would block to the timeout and fail the run.)
- `utils/tests/test_bcast_listener.py` — 6 unit tests for the URL/arg builder (no-auth, password-only, ACL user, percent-encoding, TLS scheme, no-args). All pass; `black` clean.

### Suites
- `set-bcast-tracking-0-listeners` (baseline, singular `clientconfig` — also runs on the coordinator)
- `set-bcast-tracking-100-listeners`, `set-bcast-tracking-1000-listeners` (two-tool `clientconfigs`: memtier `[0]`, bcast-listener `[1]`)

Scaling listeners 0 → 100 → 1000 isolates the per-write broadcast fan-out cost. memtier is `clientconfigs[0]` so `Validate SPEC fields` passes (`tested-groups: [string]`, `tested-commands: [set]`).

### Scope notes
- These measure the **unfiltered** broadcast cost (all listeners are the default user tracking all keys). Demonstrating **ACL send-time filtering** requires listeners authenticated as distinct ACL users with restrictive key patterns — a helper enhancement — noted in the suite descriptions.
- Multi-tool `clientconfigs` execution currently lives only in the standalone `runner` (the `pubsub-sub-bench` suites use the same path); the self-contained coordinator does not yet consume `clientconfigs`. The 100/1000-listener suites run via the runner; the 0-listener baseline runs anywhere.
- Assumes the image ENTRYPOINT is the `bcast-listener` binary (same assumption the `pubsub-sub-bench` branch makes for its image) — verify with `docker inspect` on a runner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-client Docker lifecycle (foreground vs background wait/stop) and fails runs on helper early exit; incorrect handling could block benchmarks or leak containers, but scope is benchmark runner only with unit tests.
> 
> **Overview**
> Adds **`bcast-listener`** (`redis/bcast-tracking-bench`) as a **background** client in multi-tool `clientconfigs` runs so memtier can be measured while N RESP3 **CLIENT TRACKING BCAST** listeners stay connected.
> 
> **Runner:** New dispatch builds `manual --redis-url …` (percent-encoded auth, optional `rediss`) and appends YAML args. `run_multiple_clients` now waits only on **foreground** measuring clients, marks `bcast-listener` as `is_background`, **SIGTERM-stops** helpers after memtier finishes, and **fails the run** if a helper exited early (listeners not active for the full window). Helpers are omitted from results/JSON aggregation.
> 
> **Suites:** Baseline **0 listeners** (`clientconfig`) plus **100** and **1000** listener variants (memtier + `bcast-listener`) for SET into `bench:` prefix fan-out cost.
> 
> **Tests:** `utils/tests/test_bcast_listener.py` covers URL/command building and `stop_background_helper` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 503f5bd25d5f0acc152b6284a0524ceb1363741d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->