### PR TITLE
test-suites: add connection-scale CLIENT LIST cost benchmark (2000 connections)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.24"
+version = "0.3.25"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-2000conns-client-list.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-2000conns-client-list.yml
@@ -1,0 +1,69 @@
+version: 0.4
+name: memtier_benchmark-2000conns-client-list
+description: >
+  CLIENT LIST cost at high connection scale. A PING keepalive client holds ~2000 open
+  connections (-c 250 -t 8, 1 thread/core); a separate single-connection prober issues
+  CLIENT LIST at a low fixed open-loop rate (--rate-limiting), so each CLIENT LIST walks
+  all ~2000 clients one-at-a-time without self-queueing or coordinated omission. The
+  exported metric is the prober's CLIENT LIST latency (its Totals — the prober is the
+  last clientconfig, so the multi-client runner exports its JSON): it captures the server
+  main-thread O(N-connections) client iteration + per-client formatting
+  (catClientInfoString) plus the ~2000-line reply transfer, as a connection-scale
+  regression sentinel (not a pure server-CPU isolation — pair with a profiler TMA capture
+  to attribute the walk CPU). No keyspace required.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 0
+  resources:
+    requests:
+      memory: 1g
+# tested-commands/groups reflect the CLIENT LIST prober, the exported (last) clientconfig
+# and the command this spec measures; the PING keepalive client only holds the connections.
+tested-commands:
+- client|list
+tested-groups:
+- connection
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+# Two concurrent clients (multitool suite — runs ONLY on a BENCHMARK_MULTITOOL_ENABLED
+# runner, e.g. m7i.metal-24xl; other runners skip it). EXPORT-PROVENANCE INVARIANT: the
+# runner exports the LAST memtier clientconfig's JSON (by client index — it overwrites a
+# single memtier_json slot per memtier client). The CLIENT LIST prober MUST therefore stay
+# the LAST clientconfig so the exported "Totals" is its CLIENT LIST latency (~ms), not the
+# PING client's (~sub-ms) — same convention as info-everything-1rps-with-10k-get-load,
+# whose measured client is likewise its last. Verify on the first fleet run that the
+# exported p50 matches the prober (~ms), not PING. Both run --test-time 180 to overlap fully.
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge   # idle-hold: keeps ~2000 connections OPEN
+  tool: memtier_benchmark
+  # --rate-limiting=1 = the minimum (1 PING/s per conn): the 2000 connections are held
+  # open and present in CLIENT LIST while adding only ~2000 trivial PING/s of main-thread
+  # work (negligible), so the prober measures the O(N) walk, not a queue behind PING load.
+  arguments: --command "PING" -c 250 -t 8 --rate-limiting=1
+    --thread-conn-start-max-jitter-micros=50000 --test-time 180 --hide-histogram
+  resources:
+    requests:
+      cpus: '8'
+      memory: 2g
+- run_image: redislabs/memtier_benchmark:edge   # CLIENT LIST prober: 1 conn, low fixed rate
+  tool: memtier_benchmark
+  arguments: --command "CLIENT LIST" -c 1 -t 1 --rate-limiting=10 --test-time 180
+    --print-percentiles "50,99" --hide-histogram
+  resources:
+    requests:
+      cpus: '1'
+      memory: 1g
+exporter:
+  redistimeseries:
+    timemetric: $."ALL STATS".Runtime."Start time"
+    metrics:
+    - $."ALL STATS".Totals."Latency"
+    - $."ALL STATS".Totals."Percentile Latencies"."p50.00"
+    - $."ALL STATS".Totals."Percentile Latencies"."p99.00"
+priority: 50


### PR DESCRIPTION
## What

Adds a memtier_benchmark test-suite that measures **CLIENT LIST** cost at high connection scale (~2000 connections).

`CLIENT LIST` walks the entire client list and formats every connection via `catClientInfoString` on the server main thread, so its cost grows **O(N-connections)**. This is a common monitoring/observability path (admin tooling and agents that poll `CLIENT LIST` / the `INFO` clients section), and the suite currently has no coverage for the walk-all-clients case.

## Coverage gap

The existing `connection` group covers connection **setup** (`connection-hello`, `auth-reconnect`) and single-connection introspection (`client-info` — `CLIENT INFO` is O(1), self-only). None exercise the O(N) iterate-and-format-**all**-clients path. This spec fills that gap.

## Design

Two concurrent clients (`clientconfigs`), mirroring the rare-expensive-command-under-load pattern already used by the `info-everything-1rps-with-10k-get-load` spec:

- **Idle keepalive** — `-c 250 -t 8` (= 2000 connections, 1 client thread per allocated core) holding the connection set open at the minimum rate (`--rate-limiting=1`), so the connections are present in CLIENT LIST while adding only negligible (~2000 PING/s) main-thread work — the prober measures the O(N) walk, not a queue behind PING load.
- **CLIENT LIST prober** — a single connection (`-c 1 -t 1`) issuing `CLIENT LIST` at a low fixed **open-loop** rate (`--rate-limiting=10`). Because it is one connection at a bounded rate, each `CLIENT LIST` walks the ~2000-client set one-at-a-time, with no self-queueing and no coordinated omission. The prober is listed **last**; the multi-client runner exports the last memtier clientconfig's JSON, so the exported metric is the `CLIENT LIST` latency, not the keepalive's (same convention as `info-everything-1rps-with-10k-get-load`, whose measured client is likewise last).

`--test-time 180`, `keyspacelen: 0` (no keyspace required).

## Metric

The exported metric is the prober's `CLIENT LIST` latency (`ALL STATS.Totals.{Latency, p50.00, p99.00}`). It captures the server main-thread O(N) client iteration + `catClientInfoString` formatting plus the ~2000-line reply transfer — a sensitive **connection-scale regression sentinel**. (It is an end-to-end number, not an isolated server-CPU measurement; pair with a server-side profile to attribute the walk CPU.)

## Notes

- `priority: 50` (matches the other connection-introspection specs `client-info` / `auth-reconnect`).
- Build variants: amd64 + arm64 + dockerhub.
- A single ~2000-connection point is sufficient to catch regressions in this monotone-in-N path; a smaller-N sibling can be added later for a scaling curve.


_This is a multi-client (`clientconfigs`) suite; it runs on the multitool-enabled runner._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a YAML test-suite definition and a semver patch bump only; no runner, auth, or application logic changes.
> 
> **Overview**
> Adds **`memtier_benchmark-2000conns-client-list`**, a multitool memtier suite that tracks **CLIENT LIST** latency when the server has ~2000 open connections—filling a gap next to O(1) **`CLIENT INFO`** specs in the `connection` group.
> 
> The spec uses two concurrent clients (same “expensive command under load” pattern as **`info-everything-1rps-with-10k-get-load`**): a PING keepalive (`-c 250 -t 8`, minimal rate) holds connections open with negligible main-thread load, and a **last-listed** single-connection prober runs **`CLIENT LIST`** at 10 RPS so exported Totals/p50/p99 reflect the O(N) walk and large reply, not keepalive traffic. No keyspace (`keyspacelen: 0`); amd64/arm64/dockerhub; `priority: 50`.
> 
> Package version is bumped **0.3.24 → 0.3.25** in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba92df79d56a8b879c623338408906cc2aea15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->