### PR TITLE
Add persistence-enabled replica setups + 100%-writes benchmarks (RDB / AOF-everysec)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.25"
+version = "0.3.26"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/setups/topologies/topologies.yml
+++ b/redis_benchmarks_specification/setups/topologies/topologies.yml
@@ -117,6 +117,49 @@ spec:
       requests:
         cpus: "3"
         memory: "30g"
+  # Persistence-enabled replica setups. Policy is encoded in the setup name
+  # (…-rdb, …-aof-everysec) because deployment names are the comparison key in
+  # the results TSDB and cannot be renamed later without breaking continuity.
+  #
+  # How the persistence override works (order is load-bearing): the coordinator
+  # emits a spec's dbconfig configuration-parameters FIRST and the topology's
+  # redis_arguments AFTER them on the redis-server command line. `save` is NOT
+  # last-wins — the first save directive RESETS the save points and every later
+  # one APPENDS. So a spec that sets `save: '""'` (reset to none) combined with
+  # this topology's `--save 10 1000` yields exactly one save point (10/1000).
+  # Specs using the -rdb setup MUST set `save: '""'` in configuration-parameters;
+  # a spec with a non-empty save value would ACCUMULATE both schedules.
+  # Both primary AND replica receive these arguments (replicas persist too,
+  # mirroring a typical HA deployment; per-replica dbfilename/appendfilename
+  # overrides are appended after them by the coordinator).
+  #
+  # cpus deliberately matches the plain oss-standalone-01-replicas setup
+  # (primary 1 core, replica 1 core) so results are directly comparable to that
+  # baseline cell. The bgsave / AOF-rewrite fork child inherits the primary's
+  # cpuset and competes with the main thread — that contention is part of the
+  # phenomenon these setups exist to measure.
+  - name: oss-standalone-01-replicas-rdb
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 1
+      placement: "sparse"
+    redis_arguments: --save 10 1000
+    resources:
+      requests:
+        cpus: "2"
+        memory: "20g"
+  - name: oss-standalone-01-replicas-aof-everysec
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 1
+      placement: "sparse"
+    redis_arguments: --appendonly yes --appendfsync everysec
+    resources:
+      requests:
+        cpus: "2"
+        memory: "20g"
   - name: oss-standalone-01-replicas-02-io-threads
     type: oss-standalone
     redis_topology:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-2000conns-client-list.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-2000conns-client-list.yml
@@ -19,10 +19,12 @@ dbconfig:
   resources:
     requests:
       memory: 1g
-# tested-commands/groups reflect the CLIENT LIST prober, the exported (last) clientconfig
-# and the command this spec measures; the PING keepalive client only holds the connections.
+# tested-commands lists every verb the workload sends (validator-enforced): the
+# CLIENT LIST prober is the measured/exported command; the PING keepalive client
+# only holds the ~2000 connections open but its pings are still sent traffic.
 tested-commands:
 - client|list
