### PR TITLE
test-suites: add SRANDMEMBER count coverage on a 10K-element hashtable set (CASE 3 + CASE 4)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-10K-elements-hashtable-srandmember-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-10K-elements-hashtable-srandmember-count-100.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-1key-set-10K-elements-hashtable-srandmember-count-100
+description: 'Runs memtier_benchmark against a single SET key of 10,000 elements, issuing
+  SRANDMEMBER key 100 (the positive-count, unique-elements variant). Because the requested
+  count (100) is a small fraction of the set (100*3 <= 10000), srandmemberWithCountCommand takes
+  its CASE 4 strategy: it repeatedly samples a random member into an auxiliary dictionary until
+  it has collected `count` unique members. For a hashtable-encoded set the generic path
+  heap-allocates a fresh SDS copy per sampled member; this spec exercises that per-sample
+  allocation churn on the small-count CASE 4 path (the common "sample a handful of random
+  members" usage). Companion to the count-5K (CASE 3) spec. Encoding: hashtable (10,000 integer
+  elements exceed set-max-intset-entries 512 and set-max-listpack-entries 128). Metric of
+  interest: Ops/sec (throughput); the small 100-element reply keeps the client cheap so the
+  server-side sampling/allocation cost dominates the delta.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  resources:
+    requests:
+      memory: 1g
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command="SADD set:10K:elements __key__" --command-key-pattern=P --key-maximum
+      10000 --key-prefix "" -n 10000 --hide-histogram -t 1 -c 1 --pipeline 50
+  dataset_name: 1key-set-10K-elements-int
+  dataset_description: This dataset contains 1 set key with 10,000 integer elements
+    (hashtable-encoded, exceeds set-max-intset-entries 512).
+tested-groups:
+- set
+tested-commands:
+- srandmember
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="SRANDMEMBER set:10K:elements 100" --pipeline 10 --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-10K-elements-hashtable-srandmember-count-5K.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-10K-elements-hashtable-srandmember-count-5K.yml
@@ -1,0 +1,49 @@
+version: 0.4
+name: memtier_benchmark-1key-set-10K-elements-hashtable-srandmember-count-5K
+description: 'Runs memtier_benchmark against a single SET key of 10,000 elements, issuing
+  SRANDMEMBER key 5000 (the positive-count, unique-elements variant). Because the requested
+  count (5000) is a large fraction of the set (5000*3 > 10000), srandmemberWithCountCommand
+  takes its CASE 3 strategy: it builds an auxiliary dictionary holding the WHOLE set and then
+  removes random elements down to the requested count. For a hashtable-encoded set every one of
+  those inserted members is a heap-allocated SDS in the generic path, so CASE 3 is dominated by
+  per-element sds allocation + free churn (~one alloc/free per set element per call). This spec
+  exercises that allocation-heavy CASE 3 large-fraction path on a hashtable set. Encoding:
+  hashtable (10,000 integer elements exceed set-max-intset-entries 512 and
+  set-max-listpack-entries 128). Metric of interest: Ops/sec (throughput). A modest --pipeline 4
+  keeps the single-threaded server continuously busy on the CASE 3 allocation path (avoids an
+  RTT-bound closed loop) while bounding in-flight reply memory for the large 5000-element replies.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  resources:
+    requests:
+      memory: 1g
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command="SADD set:10K:elements __key__" --command-key-pattern=P --key-maximum
+      10000 --key-prefix "" -n 10000 --hide-histogram -t 1 -c 1 --pipeline 50
+  dataset_name: 1key-set-10K-elements-int
+  dataset_description: This dataset contains 1 set key with 10,000 integer elements
+    (hashtable-encoded, exceeds set-max-intset-entries 512).
+tested-groups:
+- set
+tested-commands:
+- srandmember
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="SRANDMEMBER set:10K:elements 5000" --pipeline 4 --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 1


### PR DESCRIPTION
## Summary

Adds benchmark coverage for `SRANDMEMBER key <count>` (the positive-count, unique-elements variant), which currently has **no spec** in the suite. The count path (`srandmemberWithCountCommand`) is allocation-heavy on hashtable-encoded sets and worth tracking.

Two specs on a single 10,000-element (hashtable-encoded) integer set exercise the two distinct strategies:

| Spec | count | Strategy | What it stresses |
|------|-------|----------|------------------|
| `...srandmember-count-5K` | 5000 | **CASE 3** (`count*3 > size`) | Copies the whole set into an auxiliary dict, then removes random down to count → ~one sds alloc+free per set element per call |
| `...srandmember-count-100` | 100 | **CASE 4** (`count*3 <= size`) | Samples random members into a dict until `count` unique → ~one sds alloc+free per sampled element per call (the common "sample a handful" usage) |

## Notes
- **Encoding:** 10,000 integer elements exceed `set-max-intset-entries` (512) and `set-max-listpack-entries` (128) → **hashtable**. Noted in each description.
- **Metric:** Ops/sec (throughput). A modest `--pipeline` keeps the single-threaded server continuously busy on the allocation path (avoids an RTT-bound closed loop) while bounding in-flight reply memory (larger for the 5000-element reply, hence the smaller pipeline there).
- `keyspacelen: 1`, `tested-commands: [srandmember]`, name==filename; preload builds exactly 10,000 members (0..9999).
- Both reuse a shared `dataset_name: 1key-set-10K-elements-int`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only new YAML benchmark definitions; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds **two memtier benchmark specs** for `SRANDMEMBER key <count>` on a shared **10K-element hashtable-encoded** set (`1key-set-10K-elements-int`), filling a gap where the positive-count unique-elements path had no coverage.
> 
> One spec uses **count 5000** to hit **CASE 3** (`count*3 > size`): copy the full set into an auxiliary dict, then trim to count—stressing per-element SDS alloc/free on hashtable sets. The other uses **count 100** for **CASE 4** (`count*3 <= size`): repeated random sampling until `count` unique members—typical “sample a handful” usage with per-sample allocation churn.
> 
> Both preload via `SADD`, target **Ops/sec**, use modest `--pipeline` (4 vs 10) to keep the server busy without huge in-flight replies, and run on **oss-standalone** with the usual gcc/dockerhub build variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d32819c007b0dd4aab30537a583ef0fcada39c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->