### PR TITLE
fix(multi-tool): split client cpuset so memtier and the helper get disjoint cores

### DIFF
--- a/redis_benchmarks_specification/__common__/multi_tool.py
+++ b/redis_benchmarks_specification/__common__/multi_tool.py
@@ -14,6 +14,7 @@ cycle.
 
 import json
 import logging
+import math
 import os
 import re
 from dataclasses import dataclass, field
@@ -39,6 +40,7 @@ class ClientRunSpec:
     environment: Optional[dict] = None  # vector-db env vars
     working_dir: Optional[str] = None  # vector-db => /app
     extra_volumes: Optional[dict] = None  # vector-db => /app/results mount
+    cpus: float = 0.0  # this client's resources.requests.cpus (for cpuset split)
 
 
 @dataclass
@@ -320,6 +322,13 @@ def prepare_client_run_specs(
 
         is_background = "bcast-listener" in client_tool
 
+        try:
+            client_cpus = float(
+                client_config.get("resources", {}).get("requests", {}).get("cpus", 0)
+            )
+        except (TypeError, ValueError):
+            client_cpus = 0.0
+
         working_dir = None
         environment = None
         extra_volumes = None
@@ -341,10 +350,70 @@ def prepare_client_run_specs(
                 environment=environment,
                 working_dir=working_dir,
                 extra_volumes=extra_volumes,
+                cpus=client_cpus,
             )
         )
 
     return run_specs
