### PR TITLE
test-suites: add online feature-store HGETALL serving playbook (10M entities, 50 features)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.18"
+version = "0.3.19"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
@@ -1,0 +1,153 @@
+version: 0.4
+name: memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features
+description: |
+  Runs memtier_benchmark to simulate ONE specific online machine-learning feature-store layout on
+  Redis: ENTITY-MAJOR storage where each entity is a single hash holding all of that entity's feature
+  values, and single-entity online serving fetches the whole entity in one round-trip with HGETALL.
+  This is one of several feature-store serving layouts (see "Not modeled" below) — it is the one this
+  spec measures, not a claim that it is the only or dominant pattern.
+
+    - Each entity is ONE Redis hash, keyed `<prefix><entity-id>`, whose FIELDS are the feature
+      columns and whose VALUES are the serialized feature values, plus an `event_ts` metadata
+      timestamp field.
+    - Materialization writes the whole row at once: `HSET <key> f1 v1 ... fN vN event_ts <ts>`.
+    - Single-entity online serving reads the whole entity in ONE round-trip: `HGETALL <key>`.
+
+  Data shape:
+    - 10,000,000 entity hashes, key `feature_store:user_features:entity:<id>`.
+    - Each hash holds 50 feature fields (`feature_1`..`feature_50`) + `event_ts` = 51 fields.
+    - Values are realistic short scalar sizes (8..24 bytes) — the stringified scalars a feature store
+      serves (float scores, integer counts, booleans, RFC3339 timestamps, short categoricals).
+      Content is randomized at the right size — for HGETALL/HSET cost the value SIZE is what matters,
+      not the exact bytes — so the per-op serving cost is equivalent to typed scalars (numeric scalars
+      would listpack integer-encode slightly smaller).
+
+  Encoding: listpack (DEFAULT config, NOT overridden). 51 fields < hash-max-listpack-entries (128)
+  and every field/value <= hash-max-listpack-value (64B), so each entity hash is a listpack. HGETALL
+  walks a compact ~1.7KB listpack body (a cache-friendly contiguous read); at 10M keys the keyspace
+  dict lookup for a cold id is partly DRAM-bound, though the Zipf hot set keeps popular dict entries
+  warm. (An entity with >128 features would tip to hashtable; not modeled.)
+
+  Expected footprint: ~17 GB resident at 10M entities x 51 listpack fields (measured ~1.7 KB/entity:
+  feature-name strings are repeated per hash and account for a large share — Redis does not dedup
+  field names across hashes). At this scale the keyspace dict is well beyond cache, so the spec
+  exercises large-keyspace serving the existing small-keyspace HGETALL coverage cannot reach.
+
+  Metric of interest: PRIMARY = throughput (Hgetalls/Totals Ops/sec) of HGETALL at fixed concurrency
+  (200 total connections, t=4 x c=50, pipeline 1) against a large keyspace of small listpack hashes. SECONDARY = serving
+  latency p50/p99 — reported as CLOSED-LOOP under-load latency: representative of a concurrent serving
+  layer, but the deep tail is under-reported by coordinated omission at this concurrency, so do NOT
+  treat p99 here as an SLO-grade tail (for that, run a low-concurrency `--rate-limiting` open-loop
+  variant). Access is Zipfian over entities (`--command-key-pattern=Z`): popular / recently-active
+  entities are served far more often, exposing hot-key locality (the served working set is therefore
+  much smaller than 10M — this measures hot / cache-warm serving, not cold-keyspace random access).
+
+  Command mix (read-dominated online serving, ~95:5):
+    - Whole-entity serving read (`HGETALL`): ratio 19
+    - Whole-row feature materialization write (`HSET` all 51 fields): ratio 1
+
+  Not modeled (intentional scope limits, NOT claims about all feature stores):
+    - HMGET-subset serving: layouts that fetch only a named subset of features per inference (a single
+      `HMGET key f1..fK` of K of the 50 fields) — a common alternative serving pattern — are out of
+      scope; this spec measures whole-entity HGETALL only.
+    - Per-feature-view freshness / TTL: the single `event_ts` stands in for what may be several
+      per-view timestamps, and no key TTL / active-expiry pressure is exercised (`save ""`, no expiry).
+    - Pipelined batch scoring (many entities per round-trip), cluster topology, and cold-start MISS
+      traffic (the keyspace is fully preloaded, so Misses/sec ~ 0) are not modeled.
+
+exporter:
+  redistimeseries:
+    break_by:
+    - version
+    - commit
+    timemetric: $."ALL STATS".Runtime."Start time"
+    metrics:
+    - $."BEST RUN RESULTS".Hgetalls."Ops/sec"
+    - $."BEST RUN RESULTS".Hsets."Ops/sec"
+    - $."BEST RUN RESULTS".Totals."Ops/sec"
+    - $."BEST RUN RESULTS".Totals."Latency"
+    - $."BEST RUN RESULTS".Totals."Misses/sec"
+    - $."BEST RUN RESULTS".Totals."Percentile Latencies"."p50.00"
+    - $."BEST RUN RESULTS".Totals."Percentile Latencies"."p99.00"
+    - $."ALL STATS".Hgetalls."Ops/sec"
+    - $."ALL STATS".Hsets."Ops/sec"
+    - $."ALL STATS".Hgetalls."Percentile Latencies"."p50.00"
+    - $."ALL STATS".Hgetalls."Percentile Latencies"."p99.00"
+    - $."ALL STATS".Hsets."Percentile Latencies"."p50.00"
+    - $."ALL STATS".Hsets."Percentile Latencies"."p99.00"
+    - $."ALL STATS".Totals."Ops/sec"
+    - $."ALL STATS".Totals."Latency"
+    - $."ALL STATS".Totals."Misses/sec"
+    - $."ALL STATS".Totals."Percentile Latencies"."p50.00"
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.00"
+
+dbconfig:
+  dataset_name: 10Mkeys-feature-store-hash-50-features-entity-major
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 10000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: >
+      --data-size-range=8-24
+      --random-data
+      --key-prefix "feature_store:user_features:entity:"
+      --command='HSET __key__ feature_1 __data__ feature_2 __data__ feature_3 __data__ feature_4 __data__ feature_5 __data__ feature_6 __data__ feature_7 __data__ feature_8 __data__ feature_9 __data__ feature_10 __data__ feature_11 __data__ feature_12 __data__ feature_13 __data__ feature_14 __data__ feature_15 __data__ feature_16 __data__ feature_17 __data__ feature_18 __data__ feature_19 __data__ feature_20 __data__ feature_21 __data__ feature_22 __data__ feature_23 __data__ feature_24 __data__ feature_25 __data__ feature_26 __data__ feature_27 __data__ feature_28 __data__ feature_29 __data__ feature_30 __data__ feature_31 __data__ feature_32 __data__ feature_33 __data__ feature_34 __data__ feature_35 __data__ feature_36 __data__ feature_37 __data__ feature_38 __data__ feature_39 __data__ feature_40 __data__ feature_41 __data__ feature_42 __data__ feature_43 __data__ feature_44 __data__ feature_45 __data__ feature_46 __data__ feature_47 __data__ feature_48 __data__ feature_49 __data__ feature_50 __data__ event_ts __data__'
+      --command-key-pattern=P
+      --key-minimum=1
+      --key-maximum=10000000
+      -n 50000
+      -c 50
+      -t 4
+      --pipeline 50
+      --hide-histogram
+  resources:
+    requests:
+      memory: 32g
+  dataset_description: 10 million entity hashes (one hash per entity, entity-major), each with 50
+    feature fields + an event_ts timestamp field (51 fields), values 8-24 bytes, listpack-encoded.
+
+tested-groups:
+- hash
+tested-commands:
+- hgetall
+- hset
+
+redis-topologies:
+- oss-standalone
+
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size-range=8-24
+    --random-data
+    --key-prefix "feature_store:user_features:entity:"
+    --distinct-client-seed
+    --pipeline=1
+    --print-percentiles=50,99
+    --test-time=120
+    -c 50
+    -t 4
+    --key-minimum=1
+    --key-maximum=10000000
+    --command='HGETALL __key__'
+    --command-key-pattern=Z
+    --command-ratio=19
+    --command='HSET __key__ feature_1 __data__ feature_2 __data__ feature_3 __data__ feature_4 __data__ feature_5 __data__ feature_6 __data__ feature_7 __data__ feature_8 __data__ feature_9 __data__ feature_10 __data__ feature_11 __data__ feature_12 __data__ feature_13 __data__ feature_14 __data__ feature_15 __data__ feature_16 __data__ feature_17 __data__ feature_18 __data__ feature_19 __data__ feature_20 __data__ feature_21 __data__ feature_22 __data__ feature_23 __data__ feature_24 __data__ feature_25 __data__ feature_26 __data__ feature_27 __data__ feature_28 __data__ feature_29 __data__ feature_30 __data__ feature_31 __data__ feature_32 __data__ feature_33 __data__ feature_34 __data__ feature_35 __data__ feature_36 __data__ feature_37 __data__ feature_38 __data__ feature_39 __data__ feature_40 __data__ feature_41 __data__ feature_42 __data__ feature_43 __data__ feature_44 __data__ feature_45 __data__ feature_46 __data__ feature_47 __data__ feature_48 __data__ feature_49 __data__ feature_50 __data__ event_ts __data__'
+    --command-key-pattern=Z
+    --command-ratio=1
+    --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+
+priority: 38

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
@@ -33,15 +33,6 @@ description: |
   field names across hashes). At this scale the keyspace dict is well beyond cache, so the spec
   exercises large-keyspace serving the existing small-keyspace HGETALL coverage cannot reach.
 
