### PR TITLE
Support benchmarking RESP servers with a CMake build / gflags CLI

### DIFF
--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -528,7 +528,11 @@ def builder_process_stream(
                 z = ZipFileWithPermissions(io.BytesIO(buffer))
                 z.extractall(temporary_dir)
                 redis_dir = os.listdir(temporary_dir + "/")[0]
-                deps_dir = os.listdir(temporary_dir + "/" + redis_dir + "/deps")
+                # Not every server source tree has a top-level deps/ dir (e.g. CMake-based
+                # source trees). Guard so the listdir doesn't abort the build; deps_list is
+                # only consumed by the (currently commented-out) make-based deps path.
+                deps_path = temporary_dir + "/" + redis_dir + "/deps"
+                deps_dir = os.listdir(deps_path) if os.path.isdir(deps_path) else []
                 deps_list = [
                     "hiredis",
                     "jemalloc",
@@ -561,6 +565,20 @@ def builder_process_stream(
                 server_name = "redis"
                 if b"server_name" in testDetails:
                     server_name = testDetails[b"server_name"].decode()
+
+                # Per-build wall-clock cap for the container build step. Defaults to 600s;
+                # heavier source builds (large C++/CMake trees) can opt into a larger budget
+                # via --build_timeout without affecting existing make-based builds.
+                build_timeout_secs = 600
+                if b"build_timeout" in testDetails:
+                    try:
+                        build_timeout_secs = int(testDetails[b"build_timeout"].decode())
+                    except (ValueError, AttributeError):
+                        build_timeout_secs = 600
+                    # Guard against a 0/negative override that would make container.wait
+                    # time out immediately (or behave undefined).
+                    if build_timeout_secs <= 0:
+                        build_timeout_secs = 600
 
                 # Check if artifacts already exist before building
                 prefix = f"build_spec={build_spec}/github_org={github_org}/github_repo={github_repo}/git_branch={str(git_branch)}/git_version={str(git_version)}/git_hash={str(git_hash)}"
@@ -713,7 +731,9 @@ def builder_process_stream(
                         detach=True,
                     )
                     try:
-                        result = container.wait(timeout=600)  # 10 min max
+                        result = container.wait(
+                            timeout=build_timeout_secs
+                        )  # default 10 min; override via --build_timeout
                         exit_code = result.get("StatusCode", -1)
                         if exit_code != 0:
                             logs = container.logs(tail=50).decode(

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -200,6 +200,13 @@ def spec_cli_args(parser):
         default="",
     )
     parser.add_argument(
+        "--build_timeout",
+        type=int,
+        default=0,
+        help="Per-build container wall-clock cap in seconds (0 = pipeline default of 600). "
+        "Raise for heavy source builds such as large C++/CMake trees (e.g. 1800).",
+    )
+    parser.add_argument(
         "--git_hash",
         type=str,
         default="",

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -613,6 +613,8 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                 commit_dict["build_artifacts"] = args.build_artifacts
             if args.build_command != "":
                 commit_dict["build_command"] = args.build_command
+            if getattr(args, "build_timeout", 0):
+                commit_dict["build_timeout"] = str(args.build_timeout)
             if args.target_platform is not None:
                 commit_dict["target_platform"] = args.target_platform
                 logging.info(f"Targeting specific runner: {args.target_platform}")

--- a/redis_benchmarks_specification/__common__/runner.py
+++ b/redis_benchmarks_specification/__common__/runner.py
@@ -50,10 +50,11 @@ def execute_init_commands(
             except redis.exceptions.ResponseError as e:
                 # Some RESP servers reject redis-specific seeding commands (e.g. a
                 # CONFIG SET / DEBUG subcommand or an option form they don't implement).
-                # Keep the historical fail-fast behavior for redis; tolerate-and-continue
-                # for other servers so a benchmark isn't aborted by an unsupported init
-                # command.
-                if server_name == "redis":
+                # Keep the historical fail-fast behavior for redis-semantics servers
+                # (redis, valkey) where a seeding error is a real problem; tolerate-and-
+                # continue for other servers so a benchmark isn't aborted by an
+                # unsupported init command.
+                if server_name in ("redis", "valkey"):
                     raise
                 logging.warning(
                     "Tolerating unsupported init command for server '{}': {}".format(

--- a/redis_benchmarks_specification/__common__/runner.py
+++ b/redis_benchmarks_specification/__common__/runner.py
@@ -13,7 +13,9 @@ from redis_benchmarks_specification.__common__.timeseries import (
 )
 
 
-def execute_init_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
+def execute_init_commands(
+    benchmark_config, r, dbconfig_keyname="dbconfig", server_name="redis"
+):
     cmds = None
     lua_scripts = None
     res = 0
@@ -45,6 +47,19 @@ def execute_init_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
                     stdout = r.execute_command(cmd)
                 res = res + 1
                 logging.info("Command reply: {}".format(stdout))
+            except redis.exceptions.ResponseError as e:
+                # Some RESP servers reject redis-specific seeding commands (e.g. a
+                # CONFIG SET / DEBUG subcommand or an option form they don't implement).
+                # Keep the historical fail-fast behavior for redis; tolerate-and-continue
+                # for other servers so a benchmark isn't aborted by an unsupported init
+                # command.
+                if server_name == "redis":
+                    raise
+                logging.warning(
+                    "Tolerating unsupported init command for server '{}': {}".format(
+                        server_name, e
+                    )
+                )
             except redis.connection.ConnectionError as e:
                 logging.error(
                     "Error establishing connection to Redis. Message: {}".format(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/artifacts.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/artifacts.py
@@ -18,7 +18,7 @@ def restore_build_artifacts_from_test_details(
             artifact_fname = "{}/{}".format(temporary_dir, build_artifact)
             with open(artifact_fname, "wb") as fd:
                 fd.write(buffer)
-                os.chmod(artifact_fname, 755)
+                os.chmod(artifact_fname, 0o755)  # octal: rwxr-xr-x (was decimal 755)
 
             logging.info(
                 "Successfully restored {} into {}".format(

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -309,13 +309,15 @@ def spin_docker_cluster_redis(
     Returns:
         tuple: (cluster_conns, current_cpu_pos)
     """
-    # Dragonfly support is standalone-only (P1). The cluster path emits redis-style flags
-    # (--cluster-enabled ...) that Dragonfly's gflags parser aborts on, and uses a bare PING.
-    # Fail loudly rather than silently mis-launch / hang.
+    # gflags-based servers (e.g. dragonfly) are standalone-only for now. The cluster path
+    # emits redis-style flags (--cluster-enabled ...) such a server aborts on, and uses a
+    # bare PING. Fail loudly rather than silently mis-launch / hang.
     if server_name == "dragonfly":
         raise NotImplementedError(
-            "Dragonfly benchmarking currently supports standalone topologies only; "
-            "cluster topologies are not yet wired (see competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md)."
+            "server_name='{}' is only supported for standalone topologies; "
+            "cluster mode is not yet implemented for gflags-based servers.".format(
+                server_name
+            )
         )
     executable = "{}{}-server".format(mnt_point, server_name)
     per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
@@ -441,12 +443,14 @@ def spin_up_redis_replicas(
     the wall-clock time from container start to master_link_status=up.
     Use this as a benchmark metric for full-sync performance testing.
     """
-    # Dragonfly support is standalone-only (P1); replica topologies pass redis-style
-    # --replicaof/--masterauth flags that Dragonfly's gflags parser aborts on. Fail loudly.
+    # gflags-based servers (e.g. dragonfly) are standalone-only for now; replica topologies
+    # pass redis-style --replicaof/--masterauth flags such a server aborts on. Fail loudly.
     if server_name == "dragonfly":
         raise NotImplementedError(
-            "Dragonfly benchmarking currently supports standalone topologies only; "
-            "replica topologies are not yet wired (see competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md)."
+            "server_name='{}' is only supported for standalone topologies; "
+            "replica mode is not yet implemented for gflags-based servers.".format(
+                server_name
+            )
         )
     replica_conns = []
     sync_times_seconds = []

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -41,7 +41,7 @@ def inject_replication_sync_metrics(
         return False
 
 
-def generate_standalone_redis_server_args(
+def generate_standalone_dragonfly_server_args(
     binary,
     port,
     dbdir,
@@ -49,6 +49,88 @@ def generate_standalone_redis_server_args(
     redis_arguments="",
     password=None,
 ):
+    """Build a launch command for a Dragonfly server (gflags-based CLI).
+
+    Dragonfly parses its flags with Abseil/gflags and ABORTS on any unknown flag, so we
+    cannot pass the redis-style args (``--protected-mode``, ``--logfile``, ``--save``,
+    ``--maxmemory-policy``, ``--io-threads`` ...). We emit only valid Dragonfly gflags and
+    translate / drop the redis ``configuration-parameters`` accordingly. Snapshotting to a
+    file is disabled (``--dbfilename=``) and the server is pinned to a single proactor
+    thread by default so a standalone run is comparable to single-threaded redis-server
+    (a topology may override via a ``--proactor_threads=N`` token in ``redis_arguments``).
+    """
+    # Allow a topology to override the proactor-thread count; default to 1 (apples-to-apples
+    # vs single-threaded redis-server). Accept both the gflags "=" form (--proactor_threads=N)
+    # and the space form (--proactor_threads N); warn loudly if a proactor override is present
+    # but un-parseable so a benchmark never silently runs on the wrong thread count.
+    proactor_threads = "1"
+    if redis_arguments != "":
+        toks = redis_arguments.split(" ")
+        for i, tok in enumerate(toks):
+            if tok.startswith("--proactor_threads="):
+                proactor_threads = tok.split("=", 1)[1]
+            elif tok == "--proactor_threads" and i + 1 < len(toks):
+                proactor_threads = toks[i + 1]
+        if "proactor_threads" in redis_arguments and proactor_threads == "1":
+            logging.warning(
+                "redis_arguments contains 'proactor_threads' but no value was parsed; "
+                "defaulting Dragonfly to --proactor_threads=1. redis_arguments=%r",
+                redis_arguments,
+            )
+    command = [
+        binary,
+        "--port",
+        "{}".format(port),
+        "--logtostderr",  # replaces redis --logfile
+        "--proactor_threads={}".format(proactor_threads),
+        "--dbfilename=",  # no snapshot file (the Dragonfly analogue of redis save "")
+        "--version_check=false",  # disable the once-a-day phone-home (jitter / egress dep)
+        "--default_lua_flags=allow-undeclared-keys",  # tolerate EVAL-based init_commands
+    ]
+    if password is not None and password != "":
+        command.extend(["--requirepass", password])
+        logging.info("Dragonfly server will be started with password authentication")
+    if dbdir != "":
+        command.extend(["--dir", dbdir])
+    # Translate the handful of redis config params that have a Dragonfly equivalent; all
+    # other redis-only params are silently dropped so Dragonfly does not abort on startup.
+    dragonfly_param_map = {"maxmemory": "maxmemory"}
+    if configuration_parameters is not None:
+        for parameter, parameter_value in configuration_parameters.items():
+            if parameter in dragonfly_param_map:
+                command.append(
+                    "--{}={}".format(dragonfly_param_map[parameter], parameter_value)
+                )
+            else:
+                logging.info(
+                    "Dropping redis-only config parameter '{}' for Dragonfly launch".format(
+                        parameter
+                    )
+                )
+    return command
+
+
+def generate_standalone_redis_server_args(
+    binary,
+    port,
+    dbdir,
+    configuration_parameters=None,
+    redis_arguments="",
+    password=None,
+    server_name="redis",
+):
+    # Dragonfly speaks RESP/port-6379 but uses a gflags CLI that aborts on redis-style
+    # flags — dispatch to a server-specific arg generator. Default path (redis/valkey,
+    # which share redis-server semantics) is unchanged.
+    if server_name == "dragonfly":
+        return generate_standalone_dragonfly_server_args(
+            binary,
+            port,
+            dbdir,
+            configuration_parameters,
+            redis_arguments,
+            password,
+        )
     added_params = ["port", "protected-mode", "dir", "requirepass", "logfile"]
     # start redis-server
     command = [
@@ -227,6 +309,14 @@ def spin_docker_cluster_redis(
     Returns:
         tuple: (cluster_conns, current_cpu_pos)
     """
+    # Dragonfly support is standalone-only (P1). The cluster path emits redis-style flags
+    # (--cluster-enabled ...) that Dragonfly's gflags parser aborts on, and uses a bare PING.
+    # Fail loudly rather than silently mis-launch / hang.
+    if server_name == "dragonfly":
+        raise NotImplementedError(
+            "Dragonfly benchmarking currently supports standalone topologies only; "
+            "cluster topologies are not yet wired (see competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md)."
+        )
     executable = "{}{}-server".format(mnt_point, server_name)
     per_node_cpu = max(1, ceil_db_cpu_limit // primary_count)
     cluster_conns = []
@@ -351,6 +441,13 @@ def spin_up_redis_replicas(
     the wall-clock time from container start to master_link_status=up.
     Use this as a benchmark metric for full-sync performance testing.
     """
+    # Dragonfly support is standalone-only (P1); replica topologies pass redis-style
+    # --replicaof/--masterauth flags that Dragonfly's gflags parser aborts on. Fail loudly.
+    if server_name == "dragonfly":
+        raise NotImplementedError(
+            "Dragonfly benchmarking currently supports standalone topologies only; "
+            "replica topologies are not yet wired (see competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md)."
+        )
     replica_conns = []
     sync_times_seconds = []
     for i in range(1, replica_count + 1):

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -2641,18 +2641,24 @@ def process_self_contained_coordinator_stream(
 
                                     # Shut down all nodes in reverse order: replicas, then primary (idx 0).
                                     # ConnectionError is the expected success path (the server drops the
-                                    # connection on SHUTDOWN). Some RESP servers (e.g. Dragonfly) don't drop
-                                    # it the way redis-py expects, so .shutdown() raises a generic RedisError
-                                    # ("SHUTDOWN seems to have failed") — tolerate it: results are already
-                                    # pushed at this point and the container is force-stopped in teardown.
+                                    # connection on SHUTDOWN). redis keeps fail-fast on any other RedisError
+                                    # so a genuinely-broken shutdown still fails the test; non-redis servers
+                                    # (e.g. Dragonfly, which doesn't drop the connection the way redis-py
+                                    # expects and raises a generic "SHUTDOWN seems to have failed") tolerate
+                                    # it — results are already pushed and the container is force-stopped in
+                                    # teardown.
                                     for redis_conn in reversed(redis_conns):
                                         try:
                                             redis_conn.shutdown(save=False)
+                                        except redis.exceptions.ConnectionError:
+                                            pass
                                         except redis.exceptions.RedisError as e:
-                                            logging.info(
-                                                "Ignoring non-fatal error during server shutdown "
-                                                "(results already collected): {}".format(
-                                                    e
+                                            if server_name == "redis":
+                                                raise
+                                            logging.warning(
+                                                "Tolerating non-fatal shutdown error for server "
+                                                "'{}' (results already collected): {} ({})".format(
+                                                    server_name, e, type(e).__name__
                                                 )
                                             )
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1997,6 +1997,7 @@ def process_self_contained_coordinator_stream(
                                         benchmark_config,
                                         redis_conn,
                                         dbconfig_keyname="dbconfig",
+                                        server_name=server_name,
                                     )
 
                                 # Multi-tool clientconfigs suites (e.g. memtier +
@@ -2650,7 +2651,9 @@ def process_self_contained_coordinator_stream(
                                         except redis.exceptions.RedisError as e:
                                             logging.info(
                                                 "Ignoring non-fatal error during server shutdown "
-                                                "(results already collected): {}".format(e)
+                                                "(results already collected): {}".format(
+                                                    e
+                                                )
                                             )
 
                                 except redis.exceptions.ConnectionError as e:

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1787,6 +1787,7 @@ def process_self_contained_coordinator_stream(
                                         redis_configuration_parameters,
                                         redis_arguments,
                                         redis_password,
+                                        server_name=server_name,
                                     )
                                     command_str = " ".join(command)
                                     db_cpuset_cpus, current_cpu_pos = (
@@ -1808,7 +1809,24 @@ def process_self_contained_coordinator_stream(
                                         port=redis_proc_start_port,
                                         password=redis_password,
                                     )
-                                    redis_conn.ping()
+                                    # Retry PING after the fixed container sleep — some
+                                    # servers (e.g. io_uring-based) accept connections a
+                                    # beat later. First attempt succeeds immediately for
+                                    # redis-server, so behavior there is unchanged.
+                                    _standalone_ping_ok = False
+                                    for _ping_attempt in range(20):
+                                        try:
+                                            redis_conn.ping()
+                                            _standalone_ping_ok = True
+                                            break
+                                        except (
+                                            redis.ConnectionError,
+                                            redis.TimeoutError,
+                                        ):
+                                            time.sleep(0.5)
+                                    if not _standalone_ping_ok:
+                                        # exhausted retries — raise the underlying error
+                                        redis_conn.ping()
                                     primary_conns.append(redis_conn)
 
                                 # Allocate the client cpuset up front so that
@@ -1921,14 +1939,26 @@ def process_self_contained_coordinator_stream(
                                     )
 
                                 server_version_keyname = f"{server_name}_version"
-                                if (
-                                    git_version is None
-                                    and server_version_keyname in redis_info
-                                ):
-                                    git_version = redis_info[server_version_keyname]
-                                    logging.info(
-                                        f"Given git_version was None, we've collected that info from the server reply key named {server_version_keyname}. git_version={git_version}"
-                                    )
+                                if git_version is None:
+                                    # Prefer the server-specific version key; fall back to
+                                    # redis_version, which RESP-compatible servers that don't
+                                    # emit a "<server_name>_version" key still report (e.g.
+                                    # Dragonfly reports redis_version, not dragonfly_version).
+                                    _version_src = None
+                                    if server_version_keyname in redis_info:
+                                        git_version = redis_info[server_version_keyname]
+                                        _version_src = server_version_keyname
+                                    elif "redis_version" in redis_info:
+                                        git_version = redis_info["redis_version"]
+                                        _version_src = "redis_version"
+                                    if _version_src is not None:
+                                        logging.info(
+                                            f"Given git_version was None, we've collected it from the server reply key '{_version_src}'. git_version={git_version}"
+                                        )
+                                    else:
+                                        logging.warning(
+                                            f"git_version is None and the server reply had neither '{server_version_keyname}' nor 'redis_version'; the datapoint will be version-unlabeled."
+                                        )
                                 # Capture initial sync_full count from master so we can
                                 # compute the delta after the benchmark runs. Write-heavy
                                 # benchmarks with a small replication backlog will trigger
@@ -2608,12 +2638,20 @@ def process_self_contained_coordinator_stream(
                                         git_hash,
                                     )
 
-                                    # Shut down all nodes in reverse order: replicas, then primary (idx 0)
+                                    # Shut down all nodes in reverse order: replicas, then primary (idx 0).
+                                    # ConnectionError is the expected success path (the server drops the
+                                    # connection on SHUTDOWN). Some RESP servers (e.g. Dragonfly) don't drop
+                                    # it the way redis-py expects, so .shutdown() raises a generic RedisError
+                                    # ("SHUTDOWN seems to have failed") — tolerate it: results are already
+                                    # pushed at this point and the container is force-stopped in teardown.
                                     for redis_conn in reversed(redis_conns):
                                         try:
                                             redis_conn.shutdown(save=False)
-                                        except redis.exceptions.ConnectionError:
-                                            pass
+                                        except redis.exceptions.RedisError as e:
+                                            logging.info(
+                                                "Ignoring non-fatal error during server shutdown "
+                                                "(results already collected): {}".format(e)
+                                            )
 
                                 except redis.exceptions.ConnectionError as e:
                                     logging.critical(

--- a/utils/tests/test_dragonfly_launch_args.py
+++ b/utils/tests/test_dragonfly_launch_args.py
@@ -20,6 +20,15 @@ from redis_benchmarks_specification.__self_contained_coordinator__.docker import
     spin_up_redis_replicas,
 )
 from redis_benchmarks_specification.__cli__.args import spec_cli_args
+from redis_benchmarks_specification.__common__.runner import execute_init_commands
+import redis
+
+
+class _RaisingConn:
+    """Minimal fake redis conn whose execute_command always raises ResponseError."""
+
+    def execute_command(self, *args, **kwargs):
+        raise redis.exceptions.ResponseError("ERR unknown command")
 
 
 # Flags that Dragonfly's gflags parser would abort on if we ever emitted them.
@@ -176,7 +185,10 @@ def test_dragonfly_proactor_override_space_form():
 
 def test_dragonfly_proactor_defaults_to_one_when_absent():
     cmd = generate_standalone_dragonfly_server_args(
-        "/mnt/redis/dragonfly-server", 6379, "/mnt/redis/", redis_arguments="--io-threads 4"
+        "/mnt/redis/dragonfly-server",
+        6379,
+        "/mnt/redis/",
+        redis_arguments="--io-threads 4",
     )
     assert "--proactor_threads=1" in cmd
 
@@ -207,3 +219,18 @@ def test_replica_topology_rejects_dragonfly():
             None,
             server_name="dragonfly",
         )
+
+
+_INIT_CFG = {"dbconfig": {"init_commands": ["CONFIG SET some-redis-only-param yes"]}}
+
+
+def test_init_commands_reraise_for_redis():
+    """A failing init command still fails the run for redis (historical behavior)."""
+    with pytest.raises(redis.exceptions.ResponseError):
+        execute_init_commands(_INIT_CFG, _RaisingConn(), server_name="redis")
+
+
+def test_init_commands_tolerated_for_dragonfly():
+    """A failing/unsupported init command is tolerated for non-redis servers."""
+    # Should NOT raise.
+    execute_init_commands(_INIT_CFG, _RaisingConn(), server_name="dragonfly")

--- a/utils/tests/test_dragonfly_launch_args.py
+++ b/utils/tests/test_dragonfly_launch_args.py
@@ -230,6 +230,12 @@ def test_init_commands_reraise_for_redis():
         execute_init_commands(_INIT_CFG, _RaisingConn(), server_name="redis")
 
 
+def test_init_commands_reraise_for_valkey():
+    """valkey is redis-semantics: a failing init command still fails fast."""
+    with pytest.raises(redis.exceptions.ResponseError):
+        execute_init_commands(_INIT_CFG, _RaisingConn(), server_name="valkey")
+
+
 def test_init_commands_tolerated_for_dragonfly():
     """A failing/unsupported init command is tolerated for non-redis servers."""
     # Should NOT raise.

--- a/utils/tests/test_dragonfly_launch_args.py
+++ b/utils/tests/test_dragonfly_launch_args.py
@@ -1,0 +1,209 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+"""Pure unit tests (no docker / no network) for the server_name-aware standalone launch
+arg generator and the --build_timeout CLI flag. Validates that:
+  * the default (redis) launch path is unchanged,
+  * the Dragonfly path emits only valid gflags and never a redis-style flag,
+  * redis-only config parameters are dropped / translated for Dragonfly.
+"""
+import argparse
+
+import pytest
+
+from redis_benchmarks_specification.__self_contained_coordinator__.docker import (
+    generate_standalone_redis_server_args,
+    generate_standalone_dragonfly_server_args,
+    spin_docker_cluster_redis,
+    spin_up_redis_replicas,
+)
+from redis_benchmarks_specification.__cli__.args import spec_cli_args
+
+
+# Flags that Dragonfly's gflags parser would abort on if we ever emitted them.
+REDIS_ONLY_FLAGS = {
+    "--protected-mode",
+    "--logfile",
+    "--save",
+    "--appendonly",
+    "--maxmemory-policy",
+    "--rdbcompression",
+    "--io-threads",
+    "--io-threads-do-reads",
+}
+
+
+def test_redis_default_path_unchanged():
+    """Default server_name keeps the exact historical redis-server args."""
+    cmd = generate_standalone_redis_server_args(
+        "/mnt/redis/redis-server", 6379, "/mnt/redis/"
+    )
+    assert cmd[0] == "/mnt/redis/redis-server"
+    assert "--protected-mode" in cmd and "no" in cmd
+    assert "--port" in cmd and "6379" in cmd
+    # redis writes a logfile in the data dir
+    assert "--logfile" in cmd
+    assert "--dir" in cmd
+
+
+def test_redis_explicit_server_name_matches_default():
+    base = generate_standalone_redis_server_args(
+        "/mnt/redis/redis-server", 6379, "/mnt/redis/"
+    )
+    explicit = generate_standalone_redis_server_args(
+        "/mnt/redis/redis-server", 6379, "/mnt/redis/", server_name="redis"
+    )
+    assert base == explicit
+
+
+def test_dragonfly_dispatch_via_server_name():
+    """server_name='dragonfly' routes to the Dragonfly generator."""
+    via_dispatch = generate_standalone_redis_server_args(
+        "/mnt/redis/dragonfly-server",
+        6379,
+        "/mnt/redis/",
+        server_name="dragonfly",
+    )
+    direct = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server", 6379, "/mnt/redis/"
+    )
+    assert via_dispatch == direct
+
+
+def test_dragonfly_emits_only_valid_gflags():
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server", 6379, "/mnt/redis/"
+    )
+    assert cmd[0] == "/mnt/redis/dragonfly-server"
+    assert "--port" in cmd and "6379" in cmd
+    assert "--logtostderr" in cmd
+    assert "--proactor_threads=1" in cmd
+    assert "--dbfilename=" in cmd
+    # No redis-only flag must ever appear (Dragonfly would abort).
+    for tok in cmd:
+        assert tok not in REDIS_ONLY_FLAGS, f"redis-only flag leaked: {tok}"
+    # No redis logfile / protected-mode either.
+    assert "--protected-mode" not in cmd
+    assert "--logfile" not in cmd
+
+
+def test_dragonfly_drops_redis_only_and_translates_maxmemory():
+    cfg = {
+        "save": '""',
+        "maxmemory-policy": "noeviction",
+        "rdbcompression": "no",
+        "maxmemory": "1gb",
+    }
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server", 6379, "/mnt/redis/", configuration_parameters=cfg
+    )
+    joined = " ".join(cmd)
+    # redis-only params dropped
+    assert "save" not in joined
+    assert "maxmemory-policy" not in joined
+    assert "rdbcompression" not in joined
+    # maxmemory translated to a gflag (and NOT confused with maxmemory-policy)
+    assert "--maxmemory=1gb" in cmd
+
+
+def test_dragonfly_password_and_dir():
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server",
+        6379,
+        "/mnt/redis/",
+        password="secret",
+    )
+    assert "--requirepass" in cmd
+    i = cmd.index("--requirepass")
+    assert cmd[i + 1] == "secret"
+    assert "--dir" in cmd
+    assert "/mnt/redis/" in cmd
+
+
+def test_dragonfly_proactor_threads_override():
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server",
+        6379,
+        "/mnt/redis/",
+        redis_arguments="--proactor_threads=4",
+    )
+    assert "--proactor_threads=4" in cmd
+    assert "--proactor_threads=1" not in cmd
+
+
+def test_dragonfly_ignores_redis_style_topology_arguments():
+    """redis-style topology redis_arguments (e.g. --io-threads) must not leak through."""
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server",
+        6379,
+        "/mnt/redis/",
+        redis_arguments="--io-threads 4 --io-threads-do-reads yes",
+    )
+    joined = " ".join(cmd)
+    assert "io-threads" not in joined
+
+
+def test_build_timeout_cli_flag():
+    """--build_timeout parses as an int and defaults to 0 (pipeline default 600s)."""
+    parser = argparse.ArgumentParser()
+    spec_cli_args(parser)
+    default_args = parser.parse_args([])
+    assert default_args.build_timeout == 0
+    set_args = parser.parse_args(["--build_timeout", "1800"])
+    assert set_args.build_timeout == 1800
+
+
+def test_dragonfly_disables_version_check_phone_home():
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server", 6379, "/mnt/redis/"
+    )
+    assert "--version_check=false" in cmd
+
+
+def test_dragonfly_proactor_override_space_form():
+    """The space form --proactor_threads N must be honored (not just the = form)."""
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server",
+        6379,
+        "/mnt/redis/",
+        redis_arguments="--proactor_threads 8",
+    )
+    assert "--proactor_threads=8" in cmd
+    assert "--proactor_threads=1" not in cmd
+
+
+def test_dragonfly_proactor_defaults_to_one_when_absent():
+    cmd = generate_standalone_dragonfly_server_args(
+        "/mnt/redis/dragonfly-server", 6379, "/mnt/redis/", redis_arguments="--io-threads 4"
+    )
+    assert "--proactor_threads=1" in cmd
+
+
+def test_cluster_topology_rejects_dragonfly():
+    """Cluster topology must fail loudly for Dragonfly (standalone-only in P1)."""
+    with pytest.raises(NotImplementedError):
+        spin_docker_cluster_redis(
+            1, 1, 0, None, None, [], 6379, "img", "/tmp/", server_name="dragonfly"
+        )
+
+
+def test_replica_topology_rejects_dragonfly():
+    """Replica topology must fail loudly for Dragonfly (standalone-only in P1)."""
+    with pytest.raises(NotImplementedError):
+        spin_up_redis_replicas(
+            1,
+            6379,
+            0,
+            None,
+            [],
+            "img",
+            "",
+            "/mnt/redis/",
+            1,
+            None,
+            "",
+            None,
+            server_name="dragonfly",
+        )


### PR DESCRIPTION
Adds support for building and benchmarking RESP-compatible servers whose build and/or CLI differ from `redis-server`, reusing the existing trigger→build→benchmark pipeline and without changing existing redis/valkey runs.

## Changes
1. **Builder** — guard the optional top-level `deps/` listdir so CMake-based source trees (no `deps/` dir) build through the pipeline; add `--build_timeout` (default `0` → existing 600s) so heavier source builds can raise the per-build container wall-clock cap. Make-based builds are byte-identical.
2. **Coordinator** — a `server_name`-aware standalone launch-arg generator: servers that parse flags with gflags (and abort on redis-style flags) get a server-specific arg builder that emits only valid flags and translates/drops unsupported config parameters; the default redis path is unchanged. Cluster/replica topologies are guarded (standalone-only) with a clear error. Plus a PING readiness retry, a version-key fallback to `redis_version`, tolerance of a non-fatal SHUTDOWN at teardown, and octal file-mode for the restored binary.
3. **Tests** — pure unit coverage (no docker/network) for the launch-arg generator and the new flag.

## Why
Lets the same CLI surface (`--server_name`, `--build_command`, `--build_artifacts`) cover servers such as Dragonfly (RESP2/6379, CMake build, gflags CLI) — server-specific differences live in a `--build_command` and the launch-arg generator.

## Backward compatibility
Defaults to current behavior: `server_name` defaults to `redis`, `--build_timeout` defaults to 600s, the `deps/` guard is a strict superset. Redis launch path and existing tests unchanged.

## Validation
Built and benchmarked a standalone string workload end-to-end on the fleet (build → launch → memtier → datapoint); redis path unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core build and coordinator paths (Docker builds, server launch, init/shutdown); changes are gated by server_name and defaults preserve redis/valkey fail-fast behavior, but misconfiguration could still affect fleet benchmark runs.
> 
> **Overview**
> Extends the benchmark pipeline so **CMake / gflags** RESP servers (e.g. Dragonfly) can be built and run through the same trigger→build→run flow without changing default **redis/valkey** behavior.
> 
> **Build:** Optional top-level `deps/` is only listed when present so CMake source trees don’t fail extraction; **`--build_timeout`** (CLI → build stream, default 600s) caps the Docker build step for heavier compiles.
> 
> **Run (standalone):** `server_name` selects launch args—**Dragonfly** gets a dedicated gflags command (drops redis-only flags, maps `maxmemory`, default `--proactor_threads=1`, etc.); redis/valkey paths stay the same. **Cluster/replica** topologies raise **`NotImplementedError`** for Dragonfly. Coordinator adds **PING retries**, **`redis_version`** fallback when labeling versions, **tolerant init commands** and **shutdown** for non-redis servers, and fixes restored binary **`chmod`** to **`0o755`**.
> 
> **Tests:** Unit tests for Dragonfly args, build timeout CLI, init-command policy, and topology guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f44c8a1e7c3458f2ee9afd72a6847e6d5ed06dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->