### PR TITLE
test-suites: add XREVRANGE reverse-range read coverage (5/20/50 fields)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-stream-10K-entries-20-fields-8B-xrevrange-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-stream-10K-entries-20-fields-8B-xrevrange-count-100.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-1key-stream-10K-entries-20-fields-8B-xrevrange-count-100
+description: 'Runs memtier_benchmark, pre-loading a single stream key with 10K entries via XADD, each with 20 fields of 8B values, then testing XREVRANGE COUNT 100 for 60 seconds. XREVRANGE + - is stateless (re-reads the newest 100 entries every call), so the stream never drains. Node packing is pinned (stream-node-max-entries 100, stream-node-max-bytes 0) so the field-count sweep (5/20/50) varies only the fields-per-entry that the reverse iterator seeks back over. Streams have a single encoding (radix tree of listpack macronodes). Metric: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+    stream-node-max-entries: '100'
+    stream-node-max-bytes: '0'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "8" --command "XADD stream-key * field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__" -n 50 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: 1key-stream-10K-entries-20-fields-8B
+  dataset_description: 1 stream key with 10K entries, each with 20 fields holding 8 bytes of data.
+tested-commands:
+- xrevrange
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="XREVRANGE stream-key + - COUNT 100" --hide-histogram --test-time 60 -c 25 -t 4
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- stream
+priority: 95

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-stream-10K-entries-5-fields-8B-xrevrange-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-stream-10K-entries-5-fields-8B-xrevrange-count-100.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-1key-stream-10K-entries-5-fields-8B-xrevrange-count-100
+description: 'Runs memtier_benchmark, pre-loading a single stream key with 10K entries via XADD, each with 5 fields of 8B values, then testing XREVRANGE COUNT 100 for 60 seconds. XREVRANGE + - is stateless (re-reads the newest 100 entries every call), so the stream never drains. Node packing is pinned (stream-node-max-entries 100, stream-node-max-bytes 0) so the field-count sweep (5/20/50) varies only the fields-per-entry that the reverse iterator seeks back over. Streams have a single encoding (radix tree of listpack macronodes). Metric: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+    stream-node-max-entries: '100'
+    stream-node-max-bytes: '0'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "8" --command "XADD stream-key * field __data__ field __data__ field __data__ field __data__ field __data__" -n 50 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: 1key-stream-10K-entries-5-fields-8B
+  dataset_description: 1 stream key with 10K entries, each with 5 fields holding 8 bytes of data.
+tested-commands:
+- xrevrange
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="XREVRANGE stream-key + - COUNT 100" --hide-histogram --test-time 60 -c 25 -t 4
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- stream
+priority: 95

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-stream-10K-entries-50-fields-8B-xrevrange-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-stream-10K-entries-50-fields-8B-xrevrange-count-100.yml
@@ -1,0 +1,38 @@
+version: 0.4
+name: memtier_benchmark-1key-stream-10K-entries-50-fields-8B-xrevrange-count-100
+description: 'Runs memtier_benchmark, pre-loading a single stream key with 10K entries via XADD, each with 50 fields of 8B values, then testing XREVRANGE COUNT 100 for 60 seconds. XREVRANGE + - is stateless (re-reads the newest 100 entries every call), so the stream never drains. Node packing is pinned (stream-node-max-entries 100, stream-node-max-bytes 0) so the field-count sweep (5/20/50) varies only the fields-per-entry that the reverse iterator seeks back over. Streams have a single encoding (radix tree of listpack macronodes). Metric: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+    stream-node-max-entries: '100'
+    stream-node-max-bytes: '0'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "8" --command "XADD stream-key * field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__ field __data__" -n 50 -c 50 -t 4 --hide-histogram'
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: 1key-stream-10K-entries-50-fields-8B
+  dataset_description: 1 stream key with 10K entries, each with 50 fields holding 8 bytes of data.
+tested-commands:
+- xrevrange
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="XREVRANGE stream-key + - COUNT 100" --hide-histogram --test-time 60 -c 25 -t 4
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- stream
+priority: 95


### PR DESCRIPTION
## What

Adds 3 new stream benchmark specs covering **XREVRANGE** reverse-range reads:

- `memtier_benchmark-1key-stream-10K-entries-5-fields-8B-xrevrange-count-100`
- `memtier_benchmark-1key-stream-10K-entries-20-fields-8B-xrevrange-count-100`
- `memtier_benchmark-1key-stream-10K-entries-50-fields-8B-xrevrange-count-100`

## Why

The stream suite already covers forward iteration (`XREAD`/`XREADGROUP`) and `XADD`/`XTRIM`, but there is **no XREVRANGE spec**. Reverse-range reads walk the listpack macronodes in the opposite direction — seeking back over each entry — which is a distinct traversal path from the forward readers and is currently unmeasured.

## Design

- **Field-count sweep (5 / 20 / 50):** the per-entry reverse-seek walks the entry's elements, so a 3-point sweep makes the cost visible as fields-per-entry grows.
- **8B values:** small values keep the reply modest so the reported Ops/sec reflects server-side traversal rather than reply-byte bandwidth.
- **Pinned node packing** (`stream-node-max-entries 100`, `stream-node-max-bytes 0`): the sweep then varies only fields-per-entry, not the rax/node layout.
- **Read-only & stateless:** `XREVRANGE stream-key + - COUNT 100` re-reads the newest 100 entries every call, so the stream never drains.
- **Shared datasets:** each field-count reuses one `dataset_name`; `oss-standalone`, both arches, `priority: 95` (matches the sibling `xread-count-100` spec).

Preload (`-n 50 -c 50 -t 4` = 10K `XADD` to a single literal key) and both client commands were run end-to-end on `memtier_benchmark` locally to confirm they parse on the `:edge` flag set, create exactly 1 key with 10K entries, and return 100-entry windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark specification YAML only; no Redis server or runtime code changes.
> 
> **Overview**
> Adds **three** new memtier stream benchmark specs so **XREVRANGE** reverse-range reads are measured alongside existing forward read/write coverage.
> 
> Each spec preloads one stream with **10K** entries via **XADD**, pins node packing with `stream-node-max-entries` / `stream-node-max-bytes`, and runs stateless `XREVRANGE stream-key + - COUNT 100` for 60s. The only intentional variable across the trio is **fields per entry** (**5**, **20**, **50**) with **8B** values, to expose reverse-iterator cost as entry width grows. Topology, build variants, and `priority: 95` align with sibling stream read specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76fc2f52b45fd776525dbe6252198cef1f51cbe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->