+- ping
 tested-groups:
 - connection
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10-rate-limited-40Kops.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10-rate-limited-40Kops.yml
@@ -1,0 +1,91 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10-rate-limited-40Kops
+description: |
+  100%-writes fixed-offered-load benchmark: uniform-random SET overwrites of a
+  fully preloaded 3M-key keyspace of RAW-encoded strings (1024B incompressible
+  values, ~3 GB resident dataset) at a rate-limited aggregate offered load of
+  40K ops/s (200 connections x 200 ops/s each), 600s steady state. Metrics of
+  interest are p50/p99 latency at fixed load (Ops/sec must equal the offered
+  40K — a shortfall means the cell saturated and the datapoint is invalid).
+  Open-loop rate limiting avoids coordinated omission: when the server stalls
+  (fork, fsync, rewrite), the queued requests record the stall in the tail
+  percentiles instead of silently not being sent. Because the offered load —
+  and therefore the persistence byte-rate — is identical across server
+  versions, per-cell version deltas in latency isolate write-path cost
+  cleanly; this is the sensitive companion to the free-running saturation
+  sibling spec (same workload without --rate-limiting).
+
+  Persistence policy is pinned per setup, not by this spec: the spec resets
+  snapshotting (save "" — note redis save semantics: first save directive
+  resets, later ones append) and each setup in redis-topologies re-enables its
+  own policy via topology redis_arguments, which the coordinator appends after
+  the spec parameters. Cells: oss-standalone-01-replicas (persistence-free
+  baseline), oss-standalone-01-replicas-rdb (single 10s/1000-changes save
+  point; near-continuous ~3 GB bgsaves), and
+  oss-standalone-01-replicas-aof-everysec (AOF with everysec fsync and default
+  auto-rewrite thresholds; at 40K ops/s the AOF ingest is ~44 MB/s per
+  instance — primary plus replica stay under the runner disk ceiling, unlike a
+  free-running AOF workload, so latency reflects Redis rather than a saturated
+  volume; rewrites still trigger periodically and their forks are part of the
+  measured behavior). All cells use identical cpu allocations (primary 1 core,
+  replica 1 core; fork children share the primary core by design).
+  rdbcompression is pinned off (values are incompressible). Replica disconnect
+  cascades are pinned away (client-output-buffer-limit replica 2GB,
+  repl-backlog-size 256mb) so a replica stall cannot force a mid-run full
+  resync; any datapoint with a nonzero mid-bench full-sync count should be
+  discarded in analysis. Values use -R (random bytes) so RDB/AOF/replication
+  payload sizes are realistic, with the default constant seed for A/B
+  reproducibility and --distinct-client-seed to avoid lockstep clients. NOTE:
+  the server data dir is a bind mount on the runner root volume — persistence
+  I/O (including everysec fsync) hits the real disk.
+dbconfig:
+  # Preload BEFORE replicas spin up so the dataset transfers via one initial
+  # full sync and the measured phase is pure steady-state write traffic.
+  preload_before_replica: true
+  configuration-parameters:
+    save: '""'
+    maxmemory-policy: noeviction
+    rdbcompression: 'no'
+    repl-backlog-size: 256mb
+    client-output-buffer-limit: 'replica 2048mb 2048mb 120'
+  check:
+    keyspacelen: 3000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 1024 -R --ratio 1:0 -n allkeys --pipeline 50 --key-maximum
+      3000000 --key-pattern P:P --key-minimum 1 --hide-histogram -t 8 -c 25
+  resources:
+    requests:
+      memory: 6g
+  dataset_name: 3Mkeys-string-1KiB-size-randomdata
+  dataset_description: |
+    3 million string keys, each with a 1024-byte random (incompressible)
+    value (~3 GB dataset). Sized so a bgsave child lives for tens of seconds
+    on the runner disks while 100%-writes traffic dirties pages under it —
+    large enough for meaningful fork/CoW cost, small enough that a 600s
+    window averages many fork cycles and primary + replica + CoW headroom
+    stay small relative to runner memory.
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone-01-replicas
+- oss-standalone-01-replicas-rdb
+- oss-standalone-01-replicas-aof-everysec
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "1024" -R --command "SET __key__ __data__" --command-key-pattern
+    R --key-minimum 1 --key-maximum 3000000 --distinct-client-seed --pipeline 10
+    --rate-limiting 200 -c 25 -t 8 --test-time 600 --hide-histogram'
+  resources:
+    requests:
+      cpus: '8'
+      memory: 1g
+tested-groups:
+- string
+priority: 17

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10.yml
@@ -1,0 +1,86 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10
+description: |
+  100%-writes saturation benchmark: uniform-random SET overwrites of a fully
+  preloaded 3M-key keyspace of RAW-encoded strings (1024B incompressible
+  values, ~3 GB resident dataset), 600s steady state. Metric of interest is
+  Ops/sec — the workload continuously dirties pages across the whole dataset,
+  which is what makes the write path sensitive to background persistence
+  (fork + copy-on-write during RDB snapshot) and to the replication stream
+  fan-out. Closed-loop pipelined load; per-command latency percentiles are
+  batch latencies here, not the headline (use the rate-limited sibling spec
+  for tail-latency-under-fixed-load).
+
+  Persistence policy is pinned per setup, not by this spec: the spec resets
+  snapshotting (save "" — note redis save semantics: first save directive
+  resets, later ones append) and each setup in redis-topologies re-enables its
+  own policy via topology redis_arguments, which the coordinator appends after
+  the spec parameters. On oss-standalone-01-replicas-rdb the effective config
+  is a single 10s/1000-changes save point: with a ~3 GB dataset the bgsave
+  child runs for tens of seconds on the runner disks, so snapshots are
+  effectively near-continuous (cadence = child duration + 10s; a 600s window
+  averages ~10+ fork/CoW cycles, amortizing the variable first-fork offset —
+  bgsaves also fire during preload, so a setup-phase child may still be
+  running when measurement starts). The plain oss-standalone-01-replicas cell
+  is the persistence-free baseline; both cells use identical cpu allocations
+  (primary 1 core, replica 1 core; the fork child shares the primary core by
+  design). rdbcompression is pinned off (values are incompressible; LZF would
+  only add version-dependent child CPU). Replica disconnect cascades are
+  pinned away (client-output-buffer-limit replica 2GB, repl-backlog-size
+  256mb) so a replica stall cannot force a mid-run full resync; any datapoint
+  with a nonzero mid-bench full-sync count should be discarded in analysis.
+  Values use -R (random bytes) so RDB/replication payload sizes are realistic,
+  with the default constant seed for A/B reproducibility and
+  --distinct-client-seed to avoid lockstep clients. NOTE: the server data dir
+  is a bind mount on the runner root volume — persistence I/O hits the real
+  disk.
+dbconfig:
+  # Preload BEFORE replicas spin up so the dataset transfers via one initial
+  # full sync and the measured phase is pure steady-state write traffic.
+  preload_before_replica: true
+  configuration-parameters:
+    save: '""'
+    maxmemory-policy: noeviction
+    rdbcompression: 'no'
+    repl-backlog-size: 256mb
+    client-output-buffer-limit: 'replica 2048mb 2048mb 120'
+  check:
+    keyspacelen: 3000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 1024 -R --ratio 1:0 -n allkeys --pipeline 50 --key-maximum
+      3000000 --key-pattern P:P --key-minimum 1 --hide-histogram -t 8 -c 25
+  resources:
+    requests:
+      memory: 6g
+  dataset_name: 3Mkeys-string-1KiB-size-randomdata
+  dataset_description: |
+    3 million string keys, each with a 1024-byte random (incompressible)
+    value (~3 GB dataset). Sized so a bgsave child lives for tens of seconds
+    on the runner disks while 100%-writes traffic dirties pages under it —
+    large enough for meaningful fork/CoW cost, small enough that a 600s
+    window averages many fork cycles and primary + replica + CoW headroom
+    stay small relative to runner memory.
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone-01-replicas
+- oss-standalone-01-replicas-rdb
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "1024" -R --command "SET __key__ __data__" --command-key-pattern
+    R --key-minimum 1 --key-maximum 3000000 --distinct-client-seed --pipeline 10
+    -c 25 -t 8 --test-time 600 --hide-histogram'
+  resources:
+    requests:
+      cpus: '8'
+      memory: 1g
+tested-groups:
+- string
+priority: 17

