### PR TITLE
Add HMSET coverage for listpack-encoded hash (9 short fields, single key overwrite)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-listpack-9-fields-short-values-hmset-pipeline-1.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-listpack-9-fields-short-values-hmset-pipeline-1.yml
@@ -1,0 +1,60 @@
+version: 0.4
+name: memtier_benchmark-1key-hash-listpack-9-fields-short-values-hmset-pipeline-1
+description: >
+  Runs memtier_benchmark HMSET overwrite on a single listpack-encoded hash with 9 short
+  field/value pairs (values 3-20 bytes), mirroring the reporter's repro in
+  redis/redis#13876 (HMSET regression bisected to a25b153 / PR #13279). Each HMSET call
+  rewrites every field on the same key (`test_hmset`), so the workload exercises
+  `lpFindCmp` once per field — the function the issue identifies as the regressed path
+  after the `arg->` indirection was introduced. The existing
+  `memtier_benchmark-1Mkeys-load-hash-hmset-5-fields-with-1000B-values` spec uses
+  1000-byte values, which exceeds `hash-max-listpack-value=64` and therefore exercises
+  the hashtable encoding (different code path); this spec stays comfortably under
+  `hash-max-listpack-entries=128` and `hash-max-listpack-value=64` so the hash remains
+  listpack-encoded throughout.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: >
+      --command "HMSET test_hmset username alice age 30 location Paris field4 weugfuwebgfiwebviu field5 ewuvbgevhberihvneirn field6 weufgewihiwer field7 4tvnreiknveir field8 23rgwnrighnkwn2 field9 23jrb234jbg34ibgi3"
+      --command-key-pattern P
+      -n 1
+      -c 1
+      -t 1
+      --hide-histogram
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-hash-listpack-9-fields-short-values
+  dataset_description: Single listpack-encoded hash key `test_hmset` with 9 fields (values 3-20 bytes).
+tested-commands:
+- hmset
+tested-groups:
+- hash
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --command "HMSET test_hmset username alice age 30 location Paris field4 weugfuwebgfiwebviu field5 ewuvbgevhberihvneirn field6 weufgewihiwer field7 4tvnreiknveir field8 23rgwnrighnkwn2 field9 23jrb234jbg34ibgi3"
+    --command-key-pattern R
+    --hide-histogram
+    --test-time 180
+    --pipeline 1
+    -c 1
+    -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 67


### PR DESCRIPTION
## Why

redis/redis#13876 reports ~5% HMSET avg-latency regression between 7.2.7 and 7.4.2, bisected by the reporter to commit `a25b153` (PR #13279 — _Hash field expiration: listpack rework_). The reporter's hypothesis: `lpFindCmp` is hot on the HMSET path, and the `arg->` indirection introduced in that commit (passing arguments through a struct rather than direct locals) makes it cheaper to leave un-inlined — they note GCC actually does not inline it.

The currently registered HMSET spec — `memtier_benchmark-1Mkeys-load-hash-hmset-5-fields-with-1000B-values` — uses 1000-byte values, which exceeds `hash-max-listpack-value=64` and therefore exercises the **hashtable** encoding (a different code path that doesn't go through `lpFindCmp`). It cannot reproduce the listpack regression.

## What

This PR adds a new spec, `memtier_benchmark-1key-hash-listpack-9-fields-short-values-hmset-pipeline-1`, that mirrors the reporter's repro:

| field | value |
| --- | --- |
| preload | single key `test_hmset`, 9 fields with 3-20 byte values (under both listpack thresholds → listpack-encoded) |
| benchmark | `HMSET test_hmset username alice age 30 location Paris field4 weugfuwebgfiwebviu field5 ewuvbgevhberihvneirn field6 weufgewihiwer field7 4tvnreiknveir field8 23rgwnrighnkwn2 field9 23jrb234jbg34ibgi3` — pipeline 1, 1 client, 1 thread, test-time 180s |
| build-variants | bookworm gcc 15.2.0 amd64 + arm64 + dockerhub |
| tested-groups | hash |
| priority | 67 (regression-coverage spec, not a release gate) |

The benchmark overwrites every field on the same key on each call, so `lpFindCmp` is exercised 9 times per HMSET — the exact codepath the issue identifies.

## Notes

- Same shape as #403 (BITOP short-tail coverage for #15289) and #401 (listpack ZINCRBY coverage for #15288) — register the spec, then a bisect / version-pair compare can run on the registered name with no further plumbing.
- Spec name encodes the workload shape so the listpack-encoded HMSET bench is self-describing.
- PR #13503 was a partial fix that landed in 8.0.x only; 7.4.x is still affected per the reporter's 15-round bisect, so the spec is useful for both 7.4.x regression tracking and confirming the 8.0.x fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a benchmark YAML definition; no application or Redis server code changes.
> 
> **Overview**
> Registers a new memtier benchmark spec **`memtier_benchmark-1key-hash-listpack-9-fields-short-values-hmset-pipeline-1`** so CI can track the **listpack-encoded** HMSET path tied to redis/redis#13876 (regression around `lpFindCmp` / PR #13279).
> 
> The workload preloads a single key `test_hmset` with nine short fields (values under listpack limits), then repeatedly **HMSET**s all fields on that same key (pipeline 1, 180s, 1 client/thread) on **oss-standalone** with bookworm gcc 15.2.0 amd64/arm64 and **dockerhub**. **Priority 67** marks it as regression-coverage, not a release gate—filling a gap versus the existing 1000B-value HMSET spec that hits hashtable encoding instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6526856b046b7fee90fad406d83606a4690bfbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->