-  Metric of interest: PRIMARY = throughput (Hgetalls/Totals Ops/sec) of HGETALL at fixed concurrency
-  (200 total connections, t=4 x c=50, pipeline 1) against a large keyspace of small listpack hashes. SECONDARY = serving
-  latency p50/p99 — reported as CLOSED-LOOP under-load latency: representative of a concurrent serving
-  layer, but the deep tail is under-reported by coordinated omission at this concurrency, so do NOT
-  treat p99 here as an SLO-grade tail (for that, run a low-concurrency `--rate-limiting` open-loop
-  variant). Access is Zipfian over entities (`--command-key-pattern=Z`): popular / recently-active
-  entities are served far more often, exposing hot-key locality (the served working set is therefore
-  much smaller than 10M — this measures hot / cache-warm serving, not cold-keyspace random access).
-
   Command mix (read-dominated online serving, ~95:5):
     - Whole-entity serving read (`HGETALL`): ratio 19
     - Whole-row feature materialization write (`HSET` all 51 fields): ratio 1
@@ -99,8 +90,8 @@ dbconfig:
       --key-minimum=1
       --key-maximum=10000000
       -n allkeys
-      -c 50
-      -t 4
+      -c 1
+      -t 1
       --pipeline 50
       --hide-histogram
   resources:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
