### PR TITLE
feat(test-suites): ACL-selectivity CLIENT TRACKING suites (measure send-time filtering)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-all-filtered.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-all-filtered.yml
@@ -1,0 +1,45 @@
+version: 0.4
+name: memtier_benchmark-set-bcast-tracking-acl-200-listeners-all-filtered
+description: "CLIENT TRACKING BCAST send-time ACL-filtering benchmark (max-delta case).
+  200 bcast-listener clients all authenticate as an ACL user permitted only 'bench:hot:*'
+  (--acl-user-patterns 'bench:hot:*'), while the memtier writer SETs into 'bench:cold:*'.
+  Every write is therefore NOT permitted for any listener, so send-time ACL filtering
+  (redis/redis#15122) drops 100% of the invalidations at send time, whereas the baseline
+  delivers all of them. Compare SET ops/sec and p50/p99 latency between a build with and
+  without the filtering change. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr
+  threshold). Requires a bcast-tracking-bench image with --acl-user-patterns support, and
+  runs via the multi-tool runner path."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- string
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 -d 16 --key-prefix "bench:cold:" --key-minimum 1 --key-maximum
+    1000000 --command "SET __key__ __data__" --command-key-pattern="R" --pipeline 1
+    -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+- run_image: redis/bcast-tracking-bench:latest
+  tool: bcast-listener
+  arguments: "--listener-count 200 --tracking-prefix bench: --acl-user-patterns bench:hot:*"
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-half-filtered.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-half-filtered.yml
@@ -1,0 +1,46 @@
+version: 0.4
+name: memtier_benchmark-set-bcast-tracking-acl-200-listeners-half-filtered
+description: "CLIENT TRACKING BCAST send-time ACL-filtering benchmark (realistic 50% case).
+  200 bcast-listener clients are split round-robin across two ACL users -- one permitted
+  only 'bench:hot:*' and one only 'bench:cold:*' (--acl-user-patterns 'bench:hot:*;bench:cold:*')
+  -- while the memtier writer SETs into 'bench:hot:*'. Each write is permitted for the
+  hot-user listeners (~50%) and NOT permitted for the cold-user listeners (~50%), so
+  send-time ACL filtering (redis/redis#15122) drops roughly half of the per-write fan-out
+  that the baseline would deliver. Compare SET ops/sec and p50/p99 latency between a build
+  with and without the filtering change. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr
+  threshold). Requires a bcast-tracking-bench image with --acl-user-patterns support, and
+  runs via the multi-tool runner path."
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- string
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 -d 16 --key-prefix "bench:hot:" --key-minimum 1 --key-maximum
+    1000000 --command "SET __key__ __data__" --command-key-pattern="R" --pipeline 1
+    -c 4 -t 4 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+- run_image: redis/bcast-tracking-bench:latest
+  tool: bcast-listener
+  arguments: "--listener-count 200 --tracking-prefix bench: --acl-user-patterns bench:hot:*;bench:cold:*"
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 50


### PR DESCRIPTION
Adds two multi-tool suites that actually exercise **send-time ACL filtering** of BCAST tracking invalidations (redis/redis#15122) — unlike the existing `set-bcast-tracking-{0,100,1000}-listeners` suites, which measure only the *unfiltered* fan-out and read ~0% delta for this PR.

| suite | listeners | ACL users | memtier writes | filtered |
|---|---|---|---|---|
| `acl-200-listeners-all-filtered` | 200 | 1 (`~bench:hot:*`) | `bench:cold:*` | **100%** (max delta) |
| `acl-200-listeners-half-filtered` | 200 | 2 (`~bench:hot:*`, `~bench:cold:*`) | `bench:hot:*` | **~50%** (realistic) |

With the filtering change, the non-permitted invalidations are dropped at send time (baseline delivers all), so the `SET` ops/sec and p50/p99 latency gap between a build with vs without #15122 is the signal.

- memtier is `clientconfigs[0]` so `Validate SPEC fields` passes (`tested-groups:[string]`, `tested-commands:[set]`). Validator exit 0.
- **Depends on** a `bcast-tracking-bench` image that supports `--acl-user-patterns` (redis-performance/bcast-tracking-bench branch `feat/per-listener-acl-users`), and runs via the multi-tool **runner** path (the coordinator doesn't consume `clientconfigs`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only new benchmark YAML definitions; no runtime or Redis server code changes, with optional dependency on an updated bench image.
> 
> **Overview**
> Adds **two** multi-tool memtier benchmark suites that measure **send-time ACL filtering** of CLIENT TRACKING BCAST invalidations (redis/redis#15122), filling a gap left by the existing `set-bcast-tracking-{0,100,1000}-listeners` suites, which only cover unfiltered fan-out.
> 
> **`acl-200-listeners-all-filtered`** pairs 200 listeners (ACL `bench:hot:*`) with memtier writes to `bench:cold:*`, so ~**100%** of invalidations should be dropped at send time with the filtering build. **`acl-200-listeners-half-filtered`** splits 200 listeners across two ACL users (`bench:hot:*` / `bench:cold:*`) while writing `bench:hot:*`, targeting ~**50%** filtered fan-out. Both use `bcast-listener` with `--acl-user-patterns`, memtier as the first `clientconfig` for spec validation, and the same topology/resources pattern as the other bcast-tracking suites.
> 
> Execution depends on a `bcast-tracking-bench` image that implements `--acl-user-patterns` and the multi-tool runner path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1919196783f1d4fc5271398dc39dc463060d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->