### PR TITLE
fix(feature-store ingest): remove blank line in folded args (ran default workload)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.20"
+version = "0.3.21"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features.yml
@@ -93,7 +93,6 @@ clientconfig:
     -n 100000
     -c 10
     -t 10
-
     --pipeline=50
     --key-minimum=1
     --key-maximum=10000000


### PR DESCRIPTION
## Problem

The `memtier_benchmark-playbook-feature-store-hash-ingest-10M-entities-50-features` ingest playbook silently ran memtier's **default SET/GET workload instead of the 51-field HSET ingest**.

Its `clientconfig.arguments` `>` folded scalar contained a **blank line** between `-t 10` and `--pipeline=50`. YAML preserves a blank line inside a folded scalar as a literal `\n`, so when `redis-benchmarks-spec-client-runner` shelled the memtier args, the command split at the newline:
- memtier ran with only the pre-newline args (`--data-size-range ... -n 100000 -c 10 -t 10`) → **default SET/GET workload**
- the post-newline tail ran as a separate failed shell command → `/bin/sh: --pipeline=50: not found`, exit 127

Observed symptoms in real runs: exit 127, sub-30s duration, and a telltale **`GET miss rate 95.60%` on a pure-HSET spec** (proof the HSET `--command` never applied).

## Fix

Remove the blank line so the folded scalar collapses to a single space-joined argument string. memtier now receives the full intended workload: `... -n 100000 -c 10 -t 10 --pipeline=50 --key-minimum=1 --key-maximum=10000000 --command='HSET __key__ feature_1 __data__ ... event_ts __data__' --command-key-pattern=P --hide-histogram`.

## Verification

- `yaml.safe_load` of the fixed spec: `clientconfig.arguments` now has **no interior newline** (only the standard trailing one) and contains all of `--command='HSET...'` (104 fields), `--pipeline=50`, `--key-maximum=10000000`, `--command-key-pattern=P`, `-n 100000 -c 10 -t 10`.
- The `-n × c × t = 10M` / `key-range ÷ (c×t) = 100000 = -n` coupling is unchanged; P-pattern still writes each of the 10M keys exactly once.
- Swept all 392 test-suite specs: no other spec has an interior-newline folded-scalar bug; the companion serving spec is clean.
- Diff is exactly the one blank-line deletion (+ version bump 0.3.20 → 0.3.21).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line YAML fix in one benchmark spec plus a patch version bump; no runtime code changes.
> 
> **Overview**
> Fixes the **10M-entity / 50-feature hash ingest** memtier playbook so the runner actually executes the intended **51-field HSET** workload instead of memtier’s default SET/GET.
> 
> A **blank line** inside the YAML `arguments: >` folded scalar after `-t 10` was preserved as an interior `\n`. When `redis-benchmarks-spec-client-runner` builds the shell command from `clientconfig["arguments"]`, that newline split the string: only the prefix args reached memtier; the tail (`--pipeline`, key range, `--command='HSET …'`, etc.) ran as a separate command and failed. The change **removes that blank line** so the folded scalar is one continuous argument string. Package version is bumped **0.3.20 → 0.3.21**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a08bc1085d518bed32a5a5220e5e02456b3fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->