@@ -98,7 +98,7 @@ dbconfig:
       --command-key-pattern=P
       --key-minimum=1
       --key-maximum=10000000
-      -n 50000
+      -n allkeys
       -c 50
       -t 4
       --pipeline 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features.yml
@@ -7,12 +7,18 @@ description: |
   5%. Each entity is one hash written whole-row with a single 51-field HSET (50 feature fields +
   event_ts), pipelined — modeling a batch materialization job that rewrites a full row at once.
 
-  This is a one-time bulk load: with -n allkeys over a P (parallel, collision-free) key pattern, each
-  of the 10,000,000 entity keys is written EXACTLY ONCE, so the whole run measures the fresh-insert
-  HSET path — bulk-argument parsing (~104 args/command) and building a 51-entry listpack per key plus
-  the keyspace-dict insert/rehash as the dictionary grows from 0 to 10M. Because every key is written
-  once (no wrap, no overwrite), the measured code path does not change as the server under test gets
-  faster, keeping it sound for A/B comparison.
+  This is a one-time bulk load with a fixed, count-bounded amount of work (no --test-time): each of
+  the 100 connections (-c 10 -t 10) issues exactly -n 100000 HSETs, so the run does 100 x 100000 =
+  10,000,000 HSETs total. With the P (parallel) key pattern over the [1, 10000000] range, the 100
+  connections partition the keyspace into disjoint, collision-free sub-ranges, so those 10M HSETs
+  write each of the 10M entity keys EXACTLY ONCE (n_per_conn = key-range / (c x t) = 10000000 / 100 =
+  100000 — this coupling is load-bearing; changing -c/-t or the key range requires re-deriving -n).
+  The whole run therefore measures the fresh-insert HSET path — bulk-argument parsing (~104
+  args/command), building a 51-entry listpack per key, and the keyspace dict growing toward 10M
+  entries. Because the work is count-bounded (not time-bounded) and every key is written once (no
+  wrap, no overwrite), the measured code path does not change as the server under test gets faster,
+  keeping it sound for A/B comparison. (Reported Ops/sec is the mean across the 0->10M dict-growth
+  ramp; use the BEST<->WORST spread as the variance signal.)
 
   Encoding: listpack (51 fields < hash-max-listpack-entries 128; every value 8-24B and every field
   name <= 10B, both < hash-max-listpack-value 64B; default config, not overridden).
