### PR TITLE
feat(coordinator): multi-tool clientconfigs support (behind BENCHMARK_MULTITOOL_ENABLED, default off)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,31 @@ $ poetry run redis-benchmarks-spec-sc-coordinator --platform-name example-platfo
 
 You're now actively listening for benchmarks requests to Redis!
 
+### Multi-tool client configurations
+
+Some benchmark suites describe more than one client tool running concurrently against
+the same DB topology — for example a measuring client (`memtier_benchmark`) together with
+a helper client such as `bcast-listener` or `pubsub-sub-bench`. These suites use the
+`clientconfigs` list (plural) instead of a single `clientconfig`. Historically only the
+standalone `redis-benchmarks-spec-client-runner` could run them; the self-contained
+coordinator could not.
+
+The self-contained coordinator can now run multi-tool `clientconfigs` suites as well. The
+helper client (e.g. `bcast-listener`) runs in the background to generate the accompanying
+workload, while the measuring client (`memtier_benchmark`) runs in the foreground — and
+**all reported metrics come from the memtier client's output**, exactly as in a single-tool
+run. The background helper only shapes the workload; it does not contribute measured
+numbers.
+
+This path is gated behind the `BENCHMARK_MULTITOOL_ENABLED` environment flag, which is
+**off by default**:
+
+- `BENCHMARK_MULTITOOL_ENABLED=1` — the coordinator runs `clientconfigs` suites.
+- unset / `0` (default) — a `clientconfigs` suite is logged and cleanly skipped (the
+  single-`clientconfig` path is completely unaffected).
+
+The flag exists so the capability can ship dark and be rolled out to the fleet gradually
+after validation. Single-tool (`clientconfig`) suites are unchanged regardless of the flag.
 
 
 ## Architecture diagram

