### PR TITLE
Add small-keyspace MSET overwrite coverage (100 hot keys, 10B values)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100keys-mset-overwrite-10B-pipeline-1.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100keys-mset-overwrite-10B-pipeline-1.yml
@@ -1,5 +1,5 @@
 version: 0.4
-name: memtier_benchmark-100keys-mset-overwrite-10B-pipeline-10
+name: memtier_benchmark-100keys-mset-overwrite-10B-pipeline-1
 description: 'Runs memtier_benchmark over a tiny keyspace of 100 STRING keys (~11-byte
   key names, matching a real report) repeatedly overwritten with MSET (3 key-value
   pairs per command). Values are 10 bytes. The tiny keyspace keeps the Redis main
@@ -40,9 +40,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="MSET __key__ __data__ __key__ __data__ __key__ __data__"
-    --command-key-pattern=RRR --key-prefix "test_mset_" --key-minimum 1 --key-maximum
-    101 --data-size 10 --hide-histogram --test-time 180 --pipeline 10 -c 1 -t 1
+  arguments: --command="MSET __key__ __data__ __key__ __data__ __key__ __data__" --command-key-pattern=R --key-prefix "test_mset_" --key-minimum 1 --key-maximum 100 --data-size 10 --hide-histogram --test-time 180 --pipeline 1 -c 1 -t 1
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100keys-mset-overwrite-10B-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100keys-mset-overwrite-10B-pipeline-10.yml
@@ -1,0 +1,50 @@
+version: 0.4
+name: memtier_benchmark-100keys-mset-overwrite-10B-pipeline-10
+description: 'Runs memtier_benchmark over a tiny keyspace of 100 STRING keys (~11-byte
+  key names, matching a real report) repeatedly overwritten with MSET (3 key-value
+  pairs per command). Values are 10 bytes. The tiny keyspace keeps the Redis main
+  dict and all key objects resident in L1/L2 cache with near-zero hash collisions and
+  no rehashing, so dictFind is cache-latency dominated rather than DRAM-latency
+  dominated. Encoding: EMBSTR (10B value < 44B threshold). Metric of interest is p50
+  latency (lower is better). Designed to surface dictFind fast-path regressions on a
+  cache-hot, low-collision keyspace (redis/redis#15320 regime) that the existing
+  1M-10M distinct-key MSET load specs (DRAM-latency dominated) cannot show.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 100
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command="SET __key__ __data__" --command-key-pattern=P --key-prefix
+      "test_mset_" --key-minimum 1 --key-maximum 101 --data-size 10 -n allkeys
+      --hide-histogram -t 1 -c 1 --pipeline 50
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 100keys-string-10B-embstr
+  dataset_description: 100 string keys named test_mset_1..test_mset_100 (~11-byte
+    keys) with 10-byte EMBSTR values. The tiny keyspace fits entirely in L1/L2 cache,
+    making dictFind cache-latency dominated with no rehashing.
+tested-groups:
+- string
+tested-commands:
+- mset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="MSET __key__ __data__ __key__ __data__ __key__ __data__"
+    --command-key-pattern=RRR --key-prefix "test_mset_" --key-minimum 1 --key-maximum
+    101 --data-size 10 --hide-histogram --test-time 180 --pipeline 10 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 69


### PR DESCRIPTION
Adds an MSET benchmark over a **tiny, cache-resident keyspace** — 100 string keys (~11-byte names) repeatedly overwritten with MSET (3 pairs/command), 10-byte EMBSTR values, pipeline 10.

Existing MSET specs load 1M–10M distinct keys and are DRAM-latency dominated. This adds a low-collision, L1/L2-resident regime so dictFind fast-path effects on p50 latency are observable — the regime in redis/redis#15320.

Validated with `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` (passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a benchmark YAML spec; no server or CI runner logic changes.
> 
> **Overview**
> Adds a new memtier benchmark spec **`memtier_benchmark-100keys-mset-overwrite-10B-pipeline-1`** that exercises **MSET overwrites** on a **100-key** string keyspace with **10-byte EMBSTR** values and **pipeline 1** (3 pairs per command, random keys in `test_mset_1`–`100`).
> 
> The workload is meant to keep the main dict and keys **L1/L2-resident** with **low collisions** and **no rehashing**, so **p50 latency** reflects **dictFind fast-path** behavior—the regime called out in **redis/redis#15320**—complementing existing **1M–10M distinct-key MSET load** specs that are **DRAM-latency dominated**.
> 
> Preload uses pipelined **SET**; the run uses **180s** test time, **oss-standalone**, gcc/dockerhub build variants, and **priority 69**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c7b4f0c136db3aefe85c87bbff5307701c27425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->