### PR TITLE
release: 0.3.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.17"
+version = "0.3.18"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
Version bump to **0.3.18** to release the changes merged since 0.3.17 (PRs #405–#410, #412), notably:
- `bcast-listener` multi-tool support in the runner + background-helper lifecycle (leak-proof, crash-detecting)
- CLIENT TRACKING BCAST fan-out and ACL-selectivity test-suites
- list pop suite soundness fixes, new string-command coverage, several test-suite corrections
- coordinator comment-resilience fix

After merge I'll cut the GitHub release `v0.3.18` (triggers the PyPI publish).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version change with no runtime or behavioral code modifications in this PR.
> 
> **Overview**
> Bumps the Poetry package version from **0.3.17** to **0.3.18** in `pyproject.toml` so the project can be tagged and published to PyPI.
> 
> This release packages work already merged since 0.3.17 (e.g. `bcast-listener` multi-tool runner support, CLIENT TRACKING BCAST/ACL test suites, list-pop and string-command coverage fixes, coordinator comment handling)—none of that lands in this diff; only the version string changes here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb4a9036a3b23357aa3406d4f4683e9a8a70805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->