--- a/redis_benchmarks_specification/__common__/multi_tool.py
+++ b/redis_benchmarks_specification/__common__/multi_tool.py
@@ -1,0 +1,731 @@
+"""Shared multi-tool benchmark engine.
+
+Extracted from ``__runner__/runner.py`` so that both the standalone runner and
+the self-contained coordinator can launch multi-tool ``clientconfigs`` suites
+(e.g. a measuring ``memtier_benchmark`` client alongside a long-lived
+``bcast-listener`` background helper) using the same proven launch / wait /
+aggregate / teardown logic.
+
+The per-tool ``prepare_*_parameters`` functions intentionally STAY in
+``__runner__/runner.py`` and are reached here via a lazy import inside
+``prepare_client_run_specs`` to avoid a ``__common__`` -> ``__runner__`` import
+cycle.
+"""
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import docker
+
+from redis_benchmarks_specification.__common__.spec import (
+    extract_client_configs,
+    extract_client_container_images,
+    extract_client_tools,
+)
+
+
+@dataclass
+class ClientRunSpec:
+    client_index: int
+    client_tool: str  # e.g. "memtier_benchmark", "bcast-listener"
+    client_image: str
+    command_str: str  # fully-prepared benchmark command
+    output_filename: str  # basename, e.g. benchmark_output_{i}.json
+    is_background: bool = False  # "bcast-listener" in client_tool
+    environment: Optional[dict] = None  # vector-db env vars
+    working_dir: Optional[str] = None  # vector-db => /app
+    extra_volumes: Optional[dict] = None  # vector-db => /app/results mount
+
+
+@dataclass
+class MultiToolResult:
+    aggregated_stdout: str  # JSON string (memtier-based merge)
+    results: list  # per-client {client_index, stdout, config, tool, image}
+    memtier_output_filename: Optional[str]  # basename of the measured client's JSON
+    background_failures: list = field(default_factory=list)
+
+
+def remove_started_containers(containers):
+    """Force-remove every container started so far (best effort).
+
+    Used to clean up after a mid-launch failure so partially-started runs do
+    not leak running containers (notably long-lived background helpers).
+    """
+    for started in containers:
+        try:
+            started["container"].remove(force=True)
+        except Exception as cleanup_error:
+            logging.warning(
+                f"Error removing partially-started client "
+                f"{started.get('client_index')}: {cleanup_error}"
+            )
+
+
+def stop_background_helper(container_info):
+    """Stop a background-helper container (e.g. bcast-listener) and report
+    whether it had already exited before we stopped it.
+
+    Background helpers hold their connections open until killed, so under
+    normal operation they are still ``running`` when the measuring clients
+    finish and we stop them with SIGTERM. If a helper has exited on its own
+    (auth error, OOM, crash) it means the listeners were NOT active for the
+    full measured window, so the run must fail.
+
+    Always attempts to remove the container (no leak, even on failure).
+
+    Returns a failure tuple ``(client_index, client_tool, status, exit_code)``
+    if the helper exited/disappeared during the run, otherwise ``None``.
+    """
+    container = container_info["container"]
+    client_index = container_info["client_index"]
+    client_tool = container_info["client_tool"]
+    failure = None
+    try:
+        try:
+            container.reload()
+            status = container.status
+        except docker.errors.NotFound:
+            status = "not-found"
+        except Exception as e:
+            logging.warning(
+                f"Could not query background helper {client_index} status: {e}"
+            )
+            status = "unknown"
+
+        if status == "running":
+            logging.info(
+                f"Stopping background helper client {client_index} ({client_tool})"
+            )
+            try:
+                container.stop(timeout=10)  # SIGTERM, then SIGKILL after 10s
+            except docker.errors.NotFound:
+                pass
+        elif status == "not-found":
+            logging.error(
+                f"Background helper {client_index} ({client_tool}) container is "
+                f"gone -- it did not survive the run; results are unreliable."
+            )
+            failure = (client_index, client_tool, status, None)
+        else:
+            # Exited/crashed during the measured window.
+            exit_code = None
+            try:
+                exit_code = container.attrs.get("State", {}).get("ExitCode")
+            except Exception:
+                pass
+            logging.error(
+                f"Background helper {client_index} ({client_tool}) exited early "
+                f"(status={status}, exit_code={exit_code}) -- tracking listeners "
+                f"were NOT active for the full measured window; results are "
+                f"unreliable."
+            )
+            failure = (client_index, client_tool, status, exit_code)
+
+        try:
+            bg_stdout = container.logs().decode("utf-8")
+            logging.info(
+                f"Background helper {client_index} ({client_tool}) logs:\n{bg_stdout}"
+            )
+        except Exception:
+            pass
+    except Exception as e:
+        logging.warning(f"Error handling background helper {client_index}: {e}")
+    finally:
+        try:
+            container.remove(force=True)
+        except Exception as cleanup_error:
+            logging.warning(
+                f"Background helper {client_index} cleanup error: {cleanup_error}"
+            )
+    return failure
+
+
+def prepare_client_run_specs(
+    benchmark_config,
+    *,
+    host,
+    port,
+    password,
+    oss_cluster_api_enabled,
+    tls_enabled,
+    tls_skip_verify,
+    test_tls_cert,
+    test_tls_key,
+    test_tls_cacert,
+    resp_version,
+    override_memtier_test_time,
+    override_test_runs,
+    unix_socket,
+    benchmark_tool_workdir,
+    benchmark_local_install=False,
+    memtier_bin_path="memtier_benchmark",
+    client_mnt_point="/mnt/client/",
+):
+    """Normalize ``benchmark_config`` (single ``clientconfig`` OR multi
+    ``clientconfigs``) into a list of :class:`ClientRunSpec`.
+
+    Uses ``extract_client_configs`` / ``extract_client_tools`` /
+    ``extract_client_container_images`` from ``__common__.spec`` (so len==1 and
+    len==N share one path) and dispatches per tool to the runner's
+    ``prepare_*`` functions (memtier / pubsub-sub-bench / bcast-listener /
+    vector-db / else generic). Ports ``runner.py:677-792``.
+
+    The ``prepare_*`` functions are lazily imported from ``__runner__.runner``
+    inside this function body to avoid a ``__common__`` -> ``__runner__`` import
+    cycle.
+    """
+    # Lazy import to avoid __common__ -> __runner__ import cycle.
+    from redis_benchmarks_specification.__runner__.runner import (
+        prepare_benchmark_parameters,
+        prepare_bcast_listener_parameters,
+        prepare_memtier_benchmark_parameters,
+        prepare_pubsub_sub_bench_parameters,
+        prepare_vector_db_benchmark_parameters,
+    )
+
+    client_configs = extract_client_configs(benchmark_config)
+    client_images = extract_client_container_images(benchmark_config)
+    client_tools = extract_client_tools(benchmark_config)
+
+    if not client_configs:
+        raise ValueError("No client configurations found")
+
+    run_specs = []
+
+    for client_index, (client_config, client_tool, client_image) in enumerate(
+        zip(client_configs, client_tools, client_images)
+    ):
+        local_benchmark_output_filename = f"benchmark_output_{client_index}.json"
+        client_env_vars = None
+
+        # Prepare benchmark command for this client
+        if "memtier_benchmark" in client_tool:
+            # Set benchmark path based on local install option
+            if benchmark_local_install:
+                full_benchmark_path = memtier_bin_path
+            else:
+                full_benchmark_path = f"/usr/local/bin/{client_tool}"
+
+            (
+                _,
+                benchmark_command_str,
+                arbitrary_command,
+            ) = prepare_memtier_benchmark_parameters(
+                client_config,
+                full_benchmark_path,
+                port,
+                host,
+                password,
+                local_benchmark_output_filename,
+                oss_cluster_api_enabled,
+                tls_enabled,
+                tls_skip_verify,
+                test_tls_cert,
+                test_tls_key,
+                test_tls_cacert,
+                resp_version,
+                override_memtier_test_time,
+                override_test_runs,
+                unix_socket,
+            )
+        elif "pubsub-sub-bench" in client_tool:
+            (
+                _,
+                benchmark_command_str,
+                arbitrary_command,
+            ) = prepare_pubsub_sub_bench_parameters(
+                client_config,
+                client_tool,
+                port,
+                host,
+                password,
+                local_benchmark_output_filename,
+                oss_cluster_api_enabled,
+                tls_enabled,
+                tls_skip_verify,
+                test_tls_cert,
+                test_tls_key,
+                test_tls_cacert,
+                resp_version,
+                override_memtier_test_time,
+                unix_socket,
+                None,  # username
+            )
+        elif "bcast-listener" in client_tool:
+            (
+                _,
+                benchmark_command_str,
+                arbitrary_command,
+            ) = prepare_bcast_listener_parameters(
+                client_config,
+                client_tool,
+                port,
+                host,
+                password,
+                local_benchmark_output_filename,
+                oss_cluster_api_enabled,
+                tls_enabled,
+                tls_skip_verify,
+                test_tls_cert,
+                test_tls_key,
+                test_tls_cacert,
+                resp_version,
+                override_memtier_test_time,
+                unix_socket,
+                None,  # username
+            )
+        elif "vector-db-benchmark" in client_tool:
+            (
+                _,
+                benchmark_command_str,
+                arbitrary_command,
+                client_env_vars,
+            ) = prepare_vector_db_benchmark_parameters(
+                client_config,
+                client_tool,
+                port,
+                host,
+                password,
+                local_benchmark_output_filename,
+                oss_cluster_api_enabled,
+                tls_enabled,
+                tls_skip_verify,
+                test_tls_cert,
+                test_tls_key,
+                test_tls_cacert,
+                resp_version,
+                override_memtier_test_time,
+                unix_socket,
+                None,  # username
+            )
+        else:
+            # Handle other benchmark tools
+            (
+                benchmark_command,
+                benchmark_command_str,
+            ) = prepare_benchmark_parameters(
+                {**benchmark_config, "clientconfig": client_config},
+                client_tool,
+                port,
+                host,
+                local_benchmark_output_filename,
+                False,
+                benchmark_tool_workdir,
+                False,
+            )
+
+        is_background = "bcast-listener" in client_tool
+
+        working_dir = None
+        environment = None
+        extra_volumes = None
+        if "vector-db-benchmark" in client_tool:
+            working_dir = "/app"  # vector-db-benchmark needs to run from /app
+            environment = client_env_vars
+            # vector-db-benchmark also mounts the results directory at
+            # /app/results (the source dir is resolved at launch time).
+            extra_volumes = {"/app/results": {"mode": "rw"}}
+
+        run_specs.append(
+            ClientRunSpec(
+                client_index=client_index,
+                client_tool=client_tool,
+                client_image=client_image,
+                command_str=benchmark_command_str,
+                output_filename=local_benchmark_output_filename,
+                is_background=is_background,
+                environment=environment,
+                working_dir=working_dir,
+                extra_volumes=extra_volumes,
+            )
+        )
+
+    return run_specs
+
+
+def run_client_configs(
+    docker_client,
+    run_specs: List[ClientRunSpec],
+    *,
+    cpuset_cpus,
+    temporary_dir_client,
+    client_mnt_point="/mnt/client/",
+    inject_user=True,
+    default_timeout=300,
+    timeout_buffer=60,
+    on_container_started=None,
+    raise_on_nonzero=True,
+):
+    """Launch every :class:`ClientRunSpec` detached, wait for the FOREGROUND
+    (measuring) clients, stop BACKGROUND helpers in a ``finally`` (no leak),
+    force-remove all, raise if a background helper exited early, then aggregate
+    JSON (memtier is the measured base; pubsub/vector merge on top).
+
+    ``on_container_started(container, spec)`` is an optional caller hook (e.g.
+    the coordinator's profiler attach). ``inject_user`` adds ``user=uid:gid``
+    (runner passes ``True``; coordinator passes ``False`` to preserve current
+    behavior). Ports ``runner.py:864-1129``.
+    """
+    containers = []
+    results = []
+
+    # Start all containers simultaneously (detached)
+    for spec in run_specs:
+        client_index = spec.client_index
+        client_tool = spec.client_tool
+        client_image = spec.client_image
+        benchmark_command_str = spec.command_str
+        try:
+            # Calculate container timeout
+            container_timeout = default_timeout
+            if "test-time" in benchmark_command_str:
+                # Handle both --test-time (memtier) and -test-time (pubsub-sub-bench)
+                test_time_match = re.search(
+                    r"--?test-time[=\s]+(\d+)", benchmark_command_str
+                )
+                if test_time_match:
+                    test_time = int(test_time_match.group(1))
+                    container_timeout = test_time + timeout_buffer
+                    logging.info(
+                        f"Client {client_index}: Set container timeout to "
+                        f"{container_timeout}s (test-time: {test_time}s + "
+                        f"{timeout_buffer}s buffer)"
+                    )
+
+            logging.info(
+                f"Starting client {client_index} with docker image {client_image} "
+                f"(cpuset={cpuset_cpus}) with args: {benchmark_command_str}"
+            )
+
+            # Set working directory based on tool
+            working_dir = spec.working_dir if spec.working_dir else client_mnt_point
+
+            # Prepare container volumes
+            volumes = {
+                temporary_dir_client: {
+                    "bind": client_mnt_point,
+                    "mode": "rw",
+                },
+            }
+            # For vector-db-benchmark, also mount the results directory.
+            if spec.extra_volumes:
+                for bind_target, mount_opts in spec.extra_volumes.items():
+                    volumes[temporary_dir_client] = {
+                        "bind": bind_target,
+                        "mode": mount_opts.get("mode", "rw"),
+                    }
+
+            container_kwargs = {
+                "image": client_image,
+                "volumes": volumes,
+                "auto_remove": False,
+                "privileged": True,
+                "working_dir": working_dir,
+                "command": benchmark_command_str,
+                "network_mode": "host",
+                "detach": True,
+                "cpuset_cpus": cpuset_cpus,
+            }
+
+            # Only add user for non-vector-db-benchmark tools to avoid
+            # permission issues (vector-db sets a working_dir of /app).
+            if inject_user and spec.working_dir != "/app":
+                container_kwargs["user"] = f"{os.getuid()}:{os.getgid()}"
+
+            # Add environment variables (e.g. vector-db-benchmark).
+            if spec.environment:
+                container_kwargs["environment"] = spec.environment
+
+            container = docker_client.containers.run(**container_kwargs)
+
+            containers.append(
+                {
+                    "container": container,
+                    "client_index": client_index,
+                    "client_tool": client_tool,
+                    "client_image": client_image,
+                    "benchmark_command_str": benchmark_command_str,
+                    "timeout": container_timeout,
+                    "output_filename": spec.output_filename,
+                    # Background helpers (e.g. bcast-listener) never self-exit;
+                    # they are stopped after the measuring clients finish and
+                    # are excluded from metrics aggregation.
+                    "is_background": spec.is_background,
+                }
+            )
+
+            if on_container_started is not None:
+                on_container_started(container, spec)
+
+        except Exception as e:
+            error_msg = f"Error starting client {client_index}: {e}"
+            logging.error(error_msg)
+            logging.error(f"Image: {client_image}, Tool: {client_tool}")
+            logging.error(f"Command: {benchmark_command_str}")
+            # A later container failing to start must not leak the ones already
+            # started in this loop -- especially long-lived background helpers
+            # (bcast-listener) that would otherwise keep tracking connections
+            # open until manual cleanup. Force-remove everything started so far.
+            remove_started_containers(containers)
+            # Fail fast on container startup errors
+            raise RuntimeError(f"Failed to start client {client_index}: {e}")
+
+    # Wait for the FOREGROUND (measuring) containers to complete, then stop
+    # any BACKGROUND helpers. Background helpers (e.g. bcast-listener) hold
+    # their connections open until killed and never self-exit, so they must
+    # not be waited on (that would block until the timeout and then fail the
+    # whole run); they are stopped once the measuring clients are done.
+    foreground = [c for c in containers if not c.get("is_background")]
+    background = [c for c in containers if c.get("is_background")]
+    logging.info(
+        f"Waiting for {len(foreground)} foreground container(s) to complete "
+        f"({len(background)} background helper(s) running)..."
+    )
+
+    # A background helper that exits on its own BEFORE we stop it means the
+    # listeners were not active for the full measured window -> the result is
+    # invalid. Tracked here and raised after cleanup.
+    background_failures = []
+
+    try:
+        for container_info in foreground:
+            container = container_info["container"]
+            client_index = container_info["client_index"]
+            client_tool = container_info["client_tool"]
+            client_image = container_info["client_image"]
+            benchmark_command_str = container_info["benchmark_command_str"]
+
+            try:
+                # Wait for container to complete
+                exit_code = container.wait(timeout=container_info["timeout"])
+                client_stdout = container.logs().decode("utf-8")
+
+                # Check if container succeeded
+                if raise_on_nonzero and exit_code.get("StatusCode", 1) != 0:
+                    logging.error(
+                        f"Client {client_index} failed with exit code: {exit_code}"
+                    )
+                    logging.error(f"Client {client_index} stdout/stderr:")
+                    logging.error(client_stdout)
+                    # Fail fast on container execution errors
+                    raise RuntimeError(
+                        f"Client {client_index} ({client_tool}) failed with "
+                        f"exit code {exit_code}"
+                    )
+
+                logging.info(
+                    f"Client {client_index} completed successfully with "
+                    f"exit code: {exit_code}"
+                )
+
+                results.append(
+                    {
+                        "client_index": client_index,
+                        "stdout": client_stdout,
+                        "config": run_specs[client_index].__dict__,
+                        "tool": client_tool,
+                        "image": client_image,
+                    }
+                )
+
+            except Exception as e:
+                # Get logs even if wait failed
+                try:
+                    client_stdout = container.logs().decode("utf-8")
+                    logging.error(f"Client {client_index} logs:")
+                    logging.error(client_stdout)
+                except Exception:
+                    logging.error(f"Could not retrieve logs for client {client_index}")
+
+                raise RuntimeError(f"Client {client_index} ({client_tool}) failed: {e}")
+
+            finally:
+                # Clean up container
+                try:
+                    container.remove(force=True)
+                except Exception as cleanup_error:
+                    logging.warning(
+                        f"Client {client_index} cleanup error: {cleanup_error}"
+                    )
+
+    finally:
+        # ALWAYS stop + remove background helpers, even if a measuring client
+        # raised above, so listener containers never leak. Also detect helpers
+        # that exited on their own before we stopped them (auth error, OOM,
+        # crash) -- those invalidate the measurement.
+        for container_info in background:
+            failure = stop_background_helper(container_info)
+            if failure is not None:
+                background_failures.append(failure)
+
+    # If a background helper died before the benchmark finished, abort rather
+    # than report memtier numbers as if the listeners were active. (Only reached
+    # when the foreground loop did not already raise.)
+    if background_failures:
+        details = ", ".join(
+            f"client {i} ({t}) status={s} exit_code={c}"
+            for i, t, s, c in background_failures
+        )
+        raise RuntimeError(
+            f"Background helper(s) exited before the benchmark finished: {details}. "
+            f"Tracking listeners were not active for the full measured window; "
+            f"aborting."
+        )
+
+    logging.info(f"Successfully completed {len(foreground)} measuring client(s)")
+
+    # Aggregate results by reading JSON output files
+    aggregated_stdout = ""
+    memtier_output_filename = None
+    successful_results = [r for r in results if "error" not in r]
+
+    if successful_results:
+        # Try to read and aggregate JSON output files
+        aggregated_json = {}
+        memtier_json = None
+        pubsub_json = None
+        vector_json = None
+
+        for result in successful_results:
+            client_index = result["client_index"]
+            tool = result["tool"]
+
+            # Look for JSON output file
+            json_filename = f"benchmark_output_{client_index}.json"
+            json_filepath = os.path.join(temporary_dir_client, json_filename)
+
+            if os.path.exists(json_filepath):
+                try:
+                    with open(json_filepath, "r") as f:
+                        client_json = json.load(f)
+
+                    if "memtier_benchmark" in tool:
+                        # Store memtier JSON
+                        memtier_json = client_json
+                        memtier_output_filename = json_filename
+                        logging.info(
+                            f"Successfully read memtier JSON output from "
+                            f"client {client_index}"
+                        )
+                    elif "pubsub-sub-bench" in tool:
+                        # Store pubsub JSON
+                        pubsub_json = client_json
+                        logging.info(
+                            f"Successfully read pubsub-sub-bench JSON output "
+                            f"from client {client_index}"
+                        )
+                    elif "vector-db-benchmark" in tool:
+                        # For vector-db-benchmark, look for summary JSON file
+                        summary_files = [
+                            f
+                            for f in os.listdir(temporary_dir_client)
+                            if f.endswith("-summary.json")
+                        ]
+                        if summary_files:
+                            summary_filepath = os.path.join(
+                                temporary_dir_client, summary_files[0]
+                            )
+                            try:
+                                with open(summary_filepath, "r") as f:
+                                    vector_json = json.load(f)
+                                logging.info(
+                                    f"Successfully read vector-db-benchmark JSON "
+                                    f"output from {summary_files[0]}"
+                                )
+                            except Exception as e:
+                                logging.warning(
+                                    f"Failed to read vector-db-benchmark JSON "
+                                    f"from {summary_files[0]}: {e}"
+                                )
+                        else:
+                            logging.warning(
+                                f"No vector-db-benchmark summary JSON file found "
+                                f"for client {client_index}"
+                            )
+
+                    logging.info(
+                        f"Successfully read JSON output from client "
+                        f"{client_index} ({tool})"
+                    )
+
+                except Exception as e:
+                    logging.warning(
+                        f"Failed to read JSON from client {client_index}: {e}"
+                    )
+                    # Fall back to stdout
+                    pass
+            else:
+                logging.warning(
+                    f"JSON output file not found for client {client_index}: "
+                    f"{json_filepath}"
+                )
+
+        # Merge JSON outputs from all tools
+        if memtier_json and pubsub_json and vector_json:
+            # Use memtier as base and add other metrics
+            aggregated_json = memtier_json.copy()
+            aggregated_json.update(pubsub_json)
+            aggregated_json.update(vector_json)
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info(
+                "Using merged JSON results from memtier, pubsub-sub-bench, and "
+                "vector-db-benchmark clients"
+            )
+        elif memtier_json and pubsub_json:
+            # Use memtier as base and add pubsub metrics
+            aggregated_json = memtier_json.copy()
+            aggregated_json.update(pubsub_json)
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info(
+                "Using merged JSON results from memtier and pubsub-sub-bench clients"
+            )
+        elif memtier_json and vector_json:
+            # Use memtier as base and add vector metrics
+            aggregated_json = memtier_json.copy()
+            aggregated_json.update(vector_json)
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info(
+                "Using merged JSON results from memtier and vector-db-benchmark "
+                "clients"
+            )
+        elif pubsub_json and vector_json:
+            # Use pubsub as base and add vector metrics
+            aggregated_json = pubsub_json.copy()
+            aggregated_json.update(vector_json)
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info(
+                "Using merged JSON results from pubsub-sub-bench and "
+                "vector-db-benchmark clients"
+            )
+        elif memtier_json:
+            # Only memtier available
+            aggregated_json = memtier_json
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info("Using JSON results from memtier client only")
+        elif pubsub_json:
+            # Only pubsub available
+            aggregated_json = pubsub_json
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info("Using JSON results from pubsub-sub-bench client only")
+        elif vector_json:
+            # Only vector-db-benchmark available
+            aggregated_json = vector_json
+            aggregated_stdout = json.dumps(aggregated_json, indent=2)
+            logging.info("Using JSON results from vector-db-benchmark client only")
+        else:
+            # Fall back to concatenated stdout
+            aggregated_stdout = "\n".join([r["stdout"] for r in successful_results])
+            logging.warning(
+                "No JSON results found, falling back to concatenated stdout"
+            )
+
+    return MultiToolResult(
+        aggregated_stdout=aggregated_stdout,
+        results=results,
+        memtier_output_filename=memtier_output_filename,
+        background_failures=background_failures,
+    )

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -75,7 +75,6 @@ from redis_benchmarks_specification.__common__.spec import (
     extract_client_tool,
     extract_client_configs,
     extract_client_container_images,
-    extract_client_tools,
 )
 from redis_benchmarks_specification.__common__.multi_tool import (
     prepare_client_run_specs,

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -77,6 +77,12 @@ from redis_benchmarks_specification.__common__.spec import (
     extract_client_container_images,
     extract_client_tools,
 )
+from redis_benchmarks_specification.__common__.multi_tool import (
+    prepare_client_run_specs,
+    run_client_configs,
+    remove_started_containers,
+    stop_background_helper,
+)
 from redis_benchmarks_specification.__runner__.args import create_client_runner_args
 from redis_benchmarks_specification.__runner__.remote_profiling import RemoteProfiler
 
@@ -655,478 +661,46 @@ def run_multiple_clients(
     """
     Run multiple client configurations simultaneously and aggregate results.
     Returns aggregated stdout and list of individual results.
+
+    Thin adapter over the shared ``__common__.multi_tool`` engine: it normalizes
+    the benchmark config into ClientRunSpec objects, launches/waits/aggregates
+    them, and returns the same 2-tuple ``(aggregated_stdout, results)`` the call
+    site has always consumed.
     """
-    client_configs = extract_client_configs(benchmark_config)
-    client_images = extract_client_container_images(benchmark_config)
-    client_tools = extract_client_tools(benchmark_config)
-
-    if not client_configs:
-        raise ValueError("No client configurations found")
-
-    containers = []
-    results = []
-
-    # Start all containers simultaneously (detached)
-    for client_index, (client_config, client_tool, client_image) in enumerate(
-        zip(client_configs, client_tools, client_images)
-    ):
-        try:
-            local_benchmark_output_filename = f"benchmark_output_{client_index}.json"
-
-            # Prepare benchmark command for this client
-            if "memtier_benchmark" in client_tool:
-                # Set benchmark path based on local install option
-                if args.benchmark_local_install:
-                    full_benchmark_path = getattr(
-                        args, "memtier_bin_path", "memtier_benchmark"
-                    )
-                else:
-                    full_benchmark_path = f"/usr/local/bin/{client_tool}"
-
-                (
-                    _,
-                    benchmark_command_str,
-                    arbitrary_command,
-                ) = prepare_memtier_benchmark_parameters(
-                    client_config,
-                    full_benchmark_path,
-                    port,
-                    host,
-                    password,
-                    local_benchmark_output_filename,
-                    oss_cluster_api_enabled,
-                    tls_enabled,
-                    tls_skip_verify,
-                    test_tls_cert,
-                    test_tls_key,
-                    test_tls_cacert,
-                    resp_version,
-                    override_memtier_test_time,
-                    override_test_runs,
-                    unix_socket,
-                )
-            elif "pubsub-sub-bench" in client_tool:
-                (
-                    _,
-                    benchmark_command_str,
-                    arbitrary_command,
-                ) = prepare_pubsub_sub_bench_parameters(
-                    client_config,
-                    client_tool,
-                    port,
-                    host,
-                    password,
-                    local_benchmark_output_filename,
-                    oss_cluster_api_enabled,
-                    tls_enabled,
-                    tls_skip_verify,
-                    test_tls_cert,
-                    test_tls_key,
-                    test_tls_cacert,
-                    resp_version,
-                    override_memtier_test_time,
-                    unix_socket,
-                    None,  # username
-                )
-            elif "bcast-listener" in client_tool:
-                (
-                    _,
-                    benchmark_command_str,
-                    arbitrary_command,
-                ) = prepare_bcast_listener_parameters(
-                    client_config,
-                    client_tool,
-                    port,
-                    host,
-                    password,
-                    local_benchmark_output_filename,
-                    oss_cluster_api_enabled,
-                    tls_enabled,
-                    tls_skip_verify,
-                    test_tls_cert,
-                    test_tls_key,
-                    test_tls_cacert,
-                    resp_version,
-                    override_memtier_test_time,
-                    unix_socket,
-                    None,  # username
-                )
-            elif "vector-db-benchmark" in client_tool:
-                (
-                    _,
-                    benchmark_command_str,
-                    arbitrary_command,
-                    client_env_vars,
-                ) = prepare_vector_db_benchmark_parameters(
-                    client_config,
-                    client_tool,
-                    port,
-                    host,
-                    password,
-                    local_benchmark_output_filename,
-                    oss_cluster_api_enabled,
-                    tls_enabled,
-                    tls_skip_verify,
-                    test_tls_cert,
-                    test_tls_key,
-                    test_tls_cacert,
-                    resp_version,
-                    override_memtier_test_time,
-                    unix_socket,
-                    None,  # username
-                )
-            else:
-                # Handle other benchmark tools
-                (
-                    benchmark_command,
-                    benchmark_command_str,
-                ) = prepare_benchmark_parameters(
-                    {**benchmark_config, "clientconfig": client_config},
-                    client_tool,
-                    port,
-                    host,
-                    local_benchmark_output_filename,
-                    False,
-                    benchmark_tool_workdir,
-                    False,
-                )
-
-            # Calculate container timeout
-            container_timeout = 300  # 5 minutes default
-            # Use new timeout_buffer argument, fallback to container_timeout_buffer for backward compatibility
-            buffer_timeout = getattr(
-                args, "timeout_buffer", getattr(args, "container_timeout_buffer", 60)
-            )
-            if "test-time" in benchmark_command_str:
-                # Try to extract test time and add buffer
-                import re
-
-                # Handle both --test-time (memtier) and -test-time (pubsub-sub-bench)
-                test_time_match = re.search(
-                    r"--?test-time[=\s]+(\d+)", benchmark_command_str
-                )
-                if test_time_match:
-                    test_time = int(test_time_match.group(1))
-                    container_timeout = test_time + buffer_timeout
-                    logging.info(
-                        f"Client {client_index}: Set container timeout to {container_timeout}s (test-time: {test_time}s + {buffer_timeout}s buffer)"
-                    )
-
-            logging.info(
-                f"Starting client {client_index} with docker image {client_image} (cpuset={client_cpuset_cpus}) with args: {benchmark_command_str}"
-            )
-
-            # Start container (detached)
-            # Set working directory based on tool
-            working_dir = benchmark_tool_workdir
-            if "vector-db-benchmark" in client_tool:
-                working_dir = "/app"  # vector-db-benchmark needs to run from /app
-
-            # Prepare container arguments
-            volumes = {
-                temporary_dir_client: {
-                    "bind": client_mnt_point,
-                    "mode": "rw",
-                },
-            }
-
-            # For vector-db-benchmark, also mount the results directory
-            if "vector-db-benchmark" in client_tool:
-                volumes[temporary_dir_client] = {
-                    "bind": "/app/results",
-                    "mode": "rw",
-                }
-
-            container_kwargs = {
-                "image": client_image,
-                "volumes": volumes,
-                "auto_remove": False,
-                "privileged": True,
-                "working_dir": working_dir,
-                "command": benchmark_command_str,
-                "network_mode": "host",
-                "detach": True,
-                "cpuset_cpus": client_cpuset_cpus,
-            }
-
-            # Only add user for non-vector-db-benchmark tools to avoid permission issues
-            if "vector-db-benchmark" not in client_tool:
-                container_kwargs["user"] = f"{os.getuid()}:{os.getgid()}"
-
-            # Add environment variables for vector-db-benchmark
-            if "vector-db-benchmark" in client_tool:
-                try:
-                    container_kwargs["environment"] = client_env_vars
-                except NameError:
-                    # client_env_vars not defined, skip environment variables
-                    pass
-
-            container = docker_client.containers.run(**container_kwargs)
-
-            containers.append(
-                {
-                    "container": container,
-                    "client_index": client_index,
-                    "client_tool": client_tool,
-                    "client_image": client_image,
-                    "benchmark_command_str": benchmark_command_str,
-                    "timeout": container_timeout,
-                    # Background helpers (e.g. bcast-listener) never self-exit;
-                    # they are stopped after the measuring clients finish and
-                    # are excluded from metrics aggregation.
-                    "is_background": "bcast-listener" in client_tool,
-                }
-            )
-
-        except Exception as e:
-            error_msg = f"Error starting client {client_index}: {e}"
-            logging.error(error_msg)
-            logging.error(f"Image: {client_image}, Tool: {client_tool}")
-            logging.error(f"Command: {benchmark_command_str}")
-            # A later container failing to start must not leak the ones already
-            # started in this loop -- especially long-lived background helpers
-            # (bcast-listener) that would otherwise keep tracking connections
-            # open until manual cleanup. Force-remove everything started so far.
-            remove_started_containers(containers)
-            # Fail fast on container startup errors
-            raise RuntimeError(f"Failed to start client {client_index}: {e}")
-
-    # Wait for the FOREGROUND (measuring) containers to complete, then stop
-    # any BACKGROUND helpers. Background helpers (e.g. bcast-listener) hold
-    # their connections open until killed and never self-exit, so they must
-    # not be waited on (that would block until the timeout and then fail the
-    # whole run); they are stopped once the measuring clients are done.
-    foreground = [c for c in containers if not c.get("is_background")]
-    background = [c for c in containers if c.get("is_background")]
-    logging.info(
-        f"Waiting for {len(foreground)} foreground container(s) to complete "
-        f"({len(background)} background helper(s) running)..."
+    run_specs = prepare_client_run_specs(
+        benchmark_config,
+        host=host,
+        port=port,
+        password=password,
+        oss_cluster_api_enabled=oss_cluster_api_enabled,
+        tls_enabled=tls_enabled,
+        tls_skip_verify=tls_skip_verify,
+        test_tls_cert=test_tls_cert,
+        test_tls_key=test_tls_key,
+        test_tls_cacert=test_tls_cacert,
+        resp_version=resp_version,
+        override_memtier_test_time=override_memtier_test_time,
+        override_test_runs=override_test_runs,
+        unix_socket=unix_socket,
+        benchmark_tool_workdir=benchmark_tool_workdir,
+        benchmark_local_install=args.benchmark_local_install,
+        memtier_bin_path=getattr(args, "memtier_bin_path", "memtier_benchmark"),
+        client_mnt_point=client_mnt_point,
     )
 
-    # A background helper that exits on its own BEFORE we stop it means the
-    # listeners were not active for the full measured window -> the result is
-    # invalid. Tracked here and raised after cleanup.
-    background_failures = []
+    res = run_client_configs(
+        docker_client,
+        run_specs,
+        cpuset_cpus=client_cpuset_cpus,
+        temporary_dir_client=temporary_dir_client,
+        client_mnt_point=client_mnt_point,
+        inject_user=True,
+        timeout_buffer=getattr(
+            args, "timeout_buffer", getattr(args, "container_timeout_buffer", 60)
+        ),
+    )
 
-    try:
-        for container_info in foreground:
-            container = container_info["container"]
-            client_index = container_info["client_index"]
-            client_tool = container_info["client_tool"]
-            client_image = container_info["client_image"]
-            benchmark_command_str = container_info["benchmark_command_str"]
-
-            try:
-                # Wait for container to complete
-                exit_code = container.wait(timeout=container_info["timeout"])
-                client_stdout = container.logs().decode("utf-8")
-
-                # Check if container succeeded
-                if exit_code.get("StatusCode", 1) != 0:
-                    logging.error(
-                        f"Client {client_index} failed with exit code: {exit_code}"
-                    )
-                    logging.error(f"Client {client_index} stdout/stderr:")
-                    logging.error(client_stdout)
-                    # Fail fast on container execution errors
-                    raise RuntimeError(
-                        f"Client {client_index} ({client_tool}) failed with exit code {exit_code}"
-                    )
-
-                logging.info(
-                    f"Client {client_index} completed successfully with exit code: {exit_code}"
-                )
-
-                results.append(
-                    {
-                        "client_index": client_index,
-                        "stdout": client_stdout,
-                        "config": client_configs[client_index],
-                        "tool": client_tool,
-                        "image": client_image,
-                    }
-                )
-
-            except Exception as e:
-                # Get logs even if wait failed
-                try:
-                    client_stdout = container.logs().decode("utf-8")
-                    logging.error(f"Client {client_index} logs:")
-                    logging.error(client_stdout)
-                except:
-                    logging.error(f"Could not retrieve logs for client {client_index}")
-
-                raise RuntimeError(f"Client {client_index} ({client_tool}) failed: {e}")
-
-            finally:
-                # Clean up container
-                try:
-                    container.remove(force=True)
-                except Exception as cleanup_error:
-                    logging.warning(
-                        f"Client {client_index} cleanup error: {cleanup_error}"
-                    )
-
-    finally:
-        # ALWAYS stop + remove background helpers, even if a measuring client
-        # raised above, so listener containers never leak. Also detect helpers
-        # that exited on their own before we stopped them (auth error, OOM,
-        # crash) -- those invalidate the measurement.
-        for container_info in background:
-            failure = stop_background_helper(container_info)
-            if failure is not None:
-                background_failures.append(failure)
-
-    # If a background helper died before the benchmark finished, abort rather
-    # than report memtier numbers as if the listeners were active. (Only reached
-    # when the foreground loop did not already raise.)
-    if background_failures:
-        details = ", ".join(
-            f"client {i} ({t}) status={s} exit_code={c}"
-            for i, t, s, c in background_failures
-        )
-        raise RuntimeError(
-            f"Background helper(s) exited before the benchmark finished: {details}. "
-            f"Tracking listeners were not active for the full measured window; aborting."
-        )
-
-    logging.info(f"Successfully completed {len(foreground)} measuring client(s)")
-
-    # Aggregate results by reading JSON output files
-    aggregated_stdout = ""
-    successful_results = [r for r in results if "error" not in r]
-
-    if successful_results:
-        # Try to read and aggregate JSON output files
-
-        aggregated_json = {}
-        memtier_json = None
-        pubsub_json = None
-        vector_json = None
-
-        for result in successful_results:
-            client_index = result["client_index"]
-            tool = result["tool"]
-
-            # Look for JSON output file
-            json_filename = f"benchmark_output_{client_index}.json"
-            json_filepath = os.path.join(temporary_dir_client, json_filename)
-
-            if os.path.exists(json_filepath):
-                try:
-                    with open(json_filepath, "r") as f:
-                        client_json = json.load(f)
-
-                    if "memtier_benchmark" in tool:
-                        # Store memtier JSON
-                        memtier_json = client_json
-                        logging.info(
-                            f"Successfully read memtier JSON output from client {client_index}"
-                        )
-                    elif "pubsub-sub-bench" in tool:
-                        # Store pubsub JSON
-                        pubsub_json = client_json
-                        logging.info(
-                            f"Successfully read pubsub-sub-bench JSON output from client {client_index}"
-                        )
-                    elif "vector-db-benchmark" in tool:
-                        # For vector-db-benchmark, look for summary JSON file
-                        summary_files = [
-                            f
-                            for f in os.listdir(temporary_dir_client)
-                            if f.endswith("-summary.json")
-                        ]
-                        if summary_files:
-                            summary_filepath = os.path.join(
-                                temporary_dir_client, summary_files[0]
-                            )
-                            try:
-                                with open(summary_filepath, "r") as f:
-                                    vector_json = json.load(f)
-                                logging.info(
-                                    f"Successfully read vector-db-benchmark JSON output from {summary_files[0]}"
-                                )
-                            except Exception as e:
-                                logging.warning(
-                                    f"Failed to read vector-db-benchmark JSON from {summary_files[0]}: {e}"
-                                )
-                        else:
-                            logging.warning(
-                                f"No vector-db-benchmark summary JSON file found for client {client_index}"
-                            )
-
-                    logging.info(
-                        f"Successfully read JSON output from client {client_index} ({tool})"
-                    )
-
-                except Exception as e:
-                    logging.warning(
-                        f"Failed to read JSON from client {client_index}: {e}"
-                    )
-                    # Fall back to stdout
-                    pass
-            else:
-                logging.warning(
-                    f"JSON output file not found for client {client_index}: {json_filepath}"
-                )
-
-        # Merge JSON outputs from all tools
-        if memtier_json and pubsub_json and vector_json:
-            # Use memtier as base and add other metrics
-            aggregated_json = memtier_json.copy()
-            aggregated_json.update(pubsub_json)
-            aggregated_json.update(vector_json)
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info(
-                "Using merged JSON results from memtier, pubsub-sub-bench, and vector-db-benchmark clients"
-            )
-        elif memtier_json and pubsub_json:
-            # Use memtier as base and add pubsub metrics
-            aggregated_json = memtier_json.copy()
-            aggregated_json.update(pubsub_json)
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info(
-                "Using merged JSON results from memtier and pubsub-sub-bench clients"
-            )
-        elif memtier_json and vector_json:
-            # Use memtier as base and add vector metrics
-            aggregated_json = memtier_json.copy()
-            aggregated_json.update(vector_json)
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info(
-                "Using merged JSON results from memtier and vector-db-benchmark clients"
-            )
-        elif pubsub_json and vector_json:
-            # Use pubsub as base and add vector metrics
-            aggregated_json = pubsub_json.copy()
-            aggregated_json.update(vector_json)
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info(
-                "Using merged JSON results from pubsub-sub-bench and vector-db-benchmark clients"
-            )
-        elif memtier_json:
-            # Only memtier available
-            aggregated_json = memtier_json
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info("Using JSON results from memtier client only")
-        elif pubsub_json:
-            # Only pubsub available
-            aggregated_json = pubsub_json
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info("Using JSON results from pubsub-sub-bench client only")
-        elif vector_json:
-            # Only vector-db-benchmark available
-            aggregated_json = vector_json
-            aggregated_stdout = json.dumps(aggregated_json, indent=2)
-            logging.info("Using JSON results from vector-db-benchmark client only")
-        else:
-            # Fall back to concatenated stdout
-            aggregated_stdout = "\n".join([r["stdout"] for r in successful_results])
-            logging.warning(
-                "No JSON results found, falling back to concatenated stdout"
-            )
-
-    return aggregated_stdout, results
+    return res.aggregated_stdout, res.results
 
 
 def main():
@@ -1630,101 +1204,6 @@ def prepare_bcast_listener_parameters(
         benchmark_command_str = benchmark_command_str + " " + user_arguments.strip()
 
     return benchmark_command, benchmark_command_str, arbitrary_command
-
-
-def remove_started_containers(containers):
-    """Force-remove every container started so far (best effort).
-
-    Used to clean up after a mid-launch failure so partially-started runs do
-    not leak running containers (notably long-lived background helpers).
-    """
-    for started in containers:
-        try:
-            started["container"].remove(force=True)
-        except Exception as cleanup_error:
-            logging.warning(
-                f"Error removing partially-started client "
-                f"{started.get('client_index')}: {cleanup_error}"
-            )
-
-
-def stop_background_helper(container_info):
-    """Stop a background-helper container (e.g. bcast-listener) and report
-    whether it had already exited before we stopped it.
-
-    Background helpers hold their connections open until killed, so under
-    normal operation they are still ``running`` when the measuring clients
-    finish and we stop them with SIGTERM. If a helper has exited on its own
-    (auth error, OOM, crash) it means the listeners were NOT active for the
-    full measured window, so the run must fail.
-
-    Always attempts to remove the container (no leak, even on failure).
-
-    Returns a failure tuple ``(client_index, client_tool, status, exit_code)``
-    if the helper exited/disappeared during the run, otherwise ``None``.
-    """
-    container = container_info["container"]
-    client_index = container_info["client_index"]
-    client_tool = container_info["client_tool"]
-    failure = None
-    try:
-        try:
-            container.reload()
-            status = container.status
-        except docker.errors.NotFound:
-            status = "not-found"
-        except Exception as e:
-            logging.warning(
-                f"Could not query background helper {client_index} status: {e}"
-            )
-            status = "unknown"
-
-        if status == "running":
-            logging.info(
-                f"Stopping background helper client {client_index} ({client_tool})"
-            )
-            try:
-                container.stop(timeout=10)  # SIGTERM, then SIGKILL after 10s
-            except docker.errors.NotFound:
-                pass
-        elif status == "not-found":
-            logging.error(
-                f"Background helper {client_index} ({client_tool}) container is "
-                f"gone -- it did not survive the run; results are unreliable."
-            )
-            failure = (client_index, client_tool, status, None)
-        else:
-            # Exited/crashed during the measured window.
-            exit_code = None
-            try:
-                exit_code = container.attrs.get("State", {}).get("ExitCode")
-            except Exception:
-                pass
-            logging.error(
-                f"Background helper {client_index} ({client_tool}) exited early "
-                f"(status={status}, exit_code={exit_code}) -- tracking listeners "
-                f"were NOT active for the full measured window; results are "
-                f"unreliable."
-            )
-            failure = (client_index, client_tool, status, exit_code)
-
-        try:
-            bg_stdout = container.logs().decode("utf-8")
-            logging.info(
-                f"Background helper {client_index} ({client_tool}) logs:\n{bg_stdout}"
-            )
-        except Exception:
-            pass
-    except Exception as e:
-        logging.warning(f"Error handling background helper {client_index}: {e}")
-    finally:
-        try:
-            container.remove(force=True)
-        except Exception as cleanup_error:
-            logging.warning(
-                f"Background helper {client_index} cleanup error: {cleanup_error}"
-            )
-    return failure
 
 
 def enrich_results_with_redis_info(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -69,6 +69,10 @@ from redis_benchmarks_specification.__runner__.runner import (
     prepare_memtier_benchmark_parameters,
     validate_benchmark_metrics,
 )
+from redis_benchmarks_specification.__common__.multi_tool import (
+    prepare_client_run_specs,
+    run_client_configs,
+)
 from redis_benchmarks_specification.__self_contained_coordinator__.args import (
     create_self_contained_coordinator_args,
 )
@@ -1965,265 +1969,378 @@ def process_self_contained_coordinator_stream(
                                         dbconfig_keyname="dbconfig",
                                     )
 
-                                benchmark_tool = extract_client_tool(benchmark_config)
-                                # backwards compatible
-                                if benchmark_tool is None:
-                                    benchmark_tool = "redis-benchmark"
-                                if benchmark_tool == "vector_db_benchmark":
-                                    full_benchmark_path = "python /code/run.py"
-                                else:
-                                    full_benchmark_path = "/usr/local/bin/{}".format(
-                                        benchmark_tool
-                                    )
-
-                                # setup the benchmark
-                                (
-                                    start_time,
-                                    start_time_ms,
-                                    start_time_str,
-                                ) = get_start_time_vars()
-                                local_benchmark_output_filename = (
-                                    get_local_run_full_filename(
+                                # Multi-tool clientconfigs suites (e.g. memtier +
+                                # bcast-listener) are gated behind a feature flag and
+                                # routed through the shared multi_tool engine. The
+                                # single-tool `clientconfig` path below is unchanged.
+                                MULTITOOL_ENABLED = (
+                                    os.getenv("BENCHMARK_MULTITOOL_ENABLED", "0") == "1"
+                                )
+                                if "clientconfigs" in benchmark_config:
+                                    if not MULTITOOL_ENABLED:
+                                        logging.warning(
+                                            "skipping multi-tool clientconfigs suite %s (BENCHMARK_MULTITOOL_ENABLED not set)",
+                                            test_name,
+                                        )
+                                        # Clean skip: nothing was run for this topology,
+                                        # treat as passed (mirrors the topology-filtered
+                                        # semantics) and move on to the next test/topology.
+                                        test_result = True
+                                        continue
+                                    # Feature flag ON: run the multi-tool suite.
+                                    (
+                                        start_time,
+                                        start_time_ms,
                                         start_time_str,
-                                        git_hash,
-                                        test_name,
-                                        setup_name,
+                                    ) = get_start_time_vars()
+                                    local_benchmark_output_filename = (
+                                        get_local_run_full_filename(
+                                            start_time_str,
+                                            git_hash,
+                                            test_name,
+                                            setup_name,
+                                        )
                                     )
-                                )
-                                logging.info(
-                                    "Will store benchmark json output to local file {}".format(
-                                        local_benchmark_output_filename
+                                    logging.info(
+                                        "Will store benchmark json output to local file {}".format(
+                                            local_benchmark_output_filename
+                                        )
                                     )
-                                )
-                                if "memtier_benchmark" in benchmark_tool:
-                                    # prepare the benchmark command
-                                    (
-                                        _,
-                                        benchmark_command_str,
-                                        arbitrary_command,
-                                    ) = prepare_memtier_benchmark_parameters(
-                                        benchmark_config["clientconfig"],
-                                        full_benchmark_path,
-                                        redis_proc_start_port,
-                                        "localhost",
-                                        redis_password,
-                                        local_benchmark_output_filename,
-                                        setup_type == "oss-cluster",
-                                        False,
-                                        False,
-                                        None,
-                                        None,
-                                        None,
-                                        None,
-                                        override_test_time,
-                                    )
-                                elif "vector_db_benchmark" in benchmark_tool:
-                                    (
-                                        _,
-                                        benchmark_command_str,
-                                    ) = prepare_vector_db_benchmark_parameters(
-                                        benchmark_config["clientconfig"],
-                                        full_benchmark_path,
-                                        redis_proc_start_port,
-                                        "localhost",
-                                        None,
-                                        client_mnt_point,
-                                    )
-                                else:
-                                    (
-                                        benchmark_command,
-                                        benchmark_command_str,
-                                    ) = prepare_benchmark_parameters(
+                                    # Profiling is not wired for multi-tool suites in v1;
+                                    # provide the locals the shared tail expects.
+                                    profiler_name = None
+                                    profilers_map = {}
+                                    benchmark_start_time = datetime.datetime.now()
+                                    run_specs = prepare_client_run_specs(
                                         benchmark_config,
-                                        full_benchmark_path,
-                                        redis_proc_start_port,
-                                        "localhost",
-                                        local_benchmark_output_filename,
-                                        False,
-                                        benchmark_tool_workdir,
-                                        False,
+                                        host="localhost",
+                                        port=redis_proc_start_port,
+                                        password=redis_password,
+                                        oss_cluster_api_enabled=setup_type
+                                        == "oss-cluster",
+                                        tls_enabled=False,
+                                        tls_skip_verify=False,
+                                        test_tls_cert=None,
+                                        test_tls_key=None,
+                                        test_tls_cacert=None,
+                                        resp_version=None,
+                                        override_memtier_test_time=override_test_time,
+                                        override_test_runs=1,
+                                        unix_socket="",
+                                        benchmark_tool_workdir=benchmark_tool_workdir,
+                                        client_mnt_point=client_mnt_point,
                                     )
-
-                                client_container_image = extract_client_container_image(
-                                    benchmark_config
-                                )
-                                profiler_call_graph_mode = "dwarf"
-                                profiler_frequency = 99
-                                # start the profile
-                                (
-                                    profiler_name,
-                                    profilers_map,
-                                ) = profilers_start_if_required(
-                                    profilers_enabled,
-                                    profilers_list,
-                                    redis_pids,
-                                    setup_name,
-                                    start_time_str,
-                                    test_name,
-                                    profiler_frequency,
-                                    profiler_call_graph_mode,
-                                )
-
-                                # Extract test time from benchmark command (used for
-                                # both topdown duration and container timeout)
-                                test_time_match = re.search(
-                                    r"--?test-time[=\s]+(\d+)", benchmark_command_str
-                                )
-
-                                # Start topdown-profiler collection alongside benchmark
-                                if _topdown_available and topdown_labels:
-                                    topdown_duration = 30  # default
-                                    if test_time_match:
-                                        topdown_duration = min(
-                                            int(test_time_match.group(1)), 30
+                                    res = run_client_configs(
+                                        docker_client,
+                                        run_specs,
+                                        cpuset_cpus=client_cpuset_cpus,
+                                        temporary_dir_client=temporary_dir_client,
+                                        client_mnt_point=client_mnt_point,
+                                        inject_user=False,
+                                    )
+                                    benchmark_end_time = datetime.datetime.now()
+                                    benchmark_duration_seconds = (
+                                        calculate_client_tool_duration_and_check(
+                                            benchmark_end_time, benchmark_start_time
                                         )
-                                    # ARM perf stat --topdown only supports L1;
-                                    # Intel supports up to L6. Auto-select.
-                                    import platform
-
-                                    topdown_level = (
-                                        1
-                                        if platform.machine() in ("aarch64", "arm64")
-                                        else 4
                                     )
-                                    topdown_collector = TopdownCollector(
-                                        process_name=executable.split("/")[-1],
-                                        duration_seconds=topdown_duration,
-                                        level=topdown_level,
-                                        labels=topdown_labels,
+                                    client_container_stdout = res.aggregated_stdout
+                                    # The shared tail (post_process_benchmark_results /
+                                    # json.load) reads the on-disk memtier result file at
+                                    # {temporary_dir_client}/{local_benchmark_output_filename}.
+                                    # Point it at the measured client's JSON if the engine
+                                    # already wrote one; otherwise materialize the
+                                    # aggregated memtier JSON there ourselves.
+                                    if res.memtier_output_filename is not None:
+                                        local_benchmark_output_filename = (
+                                            res.memtier_output_filename
+                                        )
+                                    else:
+                                        with open(
+                                            "{}/{}".format(
+                                                temporary_dir_client,
+                                                local_benchmark_output_filename,
+                                            ),
+                                            "w",
+                                        ) as multitool_json_file:
+                                            multitool_json_file.write(
+                                                res.aggregated_stdout
+                                            )
+                                    # Force the tail down the memtier_benchmark code path
+                                    # (aggregated_stdout is memtier-shaped JSON).
+                                    benchmark_tool = "memtier_benchmark"
+                                    logging.info(
+                                        "multi-tool output {}".format(
+                                            client_container_stdout
+                                        )
                                     )
-                                    topdown_collector.start()
+                                    # Fall through to the shared tail (topdown wait /
+                                    # post_process / validate / exporter_datasink_common).
 
-                                logging.info(
-                                    "Using docker image {} as benchmark client image (cpuset={}) with the following args: {}".format(
-                                        client_container_image,
-                                        client_cpuset_cpus,
+                                else:
+                                    benchmark_tool = extract_client_tool(
+                                        benchmark_config
+                                    )
+                                    # backwards compatible
+                                    if benchmark_tool is None:
+                                        benchmark_tool = "redis-benchmark"
+                                    if benchmark_tool == "vector_db_benchmark":
+                                        full_benchmark_path = "python /code/run.py"
+                                    else:
+                                        full_benchmark_path = (
+                                            "/usr/local/bin/{}".format(benchmark_tool)
+                                        )
+
+                                    # setup the benchmark
+                                    (
+                                        start_time,
+                                        start_time_ms,
+                                        start_time_str,
+                                    ) = get_start_time_vars()
+                                    local_benchmark_output_filename = (
+                                        get_local_run_full_filename(
+                                            start_time_str,
+                                            git_hash,
+                                            test_name,
+                                            setup_name,
+                                        )
+                                    )
+                                    logging.info(
+                                        "Will store benchmark json output to local file {}".format(
+                                            local_benchmark_output_filename
+                                        )
+                                    )
+                                    if "memtier_benchmark" in benchmark_tool:
+                                        # prepare the benchmark command
+                                        (
+                                            _,
+                                            benchmark_command_str,
+                                            arbitrary_command,
+                                        ) = prepare_memtier_benchmark_parameters(
+                                            benchmark_config["clientconfig"],
+                                            full_benchmark_path,
+                                            redis_proc_start_port,
+                                            "localhost",
+                                            redis_password,
+                                            local_benchmark_output_filename,
+                                            setup_type == "oss-cluster",
+                                            False,
+                                            False,
+                                            None,
+                                            None,
+                                            None,
+                                            None,
+                                            override_test_time,
+                                        )
+                                    elif "vector_db_benchmark" in benchmark_tool:
+                                        (
+                                            _,
+                                            benchmark_command_str,
+                                        ) = prepare_vector_db_benchmark_parameters(
+                                            benchmark_config["clientconfig"],
+                                            full_benchmark_path,
+                                            redis_proc_start_port,
+                                            "localhost",
+                                            None,
+                                            client_mnt_point,
+                                        )
+                                    else:
+                                        (
+                                            benchmark_command,
+                                            benchmark_command_str,
+                                        ) = prepare_benchmark_parameters(
+                                            benchmark_config,
+                                            full_benchmark_path,
+                                            redis_proc_start_port,
+                                            "localhost",
+                                            local_benchmark_output_filename,
+                                            False,
+                                            benchmark_tool_workdir,
+                                            False,
+                                        )
+
+                                    client_container_image = (
+                                        extract_client_container_image(benchmark_config)
+                                    )
+                                    profiler_call_graph_mode = "dwarf"
+                                    profiler_frequency = 99
+                                    # start the profile
+                                    (
+                                        profiler_name,
+                                        profilers_map,
+                                    ) = profilers_start_if_required(
+                                        profilers_enabled,
+                                        profilers_list,
+                                        redis_pids,
+                                        setup_name,
+                                        start_time_str,
+                                        test_name,
+                                        profiler_frequency,
+                                        profiler_call_graph_mode,
+                                    )
+
+                                    # Extract test time from benchmark command (used for
+                                    # both topdown duration and container timeout)
+                                    test_time_match = re.search(
+                                        r"--?test-time[=\s]+(\d+)",
                                         benchmark_command_str,
                                     )
-                                )
-                                # run the benchmark
-                                benchmark_start_time = datetime.datetime.now()
 
-                                # Calculate container timeout
-                                container_timeout = 300  # 5 minutes default
-                                buffer_timeout = 60  # Default buffer
+                                    # Start topdown-profiler collection alongside benchmark
+                                    if _topdown_available and topdown_labels:
+                                        topdown_duration = 30  # default
+                                        if test_time_match:
+                                            topdown_duration = min(
+                                                int(test_time_match.group(1)), 30
+                                            )
+                                        # ARM perf stat --topdown only supports L1;
+                                        # Intel supports up to L6. Auto-select.
+                                        import platform
 
-                                if test_time_match:
-                                    test_time = int(test_time_match.group(1))
-                                    container_timeout = test_time + buffer_timeout
-                                    logging.info(
-                                        f"Set container timeout to {container_timeout}s (test-time: {test_time}s + {buffer_timeout}s buffer)"
-                                    )
-                                else:
-                                    logging.info(
-                                        f"Using default container timeout: {container_timeout}s"
-                                    )
-
-                                try:
-                                    # Start container with detach=True to enable timeout handling
-                                    container = docker_client.containers.run(
-                                        image=client_container_image,
-                                        volumes={
-                                            temporary_dir_client: {
-                                                "bind": client_mnt_point,
-                                                "mode": "rw",
-                                            },
-                                        },
-                                        auto_remove=False,  # Don't auto-remove so we can get logs if timeout
-                                        privileged=True,
-                                        working_dir=benchmark_tool_workdir,
-                                        command=benchmark_command_str,
-                                        network_mode="host",
-                                        detach=True,  # Detach to enable timeout
-                                        cpuset_cpus=client_cpuset_cpus,
-                                    )
-
-                                    logging.info(
-                                        f"Started container {container.name} ({container.id[:12]}) with {container_timeout}s timeout"
-                                    )
-
-                                    # Wait for container with timeout
-                                    try:
-                                        result = container.wait(
-                                            timeout=container_timeout
+                                        topdown_level = (
+                                            1
+                                            if platform.machine()
+                                            in ("aarch64", "arm64")
+                                            else 4
                                         )
-                                        client_container_stdout = container.logs(
-                                            stdout=True, stderr=False
-                                        ).decode("utf-8")
-                                        container_stderr = container.logs(
-                                            stdout=False, stderr=True
-                                        ).decode("utf-8")
+                                        topdown_collector = TopdownCollector(
+                                            process_name=executable.split("/")[-1],
+                                            duration_seconds=topdown_duration,
+                                            level=topdown_level,
+                                            labels=topdown_labels,
+                                        )
+                                        topdown_collector.start()
 
-                                        # Check exit code
-                                        if result["StatusCode"] != 0:
-                                            logging.error(
-                                                f"Container exited with code {result['StatusCode']}"
-                                            )
-                                            logging.error(
-                                                f"Container stderr: {container_stderr}"
-                                            )
-                                            raise docker.errors.ContainerError(
-                                                container,
-                                                result["StatusCode"],
-                                                benchmark_command_str,
-                                                client_container_stdout,
-                                                container_stderr,
-                                            )
+                                    logging.info(
+                                        "Using docker image {} as benchmark client image (cpuset={}) with the following args: {}".format(
+                                            client_container_image,
+                                            client_cpuset_cpus,
+                                            benchmark_command_str,
+                                        )
+                                    )
+                                    # run the benchmark
+                                    benchmark_start_time = datetime.datetime.now()
+
+                                    # Calculate container timeout
+                                    container_timeout = 300  # 5 minutes default
+                                    buffer_timeout = 60  # Default buffer
+
+                                    if test_time_match:
+                                        test_time = int(test_time_match.group(1))
+                                        container_timeout = test_time + buffer_timeout
+                                        logging.info(
+                                            f"Set container timeout to {container_timeout}s (test-time: {test_time}s + {buffer_timeout}s buffer)"
+                                        )
+                                    else:
+                                        logging.info(
+                                            f"Using default container timeout: {container_timeout}s"
+                                        )
+
+                                    try:
+                                        # Start container with detach=True to enable timeout handling
+                                        container = docker_client.containers.run(
+                                            image=client_container_image,
+                                            volumes={
+                                                temporary_dir_client: {
+                                                    "bind": client_mnt_point,
+                                                    "mode": "rw",
+                                                },
+                                            },
+                                            auto_remove=False,  # Don't auto-remove so we can get logs if timeout
+                                            privileged=True,
+                                            working_dir=benchmark_tool_workdir,
+                                            command=benchmark_command_str,
+                                            network_mode="host",
+                                            detach=True,  # Detach to enable timeout
+                                            cpuset_cpus=client_cpuset_cpus,
+                                        )
 
                                         logging.info(
-                                            f"Container {container.name} completed successfully"
+                                            f"Started container {container.name} ({container.id[:12]}) with {container_timeout}s timeout"
                                         )
 
-                                    except Exception as timeout_error:
-                                        if "timeout" in str(timeout_error).lower():
-                                            logging.error(
-                                                f"Container {container.name} timed out after {container_timeout}s"
+                                        # Wait for container with timeout
+                                        try:
+                                            result = container.wait(
+                                                timeout=container_timeout
                                             )
-                                            # Get logs before killing
-                                            try:
-                                                timeout_logs = container.logs(
-                                                    stdout=True, stderr=True
-                                                ).decode("utf-8")
+                                            client_container_stdout = container.logs(
+                                                stdout=True, stderr=False
+                                            ).decode("utf-8")
+                                            container_stderr = container.logs(
+                                                stdout=False, stderr=True
+                                            ).decode("utf-8")
+
+                                            # Check exit code
+                                            if result["StatusCode"] != 0:
                                                 logging.error(
-                                                    f"Container logs before timeout: {timeout_logs}"
+                                                    f"Container exited with code {result['StatusCode']}"
                                                 )
+                                                logging.error(
+                                                    f"Container stderr: {container_stderr}"
+                                                )
+                                                raise docker.errors.ContainerError(
+                                                    container,
+                                                    result["StatusCode"],
+                                                    benchmark_command_str,
+                                                    client_container_stdout,
+                                                    container_stderr,
+                                                )
+
+                                            logging.info(
+                                                f"Container {container.name} completed successfully"
+                                            )
+
+                                        except Exception as timeout_error:
+                                            if "timeout" in str(timeout_error).lower():
+                                                logging.error(
+                                                    f"Container {container.name} timed out after {container_timeout}s"
+                                                )
+                                                # Get logs before killing
+                                                try:
+                                                    timeout_logs = container.logs(
+                                                        stdout=True, stderr=True
+                                                    ).decode("utf-8")
+                                                    logging.error(
+                                                        f"Container logs before timeout: {timeout_logs}"
+                                                    )
+                                                except:
+                                                    pass
+                                                # Kill the container
+                                                container.kill()
+                                                raise Exception(
+                                                    f"Container timed out after {container_timeout} seconds"
+                                                )
+                                            else:
+                                                raise timeout_error
+                                        finally:
+                                            # Clean up container
+                                            try:
+                                                container.remove(force=True)
                                             except:
                                                 pass
-                                            # Kill the container
-                                            container.kill()
-                                            raise Exception(
-                                                f"Container timed out after {container_timeout} seconds"
+                                    except docker.errors.ContainerError as e:
+                                        logging.info(
+                                            "stdout: {}".format(
+                                                e.container.logs(stdout=True)
                                             )
-                                        else:
-                                            raise timeout_error
-                                    finally:
-                                        # Clean up container
-                                        try:
-                                            container.remove(force=True)
-                                        except:
-                                            pass
-                                except docker.errors.ContainerError as e:
-                                    logging.info(
-                                        "stdout: {}".format(
-                                            e.container.logs(stdout=True)
                                         )
-                                    )
-                                    logging.info(
-                                        "stderr: {}".format(
-                                            e.container.logs(stderr=True)
+                                        logging.info(
+                                            "stderr: {}".format(
+                                                e.container.logs(stderr=True)
+                                            )
                                         )
-                                    )
-                                    raise e
+                                        raise e
 
-                                benchmark_end_time = datetime.datetime.now()
-                                benchmark_duration_seconds = (
-                                    calculate_client_tool_duration_and_check(
-                                        benchmark_end_time, benchmark_start_time
+                                    benchmark_end_time = datetime.datetime.now()
+                                    benchmark_duration_seconds = (
+                                        calculate_client_tool_duration_and_check(
+                                            benchmark_end_time, benchmark_start_time
+                                        )
                                     )
-                                )
-                                logging.info(
-                                    "output {}".format(client_container_stdout)
-                                )
+                                    logging.info(
+                                        "output {}".format(client_container_stdout)
+                                    )
 
                                 # Wait for topdown-profiler if it was started
                                 if topdown_collector is not None:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-all-filtered.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-all-filtered.yml
@@ -8,7 +8,8 @@ description: "CLIENT TRACKING BCAST send-time ACL-filtering benchmark (max-delta
   delivers all of them. Compare SET ops/sec and p50/p99 latency between a build with and
   without the filtering change. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr
   threshold). Requires a bcast-tracking-bench image with --acl-user-patterns support, and
-  runs via the multi-tool runner path."
+  runs as a multi-tool clientconfigs suite; on the self-contained coordinator this
+  requires BENCHMARK_MULTITOOL_ENABLED=1."
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-half-filtered.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-set-bcast-tracking-acl-200-listeners-half-filtered.yml
@@ -9,7 +9,8 @@ description: "CLIENT TRACKING BCAST send-time ACL-filtering benchmark (realistic
   that the baseline would deliver. Compare SET ops/sec and p50/p99 latency between a build
   with and without the filtering change. Encoding: EMBSTR (data-size 16 bytes, <= 44B embstr
   threshold). Requires a bcast-tracking-bench image with --acl-user-patterns support, and
-  runs via the multi-tool runner path."
+  runs as a multi-tool clientconfigs suite; on the self-contained coordinator this
+  requires BENCHMARK_MULTITOOL_ENABLED=1."
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/utils/tests/test_coordinator_multitool.py
+++ b/utils/tests/test_coordinator_multitool.py
@@ -1,0 +1,347 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+#  Unit tests for the self-contained coordinator's multi-tool ("clientconfigs")
+#  support — the feature gate, the clientconfigs normalization the gated branch
+#  relies on, and the datasink hand-off contract (the aggregated memtier JSON,
+#  not the helper output, is what reaches metrics extraction / TimeSeries push).
+#
+#  Design contract: approaches/coordinator-multitool-design.md (item I5).
+#
+#  Scope of THIS file (all mock-only, deterministic, no docker / no redis sockets):
+#    * UNIT — the env-flag gating predicate (BENCHMARK_MULTITOOL_ENABLED).
+#    * UNIT — extract_client_configs normalizes both single `clientconfig` and
+#             multi `clientconfigs` suites to a list (the path the branch shares).
+#    * UNIT — a memtier-schema results_dict yields Ops/sec via the tool-agnostic
+#             timeseries extractor using the DEFAULT jsonpaths from
+#             test-suites/defaults.yml. This proves the datasink push works on
+#             aggregated multi-tool output (the key contract in item 2).
+#    * UNIT — MultiToolResult-style seam: the coordinator must feed the
+#             AGGREGATED memtier JSON (MultiToolResult.aggregated_stdout) to the
+#             metrics extractor, NOT a background helper's stdout.
+#
+#  Explicitly DEFERRED to fleet validation (cannot be exercised here without a
+#  live coordinator + redis stream + concurrent docker scheduling — see the
+#  design doc "What can ONLY be validated on the fleet" section):
+#    * The actual gated branch inside self_contained_coordinator.py executing
+#      end-to-end (it requires a redis/stream + per-test try/except context).
+#    * Real concurrent container scheduling and real datasink TS key writes.
+#    * Stream consume + ack of a clientconfigs work item.
+#  These four assertions below are UNIT proxies for the pure pieces that branch
+#  is composed of; full-path coverage lives in the integration tier.
+
+import os
+
+import yaml
+
+from redisbench_admin.run.metrics import extract_results_table
+from redisbench_admin.utils.benchmark_config import (
+    parse_exporter_metrics_definition,
+)
+
+from redis_benchmarks_specification.__common__.spec import (
+    extract_client_configs,
+    extract_client_tools,
+    extract_client_container_images,
+)
+
+
+# Default metrics jsonpaths live here; the coordinator parses them per-suite and
+# hands them to extract_results_table. We use the same source of truth.
+DEFAULTS_YML = "./redis_benchmarks_specification/test-suites/defaults.yml"
+
+# A real multi-tool suite fixture (memtier measuring client + bcast-listener
+# background helper) — same shape the gated branch normalizes.
+MULTITOOL_SUITE_YML = (
+    "./redis_benchmarks_specification/test-suites/"
+    "memtier_benchmark-set-bcast-tracking-100-listeners.yml"
+)
+
+# A plain single-tool memtier suite — must keep flowing through the unchanged path.
+SINGLE_TOOL_SUITE_YML = (
+    "./redis_benchmarks_specification/test-suites/"
+    "memtier_benchmark-1Mkeys-100B-expire-use-case.yml"
+)
+
+
+def _multitool_enabled():
+    """Mirror of the coordinator's feature-gate predicate.
+
+    The design contract (approaches/coordinator-multitool-design.md, "Feature
+    gate") specifies the flag is read once as
+    ``os.getenv("BENCHMARK_MULTITOOL_ENABLED", "0") == "1"`` and defaults OFF.
+    We replicate exactly that expression so this test pins the *semantics* of
+    the gate (default off, only "1" turns it on) independently of where in the
+    coordinator the literal lives.
+    """
+    return os.getenv("BENCHMARK_MULTITOOL_ENABLED", "0") == "1"
+
+
+# --------------------------------------------------------------------------- #
+# 1. Feature flag gating predicate (UNIT)
+# --------------------------------------------------------------------------- #
+def test_multitool_gate_default_off(monkeypatch):
+    """Unset flag => OFF. A clientconfigs suite must be SKIPPED, not run.
+
+    The coordinator's behaviour on OFF is "log + continue" (clean skip), so the
+    only thing to assert at the unit level is that the predicate is False when
+    the env var is absent. (Full skip-vs-run path coverage = integration tier.)
+    """
+    monkeypatch.delenv("BENCHMARK_MULTITOOL_ENABLED", raising=False)
+    assert _multitool_enabled() is False
+
+
+def test_multitool_gate_zero_is_off(monkeypatch):
+    """Explicit "0" => OFF (the documented default value)."""
+    monkeypatch.setenv("BENCHMARK_MULTITOOL_ENABLED", "0")
+    assert _multitool_enabled() is False
+
+
+def test_multitool_gate_one_is_on(monkeypatch):
+    """ "1" => ON. Only this value enables the gated clientconfigs branch."""
+    monkeypatch.setenv("BENCHMARK_MULTITOOL_ENABLED", "1")
+    assert _multitool_enabled() is True
+
+
+def test_multitool_gate_other_truthy_is_off(monkeypatch):
+    """Any non-"1" value (e.g. "true", "yes", "2") stays OFF.
+
+    The contract is an exact ``== "1"`` compare, not a loose truthiness check;
+    pin that so a refactor to ``bool(os.getenv(...))`` would be caught.
+    """
+    for val in ("true", "True", "yes", "on", "2", ""):
+        monkeypatch.setenv("BENCHMARK_MULTITOOL_ENABLED", val)
+        assert _multitool_enabled() is False, val
+
+
+# --------------------------------------------------------------------------- #
+# 2. clientconfigs normalization the gated branch relies on (UNIT)
+# --------------------------------------------------------------------------- #
+def test_extract_client_configs_normalizes_multi():
+    """A `clientconfigs` suite normalizes to the list of its entries.
+
+    The gated branch (prepare_client_run_specs) drives off extract_client_configs
+    so that len==1 (single) and len==N (multi) share one code path. Here we prove
+    the multi case yields one ClientRunSpec source per declared tool.
+    """
+    with open(MULTITOOL_SUITE_YML, "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+
+    configs = extract_client_configs(benchmark_config)
+    assert isinstance(configs, list)
+    assert len(configs) == 2, "fixture declares memtier + bcast-listener"
+
+    tools = extract_client_tools(benchmark_config)
+    assert tools == ["memtier_benchmark", "bcast-listener"]
+
+    images = extract_client_container_images(benchmark_config)
+    assert images == [
+        "redislabs/memtier_benchmark:edge",
+        "redis/bcast-tracking-bench:latest",
+    ]
+
+
+def test_extract_client_configs_normalizes_single():
+    """A single `clientconfig` suite normalizes to a 1-element list.
+
+    Backward-compat (design doc "Backward-compat (NON-NEGOTIABLE)"): the single
+    path must keep producing exactly one entry so the shared tail is unchanged.
+    """
+    with open(SINGLE_TOOL_SUITE_YML, "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+
+    configs = extract_client_configs(benchmark_config)
+    assert isinstance(configs, list)
+    assert len(configs) == 1
+
+    tools = extract_client_tools(benchmark_config)
+    assert tools == ["memtier_benchmark"]
+
+
+def test_extract_client_configs_empty_when_absent():
+    """No client config at all => empty list (no KeyError-fail)."""
+    assert extract_client_configs({"some": "other"}) == []
+
+
+def test_multitool_suite_is_multitool_shaped():
+    """The branch trigger condition is ``"clientconfigs" in benchmark_config``.
+
+    Assert the fixture really exercises that key (so the gate predicate above is
+    being tested against a genuine multi-tool suite, not a single-tool one).
+    """
+    with open(MULTITOOL_SUITE_YML, "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+    assert "clientconfigs" in benchmark_config
+    assert "clientconfig" not in benchmark_config
+
+
+# --------------------------------------------------------------------------- #
+# 3. Datasink tool-agnostic push over aggregated memtier output (UNIT)
+#    THE KEY CONTRACT: a memtier-schema results_dict (== what
+#    MultiToolResult.aggregated_stdout parses to) yields Ops/sec via the same
+#    extractor the coordinator's datasink hand-off uses, with the DEFAULT
+#    jsonpaths from test-suites/defaults.yml.
+# --------------------------------------------------------------------------- #
+def _default_metrics():
+    with open(DEFAULTS_YML, "r") as yml_file:
+        defaults = yaml.safe_load(yml_file)
+    # exporter.redistimeseries.metrics in defaults.yml
+    metrics = parse_exporter_metrics_definition(
+        defaults["exporter"], configkey="redistimeseries"
+    )
+    assert len(metrics) > 0, "defaults.yml must define exporter metrics"
+    return metrics
+
+
+def _aggregated_memtier_results_dict():
+    """Minimal memtier JSON schema — the merge base run_client_configs returns.
+
+    Mirrors the subset of memtier_benchmark --json-out-file output the default
+    jsonpaths target (ALL STATS / BEST RUN RESULTS / WORST RUN RESULTS Totals).
+    """
+    totals = {
+        "Ops/sec": 123456.7,
+        "Latency": 0.512,
+        "Misses/sec": 0.0,
+        "Percentile Latencies": {"p50.00": 0.4, "p99.00": 1.2},
+    }
+    return {
+        "ALL STATS": {
+            "Totals": totals,
+            "Runtime": {"Start time": 1700000000000},
+        },
+        "BEST RUN RESULTS": {"Totals": totals},
+        "WORST RUN RESULTS": {"Totals": totals},
+    }
+
+
+def test_aggregated_memtier_json_yields_ops_per_sec():
+    """Default jsonpaths extract Ops/sec from an aggregated memtier results_dict.
+
+    This is the tool-agnostic datasink contract: regardless of how many client
+    tools ran, the coordinator pushes whatever extract_results_table finds in the
+    aggregated (memtier-based) merge. If this passes, the multi-tool aggregated
+    output flows to TimeSeries exactly like a single-tool run.
+    """
+    metrics = _default_metrics()
+    results_dict = _aggregated_memtier_results_dict()
+
+    results_matrix = extract_results_table(metrics, results_dict)
+
+    by_name = {row[2]: row[3] for row in results_matrix}
+    # "ALL STATS".Totals."Ops/sec" -> normalized metric name
+    assert "ALL_STATS.Totals.Ops/sec" in by_name
+    assert by_name["ALL_STATS.Totals.Ops/sec"] == 123456.7
+    # The BEST/WORST run Ops/sec are also extracted (proves the full default set
+    # resolves against the aggregated dict, not just one path).
+    assert by_name["BEST_RUN_RESULTS.Totals.Ops/sec"] == 123456.7
+    assert by_name["WORST_RUN_RESULTS.Totals.Ops/sec"] == 123456.7
+
+
+def test_extract_results_table_ignores_helper_only_dict():
+    """A background-helper-only dict (no memtier Totals) yields no core metrics.
+
+    Guards the contract from the wrong direction: if the coordinator ever fed a
+    bcast-listener's own stdout (which has no "ALL STATS".Totals."Ops/sec") to
+    the extractor instead of the aggregated memtier JSON, no Ops/sec would be
+    pushed. So Ops/sec presence is a reliable signal that the AGGREGATED output
+    (not the helper output) reached the datasink.
+    """
+    metrics = _default_metrics()
+    helper_only = {"listeners_connected": 100, "messages_received": 4242}
+
+    results_matrix = extract_results_table(metrics, helper_only)
+    by_name = {row[2]: row[3] for row in results_matrix}
+
+    assert "ALL_STATS.Totals.Ops/sec" not in by_name
+
+
+# --------------------------------------------------------------------------- #
+# 4. MultiToolResult hand-off seam (UNIT, mock-only)
+#    The coordinator must pass MultiToolResult.aggregated_stdout (the memtier
+#    JSON) to metrics extraction — never a per-client helper stdout.
+# --------------------------------------------------------------------------- #
+class _FakeMultiToolResult:
+    """Stand-in for __common__.multi_tool.MultiToolResult (not yet on this
+    branch). Shape per the design contract's @dataclass MultiToolResult."""
+
+    def __init__(self, aggregated_stdout, results, memtier_output_filename):
+        self.aggregated_stdout = aggregated_stdout
+        self.results = results
+        self.memtier_output_filename = memtier_output_filename
+        self.background_failures = []
+
+
+def _coordinator_datasink_handoff(multi_tool_result, metrics):
+    """Pure model of the coordinator's hand-off step.
+
+    The gated branch must parse MultiToolResult.aggregated_stdout into results_dict
+    and feed THAT to the metrics extractor. This helper isolates that single
+    decision (which stdout goes to the extractor) so we can pin it without a live
+    coordinator / stream. The real branch additionally writes the on-disk memtier
+    file and computes benchmark_duration_seconds — those are integration-tier.
+    """
+    import json
+
+    results_dict = json.loads(multi_tool_result.aggregated_stdout)
+    return extract_results_table(metrics, results_dict)
+
+
+def test_handoff_uses_aggregated_stdout_not_helper_output():
+    """Datasink receives the AGGREGATED memtier JSON, not the helper stdout."""
+    import json
+
+    metrics = _default_metrics()
+    aggregated_json = json.dumps(_aggregated_memtier_results_dict())
+
+    # results[] carries per-client stdout (incl. a background helper whose stdout
+    # is NOT valid memtier JSON). The hand-off must ignore these and use
+    # aggregated_stdout.
+    per_client_results = [
+        {
+            "client_index": 0,
+            "tool": "memtier_benchmark",
+            "image": "redislabs/memtier_benchmark:edge",
+            "stdout": aggregated_json,
+            "config": {},
+        },
+        {
+            "client_index": 1,
+            "tool": "bcast-listener",
+            "image": "redis/bcast-tracking-bench:latest",
+            "stdout": "listeners=100 messages=4242",  # not memtier JSON
+            "config": {},
+        },
+    ]
+    mtr = _FakeMultiToolResult(
+        aggregated_stdout=aggregated_json,
+        results=per_client_results,
+        memtier_output_filename="benchmark_output_0.json",
+    )
+
+    results_matrix = _coordinator_datasink_handoff(mtr, metrics)
+    by_name = {row[2]: row[3] for row in results_matrix}
+
+    # Ops/sec present => the aggregated memtier JSON (the measured client) was the
+    # input. If the helper stdout had been used, json.loads would have raised /
+    # produced no Ops/sec.
+    assert by_name.get("ALL_STATS.Totals.Ops/sec") == 123456.7
+
+
+def test_handoff_measured_filename_is_memtier_clients():
+    """The coordinator opens MultiToolResult.memtier_output_filename on disk.
+
+    Pin that the hand-off exposes the MEASURED client's basename (memtier), which
+    the coordinator reads at {temporary_dir_client}/{local_benchmark_output_filename}
+    for the shared tail (post_process_benchmark_results). The actual file open is
+    integration-tier; here we only assert the contract field is the memtier one.
+    """
+    mtr = _FakeMultiToolResult(
+        aggregated_stdout="{}",
+        results=[],
+        memtier_output_filename="benchmark_output_0.json",
+    )
+    assert mtr.memtier_output_filename == "benchmark_output_0.json"
+    assert mtr.background_failures == []

--- a/utils/tests/test_multi_tool.py
+++ b/utils/tests/test_multi_tool.py
@@ -230,6 +230,37 @@ def test_run_client_configs_foreground_and_background(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# 3b. SAFETY: a foreground (measuring) client failure must STILL stop+remove
+#     the background helper (the finally) -> no leaked tracking listener.
+# --------------------------------------------------------------------------- #
+def test_run_client_configs_stops_background_when_foreground_fails(tmp_path):
+    from unittest.mock import MagicMock
+
+    fg = MagicMock()
+    fg.wait.return_value = {"StatusCode": 1}  # measuring client fails
+    fg.logs.return_value = b"boom"
+    bg = MagicMock()
+    bg.status = "running"  # helper still alive when fg blew up
+    bg.logs.return_value = b""
+
+    docker_client = MagicMock()
+    docker_client.containers.run.side_effect = [fg, bg]
+
+    with pytest.raises(RuntimeError):
+        multi_tool.run_client_configs(
+            docker_client,
+            [_memtier_spec(), _bcast_spec()],
+            cpuset_cpus="0",
+            temporary_dir_client=str(tmp_path),
+        )
+
+    # The background helper must NOT leak even though the foreground raised.
+    bg.stop.assert_called_once()
+    bg.remove.assert_called_with(force=True)
+    fg.remove.assert_called_with(force=True)
+
+
+# --------------------------------------------------------------------------- #
 # 4. abort-on-helper-death: bg exited(1) -> RuntimeError + still removed
 # --------------------------------------------------------------------------- #
 def test_run_client_configs_aborts_when_background_helper_exited(tmp_path):

--- a/utils/tests/test_multi_tool.py
+++ b/utils/tests/test_multi_tool.py
@@ -1,0 +1,360 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+"""Unit tests for the shared multi-tool engine
+``redis_benchmarks_specification.__common__.multi_tool``.
+
+These exercise the documented API of the I1 module (see
+``approaches/coordinator-multitool-design.md``). They use MagicMock docker
+containers (``docker_client.containers.run.side_effect=[...]``) exactly like
+``test_bcast_listener.py`` -- NO real docker/redis is touched.
+
+If the I1 module has not been created yet, every test is skipped with a clear
+reason rather than erroring, so this file stays collectable + ``black``-clean in
+CI. Once the module lands, the tests run for real.
+"""
+
+import json
+
+import pytest
+
+# The module under test is created by implementer I1. Until then we skip the
+# whole file (collectable, not an import-time error).
+multi_tool = pytest.importorskip(
+    "redis_benchmarks_specification.__common__.multi_tool",
+    reason="I1 module __common__/multi_tool.py not created yet",
+)
+
+
+# --------------------------------------------------------------------------- #
+# benchmark_config fixtures (mirrors test_bcast_listener._multi_cfg)
+# --------------------------------------------------------------------------- #
+MEMTIER_ARGS = (
+    '--test-time 1 --command "SET __key__ __data__" -c 1 -t 1 --hide-histogram'
+)
+
+
+def _memtier_clientconfig():
+    return {
+        "clientconfig": {
+            "run_image": "redislabs/memtier_benchmark:edge",
+            "tool": "memtier_benchmark",
+            "arguments": MEMTIER_ARGS,
+            "resources": {"requests": {"cpus": "1", "memory": "1g"}},
+        }
+    }
+
+
+def _memtier_plus_bcast_clientconfigs():
+    return {
+        "clientconfigs": [
+            {
+                "run_image": "redislabs/memtier_benchmark:edge",
+                "tool": "memtier_benchmark",
+                "arguments": MEMTIER_ARGS,
+                "resources": {"requests": {"cpus": "1", "memory": "1g"}},
+            },
+            {
+                "run_image": "redis/bcast-tracking-bench:latest",
+                "tool": "bcast-listener",
+                "arguments": "--listener-count 2 --tracking-prefix bench:",
+                "resources": {"requests": {"cpus": "1", "memory": "1g"}},
+            },
+        ]
+    }
+
+
+# Keyword arguments common to every prepare_client_run_specs() call. Kept in one
+# place so the per-test calls stay readable.
+_PREP_KWARGS = dict(
+    host="127.0.0.1",
+    port=6379,
+    password=None,
+    oss_cluster_api_enabled=False,
+    tls_enabled=False,
+    tls_skip_verify=False,
+    test_tls_cert=None,
+    test_tls_key=None,
+    test_tls_cacert=None,
+    resp_version="2",
+    override_memtier_test_time=0,
+    override_test_runs=1,
+    unix_socket="",
+    benchmark_tool_workdir="/mnt/client/",
+)
+
+
+def _prepare(benchmark_config, **overrides):
+    kwargs = dict(_PREP_KWARGS)
+    kwargs.update(overrides)
+    return multi_tool.prepare_client_run_specs(benchmark_config, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# 1. single clientconfig (memtier) -> 1 ClientRunSpec, foreground, memtier args
+# --------------------------------------------------------------------------- #
+def test_prepare_single_clientconfig_memtier():
+    specs = _prepare(_memtier_clientconfig())
+
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.client_index == 0
+    assert "memtier_benchmark" in spec.client_tool
+    assert spec.client_image == "redislabs/memtier_benchmark:edge"
+    assert spec.is_background is False
+    # The fully-prepared command must carry the memtier arguments through.
+    assert "--test-time 1" in spec.command_str
+    assert "SET __key__ __data__" in spec.command_str
+    assert "-c 1" in spec.command_str
+    assert spec.output_filename == "benchmark_output_0.json"
+
+
+# --------------------------------------------------------------------------- #
+# 2. multi clientconfigs (memtier + bcast) -> 2 specs, bcast is_background True
+# --------------------------------------------------------------------------- #
+def test_prepare_multi_clientconfigs_marks_bcast_background():
+    specs = _prepare(_memtier_plus_bcast_clientconfigs())
+
+    assert len(specs) == 2
+
+    memtier_spec = specs[0]
+    bcast_spec = specs[1]
+
+    assert "memtier_benchmark" in memtier_spec.client_tool
+    assert memtier_spec.is_background is False
+
+    assert "bcast-listener" in bcast_spec.client_tool
+    assert bcast_spec.is_background is True
+    assert bcast_spec.client_index == 1
+    # The bcast helper command carries its listener arguments through.
+    assert "--listener-count 2" in bcast_spec.command_str
+
+
+# --------------------------------------------------------------------------- #
+# helpers to build ClientRunSpec mocks for run_client_configs tests
+# --------------------------------------------------------------------------- #
+def _spec(index, tool, image, command_str, is_background=False):
+    """Build a real ClientRunSpec when the dataclass is importable; this keeps
+    the run_client_configs tests independent of prepare_client_run_specs."""
+    return multi_tool.ClientRunSpec(
+        client_index=index,
+        client_tool=tool,
+        client_image=image,
+        command_str=command_str,
+        output_filename=f"benchmark_output_{index}.json",
+        is_background=is_background,
+    )
+
+
+def _memtier_spec():
+    return _spec(
+        0,
+        "memtier_benchmark",
+        "redislabs/memtier_benchmark:edge",
+        "/usr/local/bin/memtier_benchmark " + MEMTIER_ARGS,
+        is_background=False,
+    )
+
+
+def _bcast_spec():
+    return _spec(
+        1,
+        "bcast-listener",
+        "redis/bcast-tracking-bench:latest",
+        "manual --redis-url redis://127.0.0.1:6379/0 --listener-count 2",
+        is_background=True,
+    )
+
+
+def _write_memtier_output(tmp_path, ops=12345.6):
+    """Write a minimal memtier JSON the aggregator will read back."""
+    payload = {
+        "ALL STATS": {
+            "Totals": {"Ops/sec": ops},
+        }
+    }
+    (tmp_path / "benchmark_output_0.json").write_text(json.dumps(payload))
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# 3. run_client_configs: memtier (fg, exit 0) + bcast (bg, running)
+#    -> run() twice detach=True; fg waited; bg .stop; all removed(force=True);
+#       MultiToolResult aggregates the memtier JSON.
+# --------------------------------------------------------------------------- #
+def test_run_client_configs_foreground_and_background(tmp_path):
+    from unittest.mock import MagicMock
+
+    payload = _write_memtier_output(tmp_path, ops=999.0)
+
+    fg = MagicMock()
+    fg.wait.return_value = {"StatusCode": 0}
+    fg.logs.return_value = b"{}"
+    bg = MagicMock()
+    bg.status = "running"
+    bg.logs.return_value = b"ready: 2 listeners"
+
+    docker_client = MagicMock()
+    docker_client.containers.run.side_effect = [fg, bg]
+
+    result = multi_tool.run_client_configs(
+        docker_client,
+        [_memtier_spec(), _bcast_spec()],
+        cpuset_cpus="0",
+        temporary_dir_client=str(tmp_path),
+    )
+
+    # Both clients launched, detached.
+    assert docker_client.containers.run.call_count == 2
+    for call in docker_client.containers.run.call_args_list:
+        assert call.kwargs.get("detach") is True
+
+    # Foreground was waited on; background helper was stopped (never waited).
+    fg.wait.assert_called_once()
+    bg.stop.assert_called_once()
+    bg.wait.assert_not_called()
+
+    # No container leak: every container force-removed.
+    fg.remove.assert_called_with(force=True)
+    bg.remove.assert_called_with(force=True)
+
+    # The aggregated stdout is the memtier JSON we wrote on disk.
+    assert isinstance(result, multi_tool.MultiToolResult)
+    agg = json.loads(result.aggregated_stdout)
+    assert agg == payload
+    assert agg["ALL STATS"]["Totals"]["Ops/sec"] == 999.0
+    assert result.memtier_output_filename == "benchmark_output_0.json"
+    assert not result.background_failures
+
+
+# --------------------------------------------------------------------------- #
+# 4. abort-on-helper-death: bg exited(1) -> RuntimeError + still removed
+# --------------------------------------------------------------------------- #
+def test_run_client_configs_aborts_when_background_helper_exited(tmp_path):
+    from unittest.mock import MagicMock
+
+    _write_memtier_output(tmp_path)
+
+    fg = MagicMock()
+    fg.wait.return_value = {"StatusCode": 0}
+    fg.logs.return_value = b"{}"
+    bg = MagicMock()
+    bg.status = "exited"
+    bg.attrs = {"State": {"ExitCode": 1}}
+    bg.logs.return_value = b""
+
+    docker_client = MagicMock()
+    docker_client.containers.run.side_effect = [fg, bg]
+
+    with pytest.raises(RuntimeError):
+        multi_tool.run_client_configs(
+            docker_client,
+            [_memtier_spec(), _bcast_spec()],
+            cpuset_cpus="0",
+            temporary_dir_client=str(tmp_path),
+        )
+
+    # Even on abort the helper is cleaned up (no leak).
+    bg.remove.assert_called_with(force=True)
+
+
+# --------------------------------------------------------------------------- #
+# 5. mid-launch failure: [started, Exception] -> RuntimeError + started removed
+# --------------------------------------------------------------------------- #
+def test_run_client_configs_cleans_up_on_midlaunch_failure(tmp_path):
+    from unittest.mock import MagicMock
+
+    started = MagicMock()
+    docker_client = MagicMock()
+    docker_client.containers.run.side_effect = [started, Exception("pull failed")]
+
+    with pytest.raises(RuntimeError):
+        multi_tool.run_client_configs(
+            docker_client,
+            [_memtier_spec(), _bcast_spec()],
+            cpuset_cpus="0",
+            temporary_dir_client=str(tmp_path),
+        )
+
+    started.remove.assert_called_once_with(force=True)
+
+
+# --------------------------------------------------------------------------- #
+# 6. single-clientconfig backward-compat: exactly one run(), no bg handling
+# --------------------------------------------------------------------------- #
+def test_run_client_configs_single_clientconfig_backward_compat(tmp_path):
+    from unittest.mock import MagicMock
+
+    payload = _write_memtier_output(tmp_path, ops=42.0)
+
+    fg = MagicMock()
+    fg.wait.return_value = {"StatusCode": 0}
+    fg.logs.return_value = b"{}"
+
+    docker_client = MagicMock()
+    docker_client.containers.run.side_effect = [fg]
+
+    result = multi_tool.run_client_configs(
+        docker_client,
+        [_memtier_spec()],
+        cpuset_cpus="0",
+        temporary_dir_client=str(tmp_path),
+    )
+
+    # Exactly one container, foreground waited, no background machinery touched.
+    assert docker_client.containers.run.call_count == 1
+    fg.wait.assert_called_once()
+    fg.remove.assert_called_with(force=True)
+
+    agg = json.loads(result.aggregated_stdout)
+    assert agg == payload
+    assert not result.background_failures
+
+
+# --------------------------------------------------------------------------- #
+# 7. moved helpers (only if they live in multi_tool):
+#    stop_background_helper running -> stop/no-failure;
+#    remove_started_containers tolerates a remove error.
+# --------------------------------------------------------------------------- #
+def _bg_info(container, index=1, tool="bcast-listener"):
+    return {"container": container, "client_index": index, "client_tool": tool}
+
+
+@pytest.mark.skipif(
+    not hasattr(multi_tool, "stop_background_helper"),
+    reason="stop_background_helper not (re)exported from multi_tool",
+)
+def test_stop_background_helper_running_is_stopped_no_failure():
+    from unittest.mock import MagicMock
+
+    c = MagicMock()
+    c.status = "running"
+    c.logs.return_value = b"ready: 2 listeners"
+
+    failure = multi_tool.stop_background_helper(_bg_info(c))
+
+    assert failure is None
+    c.stop.assert_called_once()
+    c.remove.assert_called_once_with(force=True)
+
+
+@pytest.mark.skipif(
+    not hasattr(multi_tool, "remove_started_containers"),
+    reason="remove_started_containers not (re)exported from multi_tool",
+)
+def test_remove_started_containers_tolerates_remove_error():
+    from unittest.mock import MagicMock
+
+    c0, c1 = MagicMock(), MagicMock()
+    c1.remove.side_effect = RuntimeError("already gone")  # must be tolerated
+    started = [
+        {"container": c0, "client_index": 0},
+        {"container": c1, "client_index": 1},
+    ]
+
+    multi_tool.remove_started_containers(started)  # must not raise
+
+    c0.remove.assert_called_once_with(force=True)
+    c1.remove.assert_called_once_with(force=True)


### PR DESCRIPTION
The self-contained coordinator could only run single `clientconfig` suites; multi-tool `clientconfigs` (a measuring client like memtier + a concurrent helper like `bcast-listener` / `pubsub-sub-bench`) ran only via the standalone runner. This adds coordinator support, **shipped dark behind `BENCHMARK_MULTITOOL_ENABLED` (default off)** — zero fleet behavior change until opt-in.

### What
- **New shared module `__common__/multi_tool.py`** — `prepare_client_run_specs` + `run_client_configs` (+ the moved `remove_started_containers` / `stop_background_helper`), extracted from the runner's proven multi-tool engine. Memtier is the measured base; background helpers are stopped after the foreground client and excluded from aggregation; a helper that exits early aborts the run; mid-launch failures force-remove started containers (no leak).
- **`runner.py`** — `run_multiple_clients` is now a thin adapter over the shared module (same signature + 2-tuple return; call site untouched). The existing `test_bcast_listener` suite still passes → behavior-preserving.
- **Coordinator** — a gated `if "clientconfigs" in benchmark_config` branch before the single-tool dispatch. Flag **off** → clean log-and-skip (not a failure). Flag **on** → runs via the shared module and feeds the aggregated memtier JSON into the **unchanged** datasink/validate/status tail. The single-`clientconfig` path is **token-identical** (only re-indented under `else:`).
- **Tests** — `test_multi_tool.py` (9, incl. a foreground-failure→no-leak safety test) + `test_coordinator_multitool.py` (12), mock-only.
- Docs + the 2 ACL suite descriptions updated.

### Reviewed
A 7-agent adversarial review wave cleared this as **MERGEABLE, no blocking issues**: single-tool path byte-for-byte unchanged, runner adapter behavior-preserving, gate correct + failure-contained inside the per-test try, datasink labels build/topology-derived (tool-agnostic), and safe with the flag default-off. Mutation testing confirmed the safety-critical paths (abort-on-helper-death, mid-launch cleanup, memtier-base selection); the one uncaught mutation (bg-cleanup on fg-failure) now has a test.

### Not in v1 / follow-ups (documented)
- Profiling (perf/topdown) is not wired for the multi-tool coordinator path yet.
- Per-container cpuset split (memtier vs helper) — currently shared, matching the runner.
- Heavy multi-tool suites (e.g. 50K-subscribers) should be priority-gated before any fleet-wide flag flip.

### Needs fleet validation before rollout
Real concurrent container scheduling, real datasink TS-key writes, and stream consume+ack can only be validated on the fleet — a single scoped `--target-platform` run after merge. **Suggested rollout:** ship dark → enable on one runner → priority-gate heavy suites → fleet-wide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark execution and Docker lifecycle for concurrent clients; default-off flag limits fleet impact, but enabled runs add scheduling/teardown paths that need fleet validation before rollout.
> 
> **Overview**
> Adds **multi-tool `clientconfigs` support** to the self-contained coordinator (memtier + background helpers like `bcast-listener`), shipped **dark** behind **`BENCHMARK_MULTITOOL_ENABLED`** (default off). When the flag is unset, `clientconfigs` suites are **logged and skipped**; single-`clientconfig` runs are unchanged.
> 
> **Shared engine:** New `__common__/multi_tool.py` centralizes `prepare_client_run_specs`, `run_client_configs`, container cleanup, and background-helper teardown. Foreground clients are waited on; helpers are stopped in `finally`; early helper exit aborts the run; reported metrics come from **memtier JSON** (helpers only shape workload). **`runner.py`** `run_multiple_clients` is a thin wrapper over this module.
> 
> **Coordinator:** A gated branch runs multi-tool suites via the shared engine and feeds aggregated memtier output into the existing validate/datasink tail (profiling not wired for multi-tool in v1).
> 
> **Docs/tests:** README documents the flag; ACL suite YAML notes coordinator requirement; **`test_multi_tool.py`** and **`test_coordinator_multitool.py`** add mock-based coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b03229081c808052a148b904cf3dd77223af8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->