### PR TITLE
0.3.22: add INFO everything specs (--test-time 180)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.21"
+version = "0.3.22"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-info-everything.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-info-everything.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-generic-info-everything
+description: Measures throughput of INFO everything command on a server with 1M keys loaded. INFO everything is a latency-sensitive introspection command commonly issued by monitoring/metrics pollers; unlike INFO default it adds the commandstats, latencystats, and errorstats sections, whose cost scales with the command table — making this run sensitive to per-call INFO formatting overhead on the server main thread.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-10B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes.
+tested-commands:
+- info
+tested-groups:
+- server
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "INFO everything" -c 10 -t 4 --hide-histogram --test-time 180
+    --print-percentiles=50,99,99.9,99.99
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+exporter:
+  redistimeseries:
+    timemetric: $."ALL STATS".Runtime."Start time"
+    metrics:
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.90"
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.99"
+priority: 50

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-info-everything-1rps-with-10k-get-load.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-info-everything-1rps-with-10k-get-load.yml
@@ -1,0 +1,58 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-info-everything-1rps-with-10k-get-load
+description: Reproduces a monitoring poll pattern under data-path load. One memtier client issues INFO everything from a single connection at 1 request/sec (a typical monitoring poll cadence), running concurrently with a second memtier client driving a steady 10,000 ops/sec GET workload over the same 1M-key dataset. Because Redis is single-threaded, each INFO everything (commandstats/latencystats/errorstats) steals main-thread time from the GET stream, so this spec surfaces the periodic tail-latency impact of monitoring polling on the data path rather than INFO throughput in isolation.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-10B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes.
+# tested-commands/groups reflect the first clientconfig (the INFO poller), which
+# is what the spec-fields validator inspects; the GET data-path load runs as the
+# second clientconfig below.
+tested-commands:
+- info
+tested-groups:
+- server
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+# NOTE: the GET client is listed LAST on purpose. The multi-client runner keeps
+# the last-read memtier JSON as the exported "Totals", so the measured/exported
+# percentiles are the GET data-path client's, not the 1-RPS INFO poller's.
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "INFO everything" -c 1 -t 1 --rate-limiting=1 --test-time 180
+    --print-percentiles=50,99,99.9,99.99 --hide-histogram
+  resources:
+    requests:
+      cpus: '1'
+      memory: 1g
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "GET __key__" --command-key-pattern="R" --key-minimum 1 --key-maximum
+    1000000 -c 10 -t 1 --rate-limiting=1000 --test-time 180
+    --print-percentiles=50,99,99.9,99.99 --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+exporter:
+  redistimeseries:
+    timemetric: $."ALL STATS".Runtime."Start time"
+    metrics:
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.90"
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.99"
+priority: 50


### PR DESCRIPTION
## Summary
Adds two test-suite specs that benchmark `INFO everything`, a latency-sensitive introspection command commonly issued by monitoring/metrics pollers. Unlike `INFO default` it adds the `commandstats`, `latencystats`, and `errorstats` sections, whose cost scales with the command table and executes on the single server main thread.

### 1. `memtier_benchmark-1Mkeys-generic-info-everything`
Pure `INFO everything` throughput — sibling of the existing `INFO ALL` spec for apples-to-apples comparison.
- `--command "INFO everything" -c 10 -t 4 --hide-histogram --test-time 180`, 1M keys, `oss-standalone`, priority 50.

### 2. `memtier_benchmark-1Mkeys-info-everything-1rps-with-10k-get-load`
Monitoring-under-load variation, two concurrent memtier clients:
- **poller**: 1 connection, `INFO everything` at `--rate-limiting=1` (1 RPS — a typical monitoring poll cadence).
- **data load**: `GET` at `--rate-limiting=1000` x 10 conns = **10,000 ops/sec** over the same 1M-key dataset.

Because Redis is single-threaded, each poll steals main-thread time from the GET stream — so this surfaces the **tail-latency impact of monitoring polling on the data path**, not INFO throughput in isolation. Both `--test-time 180`.

## Local verification
Ran both specs with `redis-benchmarks-spec-client-runner --override-memtier-test-time 10` against a local `redis-server`:
- Spec 1: ~27.2K ops/sec, p50 1.44ms / p99 2.74ms.
- Spec 2: `Completed 2 client configurations`, no errors; GET load ~11.1K ops/sec, p50 0.063ms / p99 0.367ms, poller running concurrently. Multi-client (`clientconfigs`) path confirmed working.

## Release
- Version bumped `0.3.21` → `0.3.22` in `pyproject.toml` (merge triggers the PyPI publish).
- Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are new benchmark definitions and a version bump only; no application or runner logic is modified.
> 
> **Overview**
> **Release 0.3.22** bumps the package version and adds two memtier benchmark suites for `INFO everything` (monitoring-style introspection with `commandstats` / `latencystats` / `errorstats`), aligned with the existing `INFO ALL` spec for comparison.
> 
> **`memtier_benchmark-1Mkeys-generic-info-everything`** measures isolated `INFO everything` throughput on a 1M-key `oss-standalone` dataset with a 180s run, exporting p99.90 / p99.99 latencies.
> 
> **`memtier_benchmark-1Mkeys-info-everything-1rps-with-10k-get-load`** runs two concurrent clients: a 1 RPS `INFO everything` poller and a ~10k ops/sec `GET` load; exported percentiles intentionally come from the **last** client (the GET stream) so CI metrics reflect data-path tail latency under polling interference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f160fd5fcf46ac932ae46c77e6da0d2077bdc9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->