### PR TITLE
fix(feature-store serving): preload --key-maximum=10000001 to load exactly 10M keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.19"
+version = "0.3.20"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
@@ -78,6 +78,11 @@ dbconfig:
     save: '""'
   check:
     keyspacelen: 10000000
+  # NOTE: the preload below uses --key-maximum=10000001 (N+1), not 10000000.
+  # memtier_benchmark `-n allkeys` issues (key-maximum - key-minimum) writes per
+  # connection; with a single connection (-c 1 -t 1) and key-minimum=1 a
+  # key-maximum of 10000000 loads only 9,999,999 keys and fails the keyspacelen
+  # check above. key-maximum=N+1 populates exactly N=10,000,000 keys (1..10M).
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
@@ -88,7 +93,7 @@ dbconfig:
       --command='HSET __key__ feature_1 __data__ feature_2 __data__ feature_3 __data__ feature_4 __data__ feature_5 __data__ feature_6 __data__ feature_7 __data__ feature_8 __data__ feature_9 __data__ feature_10 __data__ feature_11 __data__ feature_12 __data__ feature_13 __data__ feature_14 __data__ feature_15 __data__ feature_16 __data__ feature_17 __data__ feature_18 __data__ feature_19 __data__ feature_20 __data__ feature_21 __data__ feature_22 __data__ feature_23 __data__ feature_24 __data__ feature_25 __data__ feature_26 __data__ feature_27 __data__ feature_28 __data__ feature_29 __data__ feature_30 __data__ feature_31 __data__ feature_32 __data__ feature_33 __data__ feature_34 __data__ feature_35 __data__ feature_36 __data__ feature_37 __data__ feature_38 __data__ feature_39 __data__ feature_40 __data__ feature_41 __data__ feature_42 __data__ feature_43 __data__ feature_44 __data__ feature_45 __data__ feature_46 __data__ feature_47 __data__ feature_48 __data__ feature_49 __data__ feature_50 __data__ event_ts __data__'
       --command-key-pattern=P
       --key-minimum=1
-      --key-maximum=10000000
+      --key-maximum=10000001
       -n allkeys
       -c 1
       -t 1


### PR DESCRIPTION
## Problem

The `memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features` serving playbook cannot run at its intended 10M scale. Its `preload_tool` uses:

```
-n allkeys --key-minimum=1 --key-maximum=10000000 -c 1 -t 1 --command-key-pattern=P
```

memtier's `-n allkeys` request count is `key_maximum - key_minimum` (per connection). With a single connection and `key-minimum=1`, that is **9,999,999** writes → only 9,999,999 keys loaded → it fails the dbconfig gate:

```yaml
check:
  keyspacelen: 10000000
```

The runner retries the setup 7× and then aborts the whole test:

```
ERROR: The total number of keys in setup does not match the expected spec: 10000000 != 9999999. Aborting after 7 tries...
```

## Fix

memtier's allkeys range is end-exclusive, so populating exactly N keys requires `key-maximum = N + 1`. Bump the **preload** to `--key-maximum=10000001` so it writes keys `1..10,000,000` and satisfies the check. An inline `NOTE` documents the N+1.

## Scope / why only the preload

- **`clientconfig` is intentionally left at `--key-maximum=10000000`.** It addresses *existing* keys with the Zipfian (`Z`) pattern, whose range is end-**inclusive**, so `10000000` is correct there. Bumping it would address an unpopulated key (10,000,001) and reintroduce a miss. (It also *removes* a latent issue: pre-fix, the `Z` range `[1,10000000]` could sample key 10,000,000, which the old preload never wrote → an empty HGETALL at the Zipf max.)
- **The companion ingest playbook is unaffected.** It is count-bounded (`-n 100000`, not `allkeys`) with a tiled `P` pattern that writes exactly 10,000,000 distinct keys, and its `keyspacelen` check is the pre-load (`0`) check.

## Verification

- Reproduced: the serving playbook aborts at the keyspace check (`10000000 != 9999999`) before producing any results, so there is no prior data this changes.
- Confirmed against memtier source: `allkeys` request count = `key_maximum - key_minimum`; the sequential generator emits `1..N` distinct over exactly N requests (no over/undershoot). Post-fix `keyspacelen` is exactly 10,000,000.

## Note (out of scope here)

The same `-c 1 -t 1` + `-n allkeys` + `key-maximum == keyspacelen` off-by-one appears in four sibling specs (`memtier_benchmark-1Mkeys-hash-hkeys-{5,5-100B,10,50}-fields-with-...-expiration-pipeline-10`); those can be fixed in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark YAML and package version only; no runtime code, auth, or data-path changes.
> 
> **Overview**
> Fixes the **10M entity feature-store serving** playbook so preload actually loads **10,000,000** keys and passes the `keyspacelen: 10000000` gate.
> 
> **Preload** `--key-maximum` is changed from `10000000` to `10000001`. With memtier `-n allkeys`, request count is `key-maximum - key-minimum`, so the old value only wrote 9,999,999 keys and the runner aborted setup (`10000000 != 9999999`). A short **NOTE** in the YAML documents the N+1 rule.
> 
> **`clientconfig`** is unchanged at `--key-maximum=10000000` because Zipfian (`Z`) key ranges are end-inclusive for existing keys. Package version is bumped **0.3.19 → 0.3.20**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f340b004fe5c392ae395864526e5accdaf19982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->