@@ -87,6 +93,7 @@ clientconfig:
     -n 100000
     -c 10
     -t 10
+
     --pipeline=50
     --key-minimum=1
     --key-maximum=10000000

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features.yml
@@ -1,0 +1,101 @@
+version: 0.4
+name: memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features
+description: |
+  Ingestion / materialization benchmark for an entity-major online ML feature store on Redis: it
+  measures the throughput of POPULATING the entity hashes — the write side that the companion serving
+  playbook (memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features) only exercises at
+  5%. Each entity is one hash written whole-row with a single 51-field HSET (50 feature fields +
+  event_ts), pipelined — modeling a batch materialization job that rewrites a full row at once.
+
+  This is a one-time bulk load: with -n allkeys over a P (parallel, collision-free) key pattern, each
+  of the 10,000,000 entity keys is written EXACTLY ONCE, so the whole run measures the fresh-insert
+  HSET path — bulk-argument parsing (~104 args/command) and building a 51-entry listpack per key plus
+  the keyspace-dict insert/rehash as the dictionary grows from 0 to 10M. Because every key is written
+  once (no wrap, no overwrite), the measured code path does not change as the server under test gets
+  faster, keeping it sound for A/B comparison.
+
+  Encoding: listpack (51 fields < hash-max-listpack-entries 128; every value 8-24B and every field
+  name <= 10B, both < hash-max-listpack-value 64B; default config, not overridden).
+
+  Metric of interest: HSET ingestion throughput (Hsets/Totals Ops/sec; for a single-command run these
+  are equal). Secondary: write p50/p99.
+
+  Not modeled (intentional scope limits, NOT claims about all feature stores):
+    - Partial-column / streaming materialization: per-feature-view producers that update a few fields
+      (HSET of K << 51 fields) rather than the whole row are out of scope; this measures full-row
+      batch materialization only.
+    - Persistence pressure: save is disabled and there is no AOF, so RDB fork/CoW and AOF fsync/rewrite
+      cost under heavy write load is excluded — real durable ingestion throughput will be lower.
+    - TTL/freshness-on-write, HDEL of null fields, and replication propagation to replicas are not
+      modeled (oss-standalone, no expiry).
+
+exporter:
+  redistimeseries:
+    break_by:
+    - version
+    - commit
+    timemetric: $."ALL STATS".Runtime."Start time"
+    metrics:
+    - $."BEST RUN RESULTS".Hsets."Ops/sec"
+    - $."BEST RUN RESULTS".Totals."Ops/sec"
+    - $."BEST RUN RESULTS".Totals."Latency"
+    - $."BEST RUN RESULTS".Totals."Percentile Latencies"."p50.00"
+    - $."BEST RUN RESULTS".Totals."Percentile Latencies"."p99.00"
+    - $."AGGREGATED AVERAGE RESULTS (3 runs)".Hsets."Ops/sec"
+    - $."AGGREGATED AVERAGE RESULTS (3 runs)".Totals."Ops/sec"
+    - $."AGGREGATED AVERAGE RESULTS (3 runs)".Totals."Percentile Latencies"."p50.00"
+    - $."AGGREGATED AVERAGE RESULTS (3 runs)".Totals."Percentile Latencies"."p99.00"
+    - $."ALL STATS".Hsets."Ops/sec"
+    - $."ALL STATS".Hsets."Percentile Latencies"."p50.00"
+    - $."ALL STATS".Hsets."Percentile Latencies"."p99.00"
+    - $."ALL STATS".Totals."Ops/sec"
+    - $."ALL STATS".Totals."Latency"
+    - $."ALL STATS".Totals."Percentile Latencies"."p50.00"
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.00"
+
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 0
+  resources:
+    requests:
+      memory: 32g
+
+tested-groups:
+- hash
+tested-commands:
+- hset
+
+redis-topologies:
+- oss-standalone
+
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size-range=8-24
+    --random-data
+    --distinct-client-seed
+    --key-prefix "feature_store:user_features:entity:"
+    --print-percentiles=50,99
+    -n 100000
+    -c 10
+    -t 10
+    --pipeline=50
+    --key-minimum=1
+    --key-maximum=10000000
+    --command='HSET __key__ feature_1 __data__ feature_2 __data__ feature_3 __data__ feature_4 __data__ feature_5 __data__ feature_6 __data__ feature_7 __data__ feature_8 __data__ feature_9 __data__ feature_10 __data__ feature_11 __data__ feature_12 __data__ feature_13 __data__ feature_14 __data__ feature_15 __data__ feature_16 __data__ feature_17 __data__ feature_18 __data__ feature_19 __data__ feature_20 __data__ feature_21 __data__ feature_22 __data__ feature_23 __data__ feature_24 __data__ feature_25 __data__ feature_26 __data__ feature_27 __data__ feature_28 __data__ feature_29 __data__ feature_30 __data__ feature_31 __data__ feature_32 __data__ feature_33 __data__ feature_34 __data__ feature_35 __data__ feature_36 __data__ feature_37 __data__ feature_38 __data__ feature_39 __data__ feature_40 __data__ feature_41 __data__ feature_42 __data__ feature_43 __data__ feature_44 __data__ feature_45 __data__ feature_46 __data__ feature_47 __data__ feature_48 __data__ feature_49 __data__ feature_50 __data__ event_ts __data__'
+    --command-key-pattern=P
+    --hide-histogram
+  resources:
+    requests:
+      cpus: '10'
+      memory: 2g
+
+priority: 5


