### PR TITLE
Add ZSCAN MATCH+COUNT coverage on hashtable-encoded zset

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100.yml
@@ -21,12 +21,12 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: >
-      --command "ZADD test_zadd __key__ sortset-__key__"
+      --command "ZADD test_zadd 1 sortset-__key__"
       --command-key-pattern P
       --key-prefix ""
       --key-minimum 1
-      --key-maximum 1000
-      -n 1000
+      --key-maximum 1001
+      -n allkeys
       -c 1
       -t 1
       --hide-histogram
@@ -34,7 +34,7 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-hashtable-1K-elements-sortset-named
-  dataset_description: Single zset key `test_zadd` with 1000 members named `sortset-1`..`sortset-1000` (scores 1..1000); exceeds zset-max-listpack-entries=128, so skiplist+dict encoded.
+  dataset_description: Single zset key `test_zadd` with 1000 members named `sortset-1`..`sortset-1000` (all at score 1; ZSCAN walks the dict, so member-name distribution is what matters); exceeds zset-max-listpack-entries=128, so skiplist+dict encoded.
 tested-commands:
 - zscan
 tested-groups:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100.yml
@@ -1,0 +1,63 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100
+description: >
+  Runs memtier_benchmark ZSCAN with MATCH pattern and COUNT 100 on a single
+  hashtable-encoded zset (1000 elements, exceeds `zset-max-listpack-entries=128`
+  so the zset is dict+skiplist). Mirrors the reporter's repro in redis/redis#13855
+  (`ZSCAN test_zadd 0 MATCH sortset*1* COUNT 100`). The currently registered ZSCAN
+  specs (`memtier_benchmark-1key-zset-{100,1K}-elements-zscan`) issue `ZSCAN key 0`
+  with no MATCH / no COUNT, which iterates a small fixed number of slots; this spec
+  exercises the scan-callback path identified in the issue, where commit
+  `7f0a7f0a` moved the TYPE filtering branch into `scanCallback` and added an
+  unconditional `if (!o && data->type != LLONG_MAX)` check that is evaluated for
+  every visited entry — quickly dominated by the COUNT 100 walk on a populated
+  hashtable.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: >
+      --command "ZADD test_zadd __key__ sortset-__key__"
+      --command-key-pattern P
+      --key-prefix ""
+      --key-minimum 1
+      --key-maximum 1000
+      -n 1000
+      -c 1
+      -t 1
+      --hide-histogram
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-hashtable-1K-elements-sortset-named
+  dataset_description: Single zset key `test_zadd` with 1000 members named `sortset-1`..`sortset-1000` (scores 1..1000); exceeds zset-max-listpack-entries=128, so skiplist+dict encoded.
+tested-commands:
+- zscan
+tested-groups:
+- sorted-set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --command "ZSCAN test_zadd 0 MATCH sortset*1* COUNT 100"
+    --command-key-pattern R
+    --hide-histogram
+    --test-time 180
+    --pipeline 1
+    -c 1
+    -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 67


### PR DESCRIPTION
## Why

redis/redis#13855 reports a ~5% ZSCAN regression attributed to commit `7f0a7f0a`, which moved the SCAN TYPE filtering branch into `scanCallback`. The added check — `if (!o && data->type != LLONG_MAX)` — is evaluated for every visited dict entry. For ZSCAN, `o` is not NULL so the check short-circuits, but the branch is still paid on every callback invocation; the reporter measured `scanGenericCommand` going from ~73us to ~78us via in-server `clock_gettime` instrumentation on the exact command `ZSCAN test_zadd 0 MATCH sortset*1* COUNT 100`.

The currently registered ZSCAN specs (`memtier_benchmark-1key-zset-{100,1K}-elements-zscan`) issue bare `ZSCAN key 0` with neither MATCH nor COUNT, which iterates only a small fixed number of slots per call. They don't exercise the regressed scan-callback path at all.

## What

This PR adds a new spec, `memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100`, that mirrors the reporter's repro:

| field | value |
| --- | --- |
| preload | single key `test_zadd`, 1000 zset members named `sortset-1`..`sortset-1000` (1000 > `zset-max-listpack-entries=128` → skiplist+dict encoded) |
| benchmark | `ZSCAN test_zadd 0 MATCH sortset*1* COUNT 100` — pipeline 1, 1 client, 1 thread, test-time 180s |
| build-variants | bookworm gcc 15.2.0 amd64 + arm64 + dockerhub |
| tested-groups | sorted-set |
| priority | 67 (regression-coverage spec, not a release gate) |

The MATCH pattern `sortset*1*` matches a substantial fraction of the 1000 members, so the scan callback is invoked many times per ZSCAN call — which is precisely where the issue says the per-entry branch overhead dominates.

## Notes

- Same shape as #403 (BITOP short-tail coverage for #15289) and #401 (listpack ZINCRBY coverage for #15288).
- Spec name encodes the workload shape so the ZSCAN MATCH bench is self-describing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a benchmark YAML; no Redis server or client code changes.
> 
> **Overview**
> Adds a memtier benchmark spec **`memtier_benchmark-1key-zset-1K-elements-zscan-match-count-100`** so CI can catch regressions on the ZSCAN path reported in redis/redis#13855.
> 
> The spec preloads one key `test_zadd` with 1000 `sortset-*` members (dict+skiplist encoding) and benchmarks **`ZSCAN test_zadd 0 MATCH sortset*1* COUNT 100`** for 180s—unlike existing ZSCAN suites that only run bare **`ZSCAN key 0`**, which do not stress the per-entry `scanCallback` work. Priority **67** marks it as regression coverage, not a release gate; build variants match other sorted-set specs (bookworm gcc amd64/arm64 + dockerhub).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44157458c46b57d7d6c364d5d99c39f427abc368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->