+
+
+def _expand_cpuset(cpuset_cpus):
+    """Parse a cpuset string ('4-11', '4,5,6', '4-7,12') into an ordered list of ints."""
+    ids = []
+    if not cpuset_cpus:
+        return ids
+    for part in str(cpuset_cpus).split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            a, b = part.split("-", 1)
+            ids.extend(range(int(a), int(b) + 1))
+        else:
+            ids.append(int(part))
+    return ids
+
+
+def partition_cpuset(cpuset_cpus, run_specs):
+    """Give each client container a DISJOINT contiguous sub-range of the aggregate
+    client cpuset, sized by its requested cpus (rounded up), so a measuring client
+    (memtier) and a background helper (e.g. bcast-listener) do not contend for the
+    same cores -- which would contaminate the measurement.
+
+    Returns a dict {client_index: 'a,b,c'} when a clean disjoint split is possible.
+    Returns None (caller shares the full cpuset for all clients, the legacy
+    behavior) when the split is not possible: a single client, no cpuset, any
+    client without a positive cpus request, or the per-client ceils not fitting
+    the aggregate.
+    """
+    cores = _expand_cpuset(cpuset_cpus)
+    if not cores or len(run_specs) < 2:
+        return None
+    needs = []
+    for spec in run_specs:
+        try:
+            n = int(math.ceil(float(getattr(spec, "cpus", 0) or 0)))
+        except (TypeError, ValueError):
+            n = 0
+        if n <= 0:
+            return None  # cannot size this container's pin -> share the full set
+        needs.append(n)
+    if sum(needs) > len(cores):
+        logging.warning(
+            "multi_tool: sum of client cpu requests (ceil=%d) exceeds the client "
+            "cpuset size (%d cores: %s); sharing the full cpuset across all client "
+            "containers (no isolation)",
+            sum(needs),
+            len(cores),
+            cpuset_cpus,
+        )
+        return None
+    partition = {}
+    pos = 0
+    for spec, n in zip(run_specs, needs):
+        partition[spec.client_index] = ",".join(str(x) for x in cores[pos : pos + n])
+        pos += n
+    return partition
 
 
 def run_client_configs(
@@ -373,12 +442,25 @@ def run_client_configs(
     containers = []
     results = []
 
+    # Pin each client container to a DISJOINT slice of the client cpuset so a
+    # measuring client (memtier) and a background helper (e.g. bcast-listener) do
+    # not contend for the same cores. Falls back to the shared cpuset when a clean
+    # split isn't possible (single client, missing cpu requests, doesn't fit).
+    cpuset_partition = partition_cpuset(cpuset_cpus, run_specs)
+    if cpuset_partition:
+        logging.info("multi_tool: cpuset split per client -> %s", cpuset_partition)
+
     # Start all containers simultaneously (detached)
     for spec in run_specs:
         client_index = spec.client_index
         client_tool = spec.client_tool
         client_image = spec.client_image
         benchmark_command_str = spec.command_str
+        spec_cpuset = (
+            cpuset_partition.get(client_index, cpuset_cpus)
+            if cpuset_partition
+            else cpuset_cpus
+        )
         try:
             # Calculate container timeout
             container_timeout = default_timeout
@@ -398,7 +480,7 @@ def run_client_configs(
 
             logging.info(
                 f"Starting client {client_index} with docker image {client_image} "
-                f"(cpuset={cpuset_cpus}) with args: {benchmark_command_str}"
+                f"(cpuset={spec_cpuset}) with args: {benchmark_command_str}"
             )
 
             # Set working directory based on tool
@@ -428,7 +510,7 @@ def run_client_configs(
                 "command": benchmark_command_str,
                 "network_mode": "host",
                 "detach": True,
-                "cpuset_cpus": cpuset_cpus,
+                "cpuset_cpus": spec_cpuset,
             }
 
             # Only add user for non-vector-db-benchmark tools to avoid

--- a/utils/tests/test_multi_tool.py
+++ b/utils/tests/test_multi_tool.py
@@ -389,3 +389,75 @@ def test_remove_started_containers_tolerates_remove_error():
 
     c0.remove.assert_called_once_with(force=True)
     c1.remove.assert_called_once_with(force=True)
+
+
+# --------------------------------------------------------------------------- #
+# cpuset split: memtier and the background helper must get DISJOINT cores
+# --------------------------------------------------------------------------- #
+def _cpu_spec(index, tool, cpus, is_background=False):
+    return multi_tool.ClientRunSpec(
+        client_index=index,
+        client_tool=tool,
+        client_image="img",
+        command_str="cmd",
+        output_filename=f"benchmark_output_{index}.json",
+        is_background=is_background,
+        cpus=cpus,
+    )
+
+
+def test_partition_cpuset_disjoint_when_it_fits():
+    specs = [
+        _cpu_spec(0, "memtier_benchmark", 4),
+        _cpu_spec(1, "bcast-listener", 4, is_background=True),
+    ]
+    part = multi_tool.partition_cpuset("4-11", specs)
+    assert part == {0: "4,5,6,7", 1: "8,9,10,11"}
+    # disjoint
+    assert set(part[0].split(",")).isdisjoint(part[1].split(","))
+
+
+def test_partition_cpuset_shares_when_not_possible():
+    s = [_cpu_spec(0, "memtier_benchmark", 4), _cpu_spec(1, "bcast-listener", 4, True)]
+    assert multi_tool.partition_cpuset("", s) is None  # no cpuset
+    assert multi_tool.partition_cpuset("0-7", [s[0]]) is None  # single client
+    # missing cpu requests -> share
+    no_cpu = [
+        _cpu_spec(0, "memtier_benchmark", 0),
+        _cpu_spec(1, "bcast-listener", 0, True),
+    ]
+    assert multi_tool.partition_cpuset("0-7", no_cpu) is None
+    # doesn't fit (5+5 > 8) -> share
+    big = [
+        _cpu_spec(0, "memtier_benchmark", 5),
+        _cpu_spec(1, "bcast-listener", 5, True),
+    ]
+    assert multi_tool.partition_cpuset("0-7", big) is None
+
+
+def test_run_client_configs_pins_disjoint_cpusets(tmp_path):
+    from unittest.mock import MagicMock
+
+    _write_memtier_output(tmp_path)
+    fg = MagicMock()
+    fg.wait.return_value = {"StatusCode": 0}
+    fg.logs.return_value = b"{}"
+    bg = MagicMock()
+    bg.status = "running"
+    bg.logs.return_value = b""
+    docker_client = MagicMock()
+    docker_client.containers.run.side_effect = [fg, bg]
+
+    specs = [
+        _cpu_spec(0, "memtier_benchmark", 4),
+        _cpu_spec(1, "bcast-listener", 4, is_background=True),
+    ]
+    multi_tool.run_client_configs(
+        docker_client,
+        specs,
+        cpuset_cpus="4-11",
+        temporary_dir_client=str(tmp_path),
+    )
+    calls = docker_client.containers.run.call_args_list
+    cpusets = [c.kwargs.get("cpuset_cpus") for c in calls]
+    assert cpusets == ["4,5,6,7", "8,9,10,11"]  # disjoint, not the shared "4-11"


### PR DESCRIPTION
In a multi-tool run, every client container shared one `cpuset_cpus`, so a **measuring** client (memtier) and a **background helper** (e.g. `bcast-listener`, which holds N tracking connections and drains invalidation push traffic) contended for the **same cores** — contaminating the measured throughput/latency. Worse, the helper's CPU usage *varies with the workload* (more invalidations → more draining → more stolen cycles), so it confounds exactly the kind of comparison these suites exist for.

### Fix
`run_client_configs` now gives each client container a **disjoint contiguous sub-range** of the aggregate client cpuset, sized by its `resources.requests.cpus` (rounded up). The aggregate is already `ceil(sum(cpus))` (via `extract_client_cpu_limit`), so for integer cpu requests the per-client slices fit exactly. Falls back to the **shared cpuset (legacy behavior) + a warning** when a clean split isn't possible (single client, a missing/zero cpu request, or the per-client ceils exceeding the aggregate). New `partition_cpuset()` helper.

Benefits the **runner and the coordinator** (shared engine), and the existing single-`clientconfig` path is unchanged (single client → no split → full cpuset).

### Verified
- `partition_cpuset` + `run_client_configs` covered by 3 new unit tests (disjoint-when-fits, share-fallback cases, real per-container kwargs). 12 tests pass; black clean.
- **On real hardware** (m7i.metal-24xl), an ACL suite (memtier `cpus:4` + bcast-listener `cpus:4`, aggregate `4-11`) now launches with `memtier -> 4,5,6,7` and `bcast-listener -> 8,9,10,11` — disjoint, isolated.

This lands before any official coordinator measurement so the numbers cleanly isolate the server-side effect rather than mixing in client-side CPU contention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark launch behavior only, with explicit fallbacks to the prior shared-cpuset path; single-client runs are unaffected.
> 
> **Overview**
> Multi-tool benchmark runs no longer pin every client Docker container to the **same** `cpuset_cpus`, which let memtier and background helpers like `bcast-listener` fight over cores and skew throughput/latency.
> 
> **`ClientRunSpec`** now carries each client’s `resources.requests.cpus`, and **`partition_cpuset`** splits the aggregate cpuset into disjoint contiguous slices (ceil per request). **`run_client_configs`** passes the per-client `cpuset_cpus` into `containers.run` when the split works; otherwise it keeps the old shared cpuset (with a warning if requests exceed available cores). Single-client and missing/zero CPU request paths are unchanged.
> 
> Three unit tests cover partition logic, fallback cases, and disjoint pins on launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432229d6a341be89ea7ca39dd00b6548aec19c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->