### PR DESCRIPTION
## What

Adds one new test-suite playbook modelling an **online ML feature store** with an
**entity-major** Redis layout: one hash per entity holding all of that entity's
feature values, served whole-entity with a single `HGETALL` and materialized with a
full-row `HSET`.

`memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml`

## Data shape

- 10,000,000 entity hashes, key `feature_store:user_features:entity:<id>`
- 50 feature fields (`feature_1..feature_50`) + an `event_ts` timestamp = **51 fields/hash**
- Values are short stringified scalars (8–24 B)
- **Encoding: listpack** (51 < `hash-max-listpack-entries` 128, values ≤ `hash-max-listpack-value` 64 B) — default config, not overridden
- Footprint ~**17 GB** resident (measured ~1.7 KB/entity)

## Workload

- **95:5** read:write online-serving mix: `HGETALL` (ratio 19) + full-row `HSET` (ratio 1)
- **Zipfian** access over entities (`--command-key-pattern=Z`) — popular entities served far more often
- Keyspace populated via `preload_tool` (memtier, `P`-pattern, pipelined) — exact-fill of 10,000,000 keys
- Primary metric: `HGETALL` throughput (`Hgetalls`/`Totals` Ops/sec) at fixed concurrency (200 connections, `--pipeline 1`); p50/p99 exported as closed-loop under-load latency (see the description's coordinated-omission note)

## How it differs from existing coverage

`memtier_benchmark-1Mkeys-hash-hgetall-50-fields-10B-values` already covers HGETALL on a
50-field listpack hash, but read-only, uniform-random, at 1M keys. This playbook adds the
dimensions that one can't reach: a **DRAM-scale keyspace** (10M, well beyond cache),
**Zipfian** serving locality, a **write-mix** (full-row materialization), and per-command
metric export. The description includes a "Not modeled" section scoping out HMGET-subset
serving, TTL/freshness, batch-scoring pipelines, and cluster topology.

## Validation

Ran a scaled-down version locally (10K entities) against `redis-server` and both local and
`redislabs/memtier_benchmark:edge`:

- keyspacelen exact-fill confirmed (P-pattern `n×c×t` → exactly N keys)
- encoding = listpack, 51 fields, expected key naming
- memtier stat groups `Hgetalls`/`Hsets` confirmed on `:edge` (exporter JSONPaths resolve)
- 19:1 ≈ 95:5 HGETALL:HSET mix confirmed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New benchmark YAML specs and a patch version bump only; no runtime or application logic changes.
> 
> **Overview**
> Adds two memtier **playbook** test suites for an entity-major ML feature-store layout on Redis (one hash per entity, 51 listpack fields) and bumps the package to **0.3.19**.
> 
> The **serving** playbook preloads **10M** keys, then runs a **~95:5** mix of Zipfian `HGETALL` vs full-row 51-field `HSET`, with RedisTimeSeries export for `Hgetalls`/`Hsets` throughput and latency. It targets large-keyspace, locality, and write-mix behavior beyond existing 1M read-only HGETALL coverage.
> 
> The companion **ingest** playbook starts from an empty DB and performs a count-bounded bulk load: **10M** pipelined full-row `HSET`s via parallel key partitioning (one insert per entity), measuring materialization throughput separately from the serving run’s light write mix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc60f6bebda8da75f628d0485eeffe9e6b4fe0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->