### PR TITLE
feat(api): scope labeled-PR benchmarks from the diff instead of the full suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,9 @@ fabric.properties
 
 # Json result files
 *.json
+# ...except in-package data files that must ship with the wheel
+!redis_benchmarks_specification/__common__/files-to-groups.json
+!redis_benchmarks_specification/__common__/core-specs.json
 
 # perf related
 *.out

--- a/Readme.md
+++ b/Readme.md
@@ -280,6 +280,29 @@ The HTTP request is then converted into an event ( tracked within redis ) that w
 
 As soon as a new build variant request is received, the build agent ([`redis-benchmarks-spec-builder`](https://github.com/filipecosta90/redis-benchmarks-specification/tree/main/redis_benchmarks_specification/__builder__/)) 
 prepares the artifact(s) and proceeds into adding an artifact benchmark event so that the benchmark coordinator ([`redis-benchmarks-spec-sc-coordinator`](https://github.com/filipecosta90/redis-benchmarks-specification/tree/main/redis_benchmarks_specification/__self_contained_coordinator__/))  can deploy/manage the required infrastructure and DB topologies, run the benchmark, and export the performance results.
+
+### PR diff-driven benchmark scoping
+
+When a pull request is labeled with the trigger label (`action:run-benchmark`), the API
+scopes the run to the part of the suite the PR's diff actually touches, instead of running
+the full suite:
+
+- changed data-type files (`t_hash.c` → `hash`, `t_zset.c` → `sorted-set`, …) run only those
+  command groups (`tests_groups_regexp`). The file→group map is
+  [`__common__/files-to-groups.json`](redis_benchmarks_specification/__common__/files-to-groups.json);
+- a change to a broad/infra/unmapped file (`server.c`, `networking.c`, `db.c`, a new file, …),
+  or a PR with no source changes, runs a small cross-group "core" set — one representative
+  spec per group, in [`__common__/core-specs.json`](redis_benchmarks_specification/__common__/core-specs.json);
+- a very large PR, an unavailable GitHub lookup, or a push event runs the **full** suite.
+
+The active filter is shown in the build-started PR comment, so a scoped run is visible on the PR.
+
+| env var | default | meaning |
+|---|---|---|
+| `BENCHMARK_PR_DIFF_SCOPING` | `1` (on) | set to `0`/`false`/`no`/`off` to restore full-suite-on-label |
+| `BENCHMARK_PR_MAX_FILES` | `100` | PRs changing more files than this are treated as broad → full suite |
+| `GH_TOKEN` | — | recommended; without it the PR-files lookup is unauthenticated (60/hr) and degrades to full suite |
+
 ## Directory layout
 
 ### Specifications 

--- a/groups.json
+++ b/groups.json
@@ -1,4 +1,8 @@
 {
+  "array": {
+    "description": "Operations on the Array data type",
+    "display": "Array"
+  },
   "bitmap": {
     "description": "Operations on the Bitmap data type",
     "display": "Bitmap"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,15 @@ version = "0.3.18"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"
+# Ship in-package data files. These are needed because the blanket `*.json` rule in
+# .gitignore makes them untracked -> invisible to Poetry's git-based file discovery,
+# so they must be force-tracked (see .gitignore negation) AND listed here to land in
+# the wheel. The dict `format=` form needs poetry-core >= 1.1; the build-system below
+# pins >= 1.5.0 for safety.
+include = [
+    { path = "redis_benchmarks_specification/__common__/files-to-groups.json", format = ["sdist", "wheel"] },
+    { path = "redis_benchmarks_specification/__common__/core-specs.json", format = ["sdist", "wheel"] },
+]
 
 [tool.poetry.dependencies]
 python = "^3.10.0"
@@ -54,7 +63,9 @@ docker = ">=7.1.0"
 docker = "^7.1.0"
 
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+# >=1.5.0: the dict-form `include` with `format=[...]` (used to ship in-package json
+# data files into the wheel) is only honored by poetry-core >= 1.1; pin higher for safety.
+requires = ["poetry_core>=1.5.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]

--- a/redis_benchmarks_specification/__api__/app.py
+++ b/redis_benchmarks_specification/__api__/app.py
@@ -13,18 +13,19 @@ from redis_benchmarks_specification.__common__.env import (
     BENCHMARK_TRIGGER_BRANCHES,
     BENCHMARK_TRIGGER_ORGS,
     PULL_REQUEST_TRIGGER_LABEL,
+    BENCHMARK_PR_DIFF_SCOPING,
+    BENCHMARK_PR_MAX_FILES,
+    GH_TOKEN,
 )
+from redis_benchmarks_specification.__common__.scope import compute_pr_scope_fields
 
 SIG_HEADER = "X-Hub-Signature"
 
 
 def should_action(action):
-    res = False
-    types = ["synchronize", "opened", "reopened", "labeled"]
-    for tt in types:
-        if action in tt:
-            res = True
-    return res
+    # Exact match — a substring test (`action in tt`) would let stray action strings
+    # that happen to be substrings of these spuriously trigger.
+    return action in ("synchronize", "opened", "reopened", "labeled")
 
 
 def create_app(conn, user, test_config=None):
@@ -91,6 +92,11 @@ def create_app(conn, user, test_config=None):
             use_event = False
             # Pull request labeled
             pull_request_number = None
+            # Base repo of the PR (where the PR number is valid) — used to fetch the
+            # changed files for diff-scoping. For a fork PR the head repo is the fork,
+            # whose API has no such PR number, so we must query the base repo.
+            pr_base_org = None
+            pr_base_repo = None
             trigger_label = PULL_REQUEST_TRIGGER_LABEL
             if "pull_request" in request_data:
                 action = request_data["action"]
@@ -99,6 +105,12 @@ def create_app(conn, user, test_config=None):
 
                     head_dict = pull_request_dict["head"]
                     repo_dict = head_dict["repo"]
+                    base_repo_dict = (pull_request_dict.get("base") or {}).get(
+                        "repo"
+                    ) or {}
+                    base_full_name = base_repo_dict.get("full_name")
+                    if base_full_name and "/" in base_full_name:
+                        pr_base_org, pr_base_repo = base_full_name.split("/")[-2:]
                     labels = []
                     if "labels" in pull_request_dict:
                         labels = pull_request_dict["labels"]
@@ -162,6 +174,26 @@ def create_app(conn, user, test_config=None):
                     event_type = f"Push event skipped: {'; '.join(skip_reasons)}"
 
             if use_event is True:
+                # Diff-driven scoping: for a labeled PR, derive the affected command
+                # group(s) from the changed files and scope the run; broad/infra/unmapped
+                # diffs fall back to a curated core set. Empty -> full suite (today's
+                # behavior). Gated by BENCHMARK_PR_DIFF_SCOPING so it can be disabled.
+                scope_fields = {}
+                if BENCHMARK_PR_DIFF_SCOPING and pull_request_number is not None:
+                    # Query the PR's BASE repo (fall back to head if base is absent),
+                    # since the PR number only exists there.
+                    scope_fields, scope_msg = compute_pr_scope_fields(
+                        GH_TOKEN,
+                        pr_base_org or gh_org,
+                        pr_base_repo or gh_repo,
+                        pull_request_number,
+                        BENCHMARK_PR_MAX_FILES,
+                    )
+                    app.logger.info(scope_msg)
+                # NOTE: scope_fields is only ever non-empty for labeled-PR events. The
+                # merge-base baseline below runs on PUSH events (where there is no PR),
+                # so it is intentionally NOT scoped — scoped PR-head runs are compared
+                # against the full-suite baseline of the corresponding subset.
                 if before_sha is not None:
                     fields_before = {
                         "git_hash": sha,
@@ -192,6 +224,7 @@ def create_app(conn, user, test_config=None):
                 }
                 if pull_request_number is not None:
                     fields_after["pull_request"] = pull_request_number
+                fields_after.update(scope_fields)
                 app.logger.info(
                     "Using event {} to trigger benchmark. final fields: {}".format(
                         event_type, fields_after

--- a/redis_benchmarks_specification/__common__/core-specs.json
+++ b/redis_benchmarks_specification/__common__/core-specs.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Curated 'core' benchmark set: one representative spec per command group, used as the webhook's fallback when a labeled PR touches a broad/infra/unmapped source file (so it runs a small cross-group smoke set instead of the full ~394 suite). The webhook emits these as an anchored tests_regexp. Each entry is a test-suite FILENAME STEM (no .yml) — it must exist in test-suites/ (a CI test enforces this) and collectively these must cover every group that has specs (another CI test enforces this). Tune freely; keep one per group. cluster/sentinel have no specs in this repo and are intentionally absent.",
+  "core_specs": [
+    "memtier_benchmark-1Mkeys-string-get-10B",
+    "memtier_benchmark-1Mkeys-hash-hmget-5-fields-with-100B-values-pipeline-10",
+    "memtier_benchmark-1key-list-10K-elements-lpos-string",
+    "memtier_benchmark-1key-set-10M-elements-srem-50pct-chance",
+    "memtier_benchmark-1key-zset-100-elements-zrangebyscore-all-elements",
+    "memtier_benchmark-1Mkeys-load-stream-1-fields-with-100B-values",
+    "memtier_benchmark-1key-geo-2-elements-geopos",
+    "memtier_benchmark-1key-100M-bits-bitmap-bitpos",
+    "memtier_benchmark-multiple-hll-pfcount-1key-10Mkeys-multitenant-tagged",
+    "memtier_benchmark-nokeys-pubsub-publish-1K-channels-10B-no-subscribers",
+    "memtier_benchmark-playbook-rate-limiting-lua-100k-sessions",
+    "memtier_benchmark-1Mkeys-string-watch-multi-exec-32B",
+    "memtier_benchmark-1Mkeys-generic-expire-pipeline-10",
+    "memtier_benchmark-connection-hello",
+    "memtier_benchmark-nokeys-server-time-pipeline-10",
+    "memtier_benchmark-playbook-session-caching-json-100k-sessions",
+    "memtier_benchmark-array-arget-1K-random"
+  ]
+}

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -119,3 +119,29 @@ MACHINE_NAME = os.uname()[1]
 # Webhook push filtering — comma-separated allowlists
 BENCHMARK_TRIGGER_BRANCHES = os.getenv("BENCHMARK_TRIGGER_BRANCHES", "unstable")
 BENCHMARK_TRIGGER_ORGS = os.getenv("BENCHMARK_TRIGGER_ORGS", "redis")
+
+# Webhook PR diff-driven scoping. When a PR is labeled with the trigger label, derive
+# which command groups its diff touches and scope the run instead of executing the full
+# suite. Set BENCHMARK_PR_DIFF_SCOPING to a falsey value (0/false/no/off) to restore
+# full-suite-on-label.
+BENCHMARK_PR_DIFF_SCOPING = os.getenv(
+    "BENCHMARK_PR_DIFF_SCOPING", "1"
+).strip().lower() in ("1", "true", "yes", "on")
+# PRs changing more than this many files are treated as inherently broad -> full suite
+# (also bounds the synchronous GitHub pagination done inside the webhook request).
+try:
+    BENCHMARK_PR_MAX_FILES = int(os.getenv("BENCHMARK_PR_MAX_FILES", "100"))
+    if BENCHMARK_PR_MAX_FILES <= 0:
+        raise ValueError("must be > 0")
+except ValueError:
+    logging.warning(
+        "invalid BENCHMARK_PR_MAX_FILES (must be a positive int); using 100"
+    )
+    BENCHMARK_PR_MAX_FILES = 100
+# Diff-scoping needs to read PR files from the GitHub API. Without a token it runs
+# unauthenticated (60 req/hr) and will usually rate-limit -> silent full-suite fallback.
+if BENCHMARK_PR_DIFF_SCOPING and not GH_TOKEN:
+    logging.warning(
+        "BENCHMARK_PR_DIFF_SCOPING is on but GH_TOKEN is unset; PR diff lookups will hit "
+        "the 60/hr unauthenticated GitHub limit and degrade to full-suite runs"
+    )

--- a/redis_benchmarks_specification/__common__/files-to-groups.json
+++ b/redis_benchmarks_specification/__common__/files-to-groups.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Maps a changed Redis source-file basename to the benchmark command group(s) it exercises. Used by the webhook (__api__/app.py) to scope an action:run-benchmark run from the PR diff instead of running the full suite. Group names MUST match groups.json (a CI test enforces this). Source files NOT listed here (server.c, networking.c, db.c, dict.c, kvstore.c, object.c, sds.c, ae.c, rdb.c, aof.c, replication.c, cluster*.c, *.h, brand-new files, ...) are treated as broad/infra: the run falls back to the curated core set in core-specs.json. This is the only file->group source of truth; commands.json is keyed by command, not file. Keyed by basename (Redis has no same-basename collisions across dirs for these).",
+  "exact": {
+    "t_string.c": ["string"],
+    "t_hash.c": ["hash"],
+    "t_zset.c": ["sorted-set"],
+    "t_list.c": ["list"],
+    "t_set.c": ["set"],
+    "t_stream.c": ["stream"],
+    "t_array.c": ["array"],
+    "geo.c": ["geo", "sorted-set"],
+    "hyperloglog.c": ["hyperloglog"],
+    "bitops.c": ["bitmap"],
+    "pubsub.c": ["pubsub"],
+    "multi.c": ["transactions"],
+    "eval.c": ["scripting"],
+    "script.c": ["scripting"],
+    "functions.c": ["scripting"]
+  }
+}

--- a/redis_benchmarks_specification/__common__/scope.py
+++ b/redis_benchmarks_specification/__common__/scope.py
@@ -1,0 +1,194 @@
+"""
+Diff-driven benchmark scoping for the webhook trigger.
+
+When a pull request is labeled with the trigger label (action:run-benchmark), the
+webhook (``__api__/app.py``) uses this module to look at the PR's changed files and
+decide which subset of the benchmark suite to run — instead of always running the
+full suite. The decision is purely deterministic (no AI):
+
+  * changed source files that map cleanly to a data-type group (t_hash.c -> hash,
+    t_zset.c -> sorted-set, ...) -> run only those groups (``tests_groups_regexp``);
+  * any broad/infra or unmapped source file (server.c, networking.c, db.c, dict.c,
+    *.h, a brand new file, ...), or a PR with no source changes -> run the curated
+    cross-group "core" set from core-specs.json (``tests_regexp``) — small, but with
+    one representative per group so a cross-cutting regression still surfaces;
+  * a very large PR, an unavailable/failed GitHub fetch, or any internal error ->
+    no filter -> full suite (today's behavior). Scoping must never break the trigger.
+
+The emitted regexes are ANCHORED (``^(?:...)$``) because the coordinator matches them
+with ``re.search`` against each group name / the test-name stem — unanchored, "set"
+would also select "sorted-set". The resulting fields are merged into the commit-stream
+event, where the builder and coordinator already honor ``tests_groups_regexp`` and
+``tests_regexp`` (verified end-to-end). No downstream change is required.
+
+Gated by ``BENCHMARK_PR_DIFF_SCOPING`` (env, default on); restore full-suite-on-label
+by setting it to 0 — no code change.
+"""
+
+import json
+import logging
+import os
+import re
+
+_COMMON_DIR = os.path.dirname(__file__)
+_FILES_TO_GROUPS_PATH = os.path.join(_COMMON_DIR, "files-to-groups.json")
+_CORE_SPECS_PATH = os.path.join(_COMMON_DIR, "core-specs.json")
+
+
+def load_files_to_groups(path=None):
+    """Load the file-basename -> [group, ...] map. Values are normalized to lists."""
+    path = path or _FILES_TO_GROUPS_PATH
+    with open(path) as fh:
+        data = json.load(fh)
+    exact = data.get("exact", data)
+    return {
+        base: (groups if isinstance(groups, list) else [groups])
+        for base, groups in exact.items()
+        if not base.startswith("_")
+    }
+
+
+def load_core_specs(path=None):
+    """Load the curated core-set test-name stems (one representative per group)."""
+    path = path or _CORE_SPECS_PATH
+    with open(path) as fh:
+        data = json.load(fh)
+    return list(data.get("core_specs", data) if isinstance(data, dict) else data)
+
+
+# Loaded once at import, guarded: a missing/corrupt data file degrades to "no scope
+# data" -> full suite everywhere, instead of raising on the webhook hot path.
+try:
+    _FILES_TO_GROUPS = load_files_to_groups()
+    _CORE_SPECS = load_core_specs()
+except Exception as exc:  # noqa: BLE001 — never break import of the webhook
+    logging.error("diff-scoping: failed to load scope data, scoping disabled: %s", exc)
+    _FILES_TO_GROUPS, _CORE_SPECS = {}, []
+
+
+def _anchored_alt(items):
+    """Build an anchored alternation regex from literal strings: ^(?:a|b|c)$."""
+    return "^(?:%s)$" % "|".join(re.escape(s) for s in items)
+
+
+def scope_fields_from_changed_files(
+    changed_files, files_to_groups=None, core_specs=None
+):
+    """
+    Convert a PR's changed file paths into benchmark stream filter fields.
+
+    Returns one of:
+      * ``{"tests_groups_regexp": "^(?:hash|sorted-set)$"}`` — every changed *source*
+        file maps to a known data-type group;
+      * ``{"tests_regexp": "^(?:<core spec>|...)$"}`` — a broad/infra/unmapped source
+        file, or no source changes (the curated cross-group core set);
+      * ``{}`` — the PR changed nothing, OR the core list is empty / nothing mapped
+        with no core list available (caller -> full suite).
+
+    Only ``src/*.c`` / ``src/*.h`` files influence the decision; docs, tests and CI
+    changes are ignored so a hash-only PR that also edits a .tcl test still scopes to
+    ``hash``.
+    """
+    if files_to_groups is None:
+        files_to_groups = _FILES_TO_GROUPS
+    if core_specs is None:
+        core_specs = _CORE_SPECS
+    if not changed_files:
+        return {}
+    src_files = [
+        f
+        for f in changed_files
+        if f.startswith("src/") and (f.endswith(".c") or f.endswith(".h"))
+    ]
+    groups = []
+    all_mapped = True
+    for f in src_files:
+        base = f.rsplit("/", 1)[-1]
+        mapped = files_to_groups.get(base)
+        if mapped:
+            for g in mapped:
+                if g not in groups:
+                    groups.append(g)
+        else:
+            all_mapped = False
+    if src_files and all_mapped and groups:
+        return {"tests_groups_regexp": _anchored_alt(groups)}
+    # broad / infra / unmapped source file, or no source files -> curated core set.
+    # If the core list is unavailable, fall through to the full suite (safe default).
+    if not core_specs:
+        return {}
+    return {"tests_regexp": _anchored_alt(core_specs)}
+
+
+def get_pr_changed_files(github_token, gh_org, gh_repo, pr_number, max_files=100):
+    """
+    Return the list of file paths changed in a PR, or ``None`` if scoping should
+    fall back to the full suite — i.e. on any error (auth/network/API) OR when the PR
+    is too large to scope meaningfully (> ``max_files``; such a PR is inherently broad
+    and the per-file pagination would add many synchronous round-trips on the webhook
+    hot path). ``None`` is the safe sentinel: the caller runs the full suite.
+    """
+    try:
+        from github import Github
+
+        # This runs inside the webhook request, which GitHub gives ~10s before it marks
+        # delivery failed and retries (-> duplicate triggers). Bound the total work:
+        #   - short per-request timeout,
+        #   - per_page=100 so a <=max_files PR is a single get_files page,
+        #   - lazy=True so get_repo costs no round-trip (get_pull is the first call).
+        # Worst case is then 2 sequential API calls.
+        gh = (
+            Github(github_token, timeout=4, per_page=100)
+            if github_token
+            else Github(timeout=4, per_page=100)
+        )
+        pull = gh.get_repo("{}/{}".format(gh_org, gh_repo), lazy=True).get_pull(
+            int(pr_number)
+        )
+        changed = pull.changed_files or 0
+        if changed > max_files:
+            logging.info(
+                "diff-scoping: PR %s/%s#%s changed %d files (> %d) -> full suite",
+                gh_org,
+                gh_repo,
+                pr_number,
+                changed,
+                max_files,
+            )
+            return None
+        return [f.filename for f in pull.get_files()]
+    except Exception as exc:  # noqa: BLE001 — never let scoping break the trigger
+        logging.warning(
+            "diff-scoping: could not fetch changed files for %s/%s#%s (%s: %s) -> full suite",
+            gh_org,
+            gh_repo,
+            pr_number,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def compute_pr_scope_fields(github_token, gh_org, gh_repo, pr_number, max_files=100):
+    """
+    High-level entry point used by the webhook. Returns ``(fields, message)`` where
+    ``fields`` is the dict to merge into the commit-stream event ({} = full suite)
+    and ``message`` is a human-readable one-liner for the logs.
+
+    Fully guarded: any failure (including missing scope-data files) returns ({}, ...)
+    so the webhook always falls back to the full suite and never 500s.
+    """
+    try:
+        files = get_pr_changed_files(
+            github_token, gh_org, gh_repo, pr_number, max_files
+        )
+        if files is None:
+            return {}, "diff-scoping: full suite (diff unavailable or PR too large)"
+        fields = scope_fields_from_changed_files(files)
+        return fields, "diff-scoping: %d changed files -> %s" % (
+            len(files),
+            fields if fields else "full suite",
+        )
+    except Exception as exc:  # noqa: BLE001 — entry-point safety net
+        logging.warning("diff-scoping: unexpected error -> full suite: %s", exc)
+        return {}, "diff-scoping: full suite (internal error)"

--- a/utils/tests/test_app.py
+++ b/utils/tests/test_app.py
@@ -6,9 +6,11 @@
 import json
 from hashlib import sha1
 from hmac import HMAC
+from unittest.mock import patch, MagicMock
 
 import redis
 
+import redis_benchmarks_specification.__api__.app as app_module
 from redis_benchmarks_specification.__api__.app import (
     create_app,
     SIG_HEADER,
@@ -74,7 +76,11 @@ def test_create_app():
                 key=auth_token.encode(), msg=req_data, digestmod=sha1
             ).hexdigest()
 
-            with flask_app.test_client() as test_client:
+            # Stub diff-scoping so this test does not depend on a live GitHub PR-files
+            # lookup (the scope-merge itself is covered by the dedicated tests below).
+            with flask_app.test_client() as test_client, patch.object(
+                app_module, "compute_pr_scope_fields", return_value=({}, "noop")
+            ):
                 response = test_client.post(
                     "/api/gh/redis/redis/commits",
                     content_type="application/json",
@@ -163,3 +169,71 @@ def test_should_action():
     assert should_action("na") == False
     assert should_action("reopened") == True
     assert should_action("synchronize") == True
+    # exact match: a substring of a real action must NOT trigger
+    assert should_action("label") == False
+    assert should_action("open") == False
+    assert should_action("unlabeled") == False
+
+
+def _post_labelled_pr(flask_app, auth_token):
+    with open("./utils/tests/test_data/event_webhook_labelled_pr.json") as fh:
+        req_data = json.dumps(json.load(fh)).encode()
+    sign = HMAC(key=auth_token.encode(), msg=req_data, digestmod=sha1).hexdigest()
+    with flask_app.test_client() as client:
+        return client.post(
+            "/api/gh/redis/redis/commits",
+            content_type="application/json",
+            data=req_data,
+            headers={
+                "Content-type": "application/json",
+                SIG_HEADER: "sha1={}".format(sign),
+            },
+        )
+
+
+# These app-level tests run with NO redis and NO network: a MagicMock conn satisfies
+# the auth lookup, and commit_schema_to_stream is stubbed to echo the event fields it
+# is handed — so they deterministically prove the app.py scope-field merge in any CI
+# lane (no silent skip when redis is absent).
+def _mock_app(auth_token="diff-scope-test-token"):
+    conn = MagicMock()
+    conn.get.return_value = auth_token  # default:auth_token lookup in verify_signature
+    return create_app(conn, "default"), auth_token
+
+
+def _echo_commit_schema(fields, *args, **kwargs):
+    # mirror commit_schema_to_stream's contract: (result, reply_fields, err)
+    return True, dict(fields), None
+
+
+def test_pr_event_merges_scope_fields_into_stream_event():
+    # a labeled PR whose diff scopes to a group must carry that filter into the event
+    flask_app, auth_token = _mock_app()
+    with patch.object(
+        app_module,
+        "compute_pr_scope_fields",
+        return_value=({"tests_groups_regexp": "^(?:hash)$"}, "stub"),
+    ), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=_echo_commit_schema
+    ):
+        resp = _post_labelled_pr(flask_app, auth_token)
+    assert resp.status_code == 200
+    assert resp.json.get("tests_groups_regexp") == "^(?:hash)$"
+
+
+def test_pr_event_disabled_gate_skips_scoping():
+    # with scoping disabled, the GitHub helper must not be called and no filter is added
+    flask_app, auth_token = _mock_app()
+
+    def _boom(*a, **k):
+        raise AssertionError("compute_pr_scope_fields called while disabled")
+
+    with patch.object(app_module, "BENCHMARK_PR_DIFF_SCOPING", False), patch.object(
+        app_module, "compute_pr_scope_fields", _boom
+    ), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=_echo_commit_schema
+    ):
+        resp = _post_labelled_pr(flask_app, auth_token)
+    assert resp.status_code == 200
+    assert "tests_groups_regexp" not in resp.json
+    assert "tests_regexp" not in resp.json

--- a/utils/tests/test_scope.py
+++ b/utils/tests/test_scope.py
@@ -1,0 +1,227 @@
+import glob
+import json
+import os
+
+import yaml
+
+from redis_benchmarks_specification.__common__ import scope as scope_mod
+from redis_benchmarks_specification.__common__.scope import (
+    load_files_to_groups,
+    load_core_specs,
+    scope_fields_from_changed_files,
+    get_pr_changed_files,
+    compute_pr_scope_fields,
+)
+
+F2G = load_files_to_groups()
+CORE = load_core_specs()
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(scope_mod.__file__), "..", "..")
+)
+_SUITES = os.path.join(_REPO_ROOT, "redis_benchmarks_specification", "test-suites")
+
+
+def _spec_stems_and_groups():
+    out = []
+    for f in glob.glob(os.path.join(_SUITES, "*.yml")):
+        try:
+            d = yaml.safe_load(open(f))
+        except Exception:
+            continue
+        if isinstance(d, dict):
+            out.append(
+                (os.path.basename(f)[: -len(".yml")], d.get("tested-groups") or [])
+            )
+    return out
+
+
+# ----------------------------- mapping logic -------------------------------------------
+
+
+def test_single_type_file_scopes_to_one_anchored_group():
+    assert scope_fields_from_changed_files(["src/t_hash.c"], F2G, CORE) == {
+        "tests_groups_regexp": "^(?:hash)$"
+    }
+
+
+def test_multiple_type_files_union_anchored():
+    f = scope_fields_from_changed_files(["src/t_hash.c", "src/t_zset.c"], F2G, CORE)
+    assert f == {"tests_groups_regexp": "^(?:hash|sorted\\-set)$"}
+
+
+def test_anchoring_prevents_set_matching_sorted_set():
+    # the whole reason for anchoring: a 'set' scope must NOT select 'sorted-set'
+    import re
+
+    rx = re.compile(
+        scope_fields_from_changed_files(["src/t_set.c"], F2G, CORE)[
+            "tests_groups_regexp"
+        ]
+    )
+    assert re.search(rx, "set")
+    assert not re.search(rx, "sorted-set")
+    assert not re.search(rx, "hset")
+
+
+def test_geo_maps_to_geo_and_sorted_set():
+    # geo.c calls into the zset machinery, so it must widen to sorted-set too
+    f = scope_fields_from_changed_files(["src/geo.c"], F2G, CORE)
+    assert f == {"tests_groups_regexp": "^(?:geo|sorted\\-set)$"}
+
+
+def test_array_file_is_mapped():
+    assert scope_fields_from_changed_files(["src/t_array.c"], F2G, CORE) == {
+        "tests_groups_regexp": "^(?:array)$"
+    }
+
+
+def test_non_source_changes_ignored():
+    f = scope_fields_from_changed_files(
+        ["src/t_hash.c", "tests/unit/type/hash.tcl", ".github/workflows/ci.yml"],
+        F2G,
+        CORE,
+    )
+    assert f == {"tests_groups_regexp": "^(?:hash)$"}
+
+
+def test_broad_file_falls_back_to_core_set():
+    f = scope_fields_from_changed_files(["src/networking.c"], F2G, CORE)
+    assert "tests_regexp" in f and f["tests_regexp"].startswith("^(?:")
+    # core set, not a group filter
+    assert "tests_groups_regexp" not in f
+
+
+def test_mixed_type_and_broad_widens_to_core_set():
+    f = scope_fields_from_changed_files(["src/t_hash.c", "src/server.c"], F2G, CORE)
+    assert "tests_regexp" in f and "tests_groups_regexp" not in f
+
+
+def test_unmapped_source_file_falls_back_to_core_set():
+    f = scope_fields_from_changed_files(["src/quicklist.c"], F2G, CORE)
+    assert "tests_regexp" in f
+
+
+def test_header_change_is_broad():
+    f = scope_fields_from_changed_files(["src/server.h"], F2G, CORE)
+    assert "tests_regexp" in f
+
+
+def test_docs_only_pr_gets_core_set():
+    assert "tests_regexp" in scope_fields_from_changed_files(["README.md"], F2G, CORE)
+
+
+def test_empty_diff_returns_full_suite():
+    assert scope_fields_from_changed_files([], F2G, CORE) == {}
+
+
+def test_empty_core_list_degrades_to_full_suite():
+    # if the core list is unavailable, a broad diff must run the full suite, never an
+    # empty tests_regexp that would silently run zero benchmarks
+    assert scope_fields_from_changed_files(["src/server.c"], F2G, []) == {}
+
+
+def test_empty_map_degrades_to_full_or_core_never_zero():
+    # nothing mapped + a core list -> core set (not an empty groups regex)
+    f = scope_fields_from_changed_files(["src/t_hash.c"], {}, CORE)
+    assert "tests_regexp" in f
+
+
+# ----------------------------- drift / corpus guards -----------------------------------
+
+
+def test_every_mapped_group_exists_in_groups_json():
+    valid = set(json.load(open(os.path.join(_REPO_ROOT, "groups.json"))))
+    for base, groups in F2G.items():
+        for g in groups:
+            assert g in valid, "%s -> unknown group %r (not in groups.json)" % (base, g)
+
+
+def test_every_mapped_group_matches_at_least_one_spec():
+    spec_groups = set(g for _, gs in _spec_stems_and_groups() for g in gs)
+    for base, groups in F2G.items():
+        for g in groups:
+            assert g in spec_groups, "%s -> group %r matches zero specs" % (base, g)
+
+
+def test_every_core_spec_exists_in_the_suite():
+    stems = {s for s, _ in _spec_stems_and_groups()}
+    for name in CORE:
+        assert name in stems, "core spec %r not found in test-suites/" % name
+
+
+def test_core_specs_cover_every_group_that_has_specs():
+    by_stem = dict(_spec_stems_and_groups())
+    covered = set(g for name in CORE for g in by_stem.get(name, []))
+    all_spec_groups = set(g for _, gs in _spec_stems_and_groups() for g in gs)
+    missing = all_spec_groups - covered
+    assert not missing, "core set does not cover groups: %s" % sorted(missing)
+
+
+# ----------------------------- fetch / safety paths ------------------------------------
+
+
+def test_get_pr_changed_files_returns_none_on_error(monkeypatch):
+    class Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("api down")
+
+    monkeypatch.setattr("github.Github", Boom, raising=False)
+    assert get_pr_changed_files("tok", "redis", "redis", 1) is None
+
+
+def test_large_pr_falls_back_to_full_suite(monkeypatch):
+    calls = {"get_files": 0}
+
+    class FakePull:
+        changed_files = 500
+
+        def get_files(self):  # must not be called for an over-cap PR
+            calls["get_files"] += 1
+            return []
+
+    class FakeRepo:
+        def get_pull(self, n):
+            return FakePull()
+
+    class FakeGH:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, slug, lazy=False):  # production passes lazy=True
+            return FakeRepo()
+
+    monkeypatch.setattr("github.Github", FakeGH, raising=False)
+    assert get_pr_changed_files("tok", "redis", "redis", 1, max_files=100) is None
+    # load-bearing: prove we returned via the cap, not via a swallowed error
+    assert calls["get_files"] == 0
+
+
+def test_compute_full_suite_when_files_unavailable(monkeypatch):
+    monkeypatch.setattr(scope_mod, "get_pr_changed_files", lambda *a, **k: None)
+    fields, msg = compute_pr_scope_fields("tok", "redis", "redis", 123)
+    assert fields == {}
+    assert "full suite" in msg
+
+
+def test_compute_scopes_from_diff(monkeypatch):
+    monkeypatch.setattr(
+        scope_mod, "get_pr_changed_files", lambda *a, **k: ["src/t_zset.c"]
+    )
+    fields, _ = compute_pr_scope_fields("tok", "redis", "redis", 123)
+    assert fields == {"tests_groups_regexp": "^(?:sorted\\-set)$"}
+
+
+def test_compute_never_raises_on_internal_error(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(scope_mod, "get_pr_changed_files", boom)
+    fields, msg = compute_pr_scope_fields("tok", "redis", "redis", 123)
+    assert fields == {} and "full suite" in msg
+
+
+def test_load_normalizes_scalar_group_value(tmp_path):
+    p = tmp_path / "f2g.json"
+    p.write_text('{"exact": {"t_foo.c": "string"}}')
+    assert load_files_to_groups(str(p)) == {"t_foo.c": ["string"]}


### PR DESCRIPTION
## Problem

When a PR is labeled with the trigger label (`action:run-benchmark`), the webhook runs the **entire** suite (~394 specs x topologies). The API sends no test filters, so the builder defaults `tests_regexp` / `tests_groups_regexp` / `command_regexp` to `.*` and everything runs — even for a one-file change.

## What this does

The webhook now derives the affected command group(s) from the PR's **diff** and scopes the run. No new labels — a deterministic file->group lookup:

- **data-type files** (`t_hash.c` -> `hash`, `t_zset.c` -> `sorted-set`, `t_array.c` -> `array`, `geo.c` -> `geo`+`sorted-set`, ...) run only those groups via `tests_groups_regexp`. The map is `redis_benchmarks_specification/__common__/files-to-groups.json`.
- **broad/infra/unmapped** files (`server.c`, `networking.c`, `db.c`, `*.h`, a brand-new file), or a PR with no source changes, run a curated cross-group **core set** — one representative spec per group, in `redis_benchmarks_specification/__common__/core-specs.json` — so a cross-cutting regression still surfaces.
- **large PRs** (`> BENCHMARK_PR_MAX_FILES`), an unavailable GitHub lookup, or a push event run the **full** suite, exactly as today.

Emitted regexes are anchored (`^(?:...)$`) so `set` does not also select `sorted-set`. The active filter already appears in the build-started PR comment, so a scoped run is visible on the PR.

## Why it is low-risk

- The builder and coordinator already honor `tests_groups_regexp` and `tests_regexp` from the commit stream — **no downstream change**.
- Scoping **never breaks the trigger**: every failure path (missing data file, GitHub error, large PR, scoping disabled, push event) falls back to the full suite. Data files load once at import behind a guard; the GitHub lookup is bounded (lazy repo + `per_page=100` + short timeout) and fully wrapped.
- Fork PRs are handled by querying the PR's **base** repo (where the PR number is valid).

## Configuration

| env var | default | meaning |
|---|---|---|
| `BENCHMARK_PR_DIFF_SCOPING` | `1` (on) | set to `0`/`false`/`no`/`off` to restore full-suite-on-label |
| `BENCHMARK_PR_MAX_FILES` | `100` | PRs changing more files than this run the full suite |
| `GH_TOKEN` | — | recommended; without it the PR-files lookup is unauthenticated (60/hr) and degrades to full suite |

## Tests

`utils/tests/test_scope.py` (logic, drift guards that fail loudly if the file->group map or core set drifts from `groups.json` / the suite, and the safety/fallback paths) and `utils/tests/test_app.py` (the webhook scope-field merge + disabled gate, redis- and network-free). Docs added to the README.

> Note: takes effect once the webhook service is redeployed with this build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds synchronous GitHub API work on the webhook hot path and changes default benchmark coverage for labeled PRs, though all failure paths fall back to the full suite.
> 
> **Overview**
> Labeled PR benchmark triggers (`action:run-benchmark`) now **scope the suite from the PR diff** instead of always running the full suite. The webhook calls new **`scope`** logic: mapped `src/*.c` files (via **`files-to-groups.json`**) emit **`tests_groups_regexp`**; broad/unmapped/infra changes or non-source-only diffs use a curated **`tests_regexp`** from **`core-specs.json`**; large PRs, GitHub failures, or empty scope still mean **full suite**.
> 
> **`app.py`** merges those fields into the commit-stream event, resolves the PR’s **base repo** for file lists (fork-safe), gates on **`BENCHMARK_PR_DIFF_SCOPING`**, and fixes **`should_action`** to exact-match webhook actions. **`env.py`** adds **`BENCHMARK_PR_MAX_FILES`** and **`GH_TOKEN`** warnings. Packaging tracks the JSON maps in **`.gitignore`** / **`pyproject.toml`** so they ship in the wheel; **`groups.json`** gains **array**. README documents behavior and env vars. **`test_scope.py`** and **`test_app.py`** cover mapping, drift guards, fallbacks, and webhook merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210cbbc5ca9b53409ec2fb0e154568c7f1966aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->