--- a/utils/tests/test_self_contained_coordinator.py
+++ b/utils/tests/test_self_contained_coordinator.py
@@ -165,6 +165,8 @@ def test_preload_before_replica_default_off():
         "memtier_benchmark-20Mkeys-load-string-with-1KiB-values-replica-only-parallel-fullsync-04.yml",
         "memtier_benchmark-20Mkeys-load-string-with-1KiB-values-replica-only-parallel-fullsync-04-16cpu.yml",
         "memtier_benchmark-20Mkeys-load-string-with-1KiB-values-replica-only-parallel-fullsync-08-16cpu.yml",
+        "memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10.yml",
+        "memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10-rate-limited-40Kops.yml",
     }
     assert (
         set(enabled_specs) == expected


### PR DESCRIPTION
## What

Adds the first setups that combine **replication with persistence**, and two 100%-writes specs that exercise them:

**Setups** (`topologies.yml`):
- `oss-standalone-01-replicas-rdb` — 1 primary + 1 replica, `--save 10 1000`
- `oss-standalone-01-replicas-aof-everysec` — 1 primary + 1 replica, `--appendonly yes --appendfsync everysec`

cpus/memory are identical to the plain `oss-standalone-01-replicas` setup, so the persistence cells are directly comparable to that baseline (primary 1 core, replica 1 core; the bgsave/AOF-rewrite fork child deliberately shares the primary's cpuset — that contention is part of what these setups measure). The policy is encoded in the setup name because deployment names are the comparison key in the results TSDB.

**Specs** (both: uniform-random SET overwrites of a fully-preloaded 3M-key × 1KiB incompressible keyspace, 600s steady state, 8-core client):
- `memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10` — free-running saturation (Ops/sec headline), baseline + `-rdb` cells
- `memtier_benchmark-3Mkeys-string-set-1KiB-pipeline-10-rate-limited-40Kops` — open-loop fixed offered load (`--rate-limiting 200` × 200 conns = 40K ops/s; p50/p99 headline), baseline + `-rdb` + `-aof-everysec` cells. Rate-limiting keeps the AOF byte-rate (~44 MB/s per instance, primary+replica) under the runner disk ceiling — a free-running AOF cell just measures the volume — and avoids coordinated omission during fork/fsync stalls, which is exactly when a closed-loop run stops sending.

## Why

Coverage gap: no registered spec measures write throughput with a live replica and/or persistence enabled. The only replica-topology specs are the full-sync-time benchmarks (whose measured phase is read-only), and no spec enables RDB or AOF at all — so a write-path regression that only manifests under snapshotting or fsync is currently invisible to the suite.

## Design notes

- **`save` semantics are load-bearing**: redis `save` is reset-then-append, not last-wins. The spec-level `save: '""'` (emitted before topology `redis_arguments`) resets, then the topology's `--save 10 1000` appends exactly one save point. The topology comment documents that specs using `-rdb` must set `save: '""'`.
- Both specs pin `rdbcompression no` (values are incompressible via `-R`), `client-output-buffer-limit 'replica 2048mb 2048mb 120'` and `repl-backlog-size 256mb` so a replica stall cannot force a mid-run full resync and crater a datapoint.
- Preload runs before replica spin-up (`preload_before_replica: true`, same as the full-sync specs) so measurement starts from a synced steady state; the CI allowlist test is updated accordingly.
- Version bumped to 0.3.26 (new setups/specs need a release + coordinator update to be runnable on the fleet).

## Tests

`utils/tests/test_self_contained_coordinator.py`, `test_spec.py`, `test_topologies.py` — 34 passed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML topology and benchmark spec additions plus a minor validator fix; no coordinator or runtime code changes beyond test allowlist updates.
> 
> **Overview**
> Adds **replication + persistence** deployment cells and benchmarks so write-path cost under RDB/AOF is visible in the suite. Package version is bumped to **0.3.26** for fleet rollout.
> 
> **Topologies:** New `oss-standalone-01-replicas-rdb` (`--save 10 1000`) and `oss-standalone-01-replicas-aof-everysec` (`--appendonly yes --appendfsync everysec`), with the same CPU/memory as `oss-standalone-01-replicas`. Inline comments document how spec `save: '""'` plus topology `redis_arguments` compose (reset-then-append `save` semantics).
> 
> **New specs:** Two 3M-key × 1KiB random **100% SET** workloads with `preload_before_replica: true`, shared db tuning (no RDB compression, large replica output buffers), and baseline vs persistence topologies. Saturation spec (`…-pipeline-10`) targets **Ops/sec** on baseline + RDB. Rate-limited sibling (`…-rate-limited-40Kops`, 40K ops/s open loop) targets **p50/p99** on baseline, RDB, and AOF-everysec.
> 
> **Other:** `memtier_benchmark-2000conns-client-list` adds `ping` to `tested-commands` for validator compliance. Coordinator test allowlist for `preload_before_replica` includes the two new specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3859af27a8464badf891eadc8201ee0a034e69e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->