### PR TITLE
test-suites: add benchmark coverage for LSET command

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-growlist-10-elements-lset-listpack-to-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-growlist-10-elements-lset-listpack-to-quicklist.yml
@@ -1,5 +1,5 @@
 version: 0.4
-name: memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist
+name: memtier_benchmark-1key-growlist-10-elements-lset-listpack-to-quicklist
 description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST starts as a small
   listpack (10 elements) and we LSET an element with a value of 9000 Bytes, which is above the
   list-max-listpack-size -2 (8 KiB) node limit and therefore forces a listpack -> quicklist

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist.yml
@@ -1,0 +1,41 @@
+version: 0.4
+name: memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist
+description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST starts as a small
+  listpack (10 elements) and we LSET an element with a value of 9000 Bytes, which is above the
+  list-max-listpack-size -2 (8 KiB) node limit and therefore forces a listpack -> quicklist
+  conversion. This exercises the GROWING branch of the per-call encoding-conversion check
+  (listTypeTryConversionRaw in t_list.c). The first LSET performs the actual conversion; every
+  subsequent LSET still pays the encoding-conversion check on a quicklist. Encoding: listpack -> quicklist.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  resources:
+    requests:
+      memory: 1g
+  init_commands:
+  - '"RPUSH" "growlist:10" "elem000000" "elem000001" "elem000002" "elem000003" "elem000004"
+    "elem000005" "elem000006" "elem000007" "elem000008" "elem000009"'
+  dataset_name: 1key-list-10-elements
+  dataset_description: This dataset contains 1 list key with 10 small elements (listpack encoded).
+tested-groups:
+- list
+tested-commands:
+- lset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="LSET growlist:10 5 __data__" --data-size 9000 --command-key-pattern
+    R  --hide-histogram --test-time 180
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 34

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist.yml
@@ -32,8 +32,8 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="LSET growlist:10 5 __data__" --data-size 9000 --command-key-pattern
-    R  --hide-histogram --test-time 180
+  arguments: --command="LSET growlist:10 5 __data__" --data-size 9000 --hide-histogram
+    --test-time 180
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10-elements-lset-listpack-to-quicklist.yml
@@ -17,8 +17,10 @@ dbconfig:
   init_commands:
   - '"RPUSH" "growlist:10" "elem000000" "elem000001" "elem000002" "elem000003" "elem000004"
     "elem000005" "elem000006" "elem000007" "elem000008" "elem000009"'
-  dataset_name: 1key-list-10-elements
-  dataset_description: This dataset contains 1 list key with 10 small elements (listpack encoded).
+  dataset_name: 1key-growlist-10-elements
+  dataset_description: This dataset contains 1 list key (growlist:10) with 10 small elements
+    (listpack encoded) -- distinct from the 1key-list-10-elements dataset used by the LRANGE
+    siblings, which seeds a different key (list:10) with different values.
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-100-elements-lset-listpack.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-100-elements-lset-listpack.yml
@@ -1,0 +1,54 @@
+version: 0.4
+name: memtier_benchmark-1key-list-100-elements-lset-listpack
+description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST contains 100
+  elements in it and we replace an element in the middle using LSET with a same-sized small value.
+  This exercises the LSET hot path where the per-call encoding-conversion check (listTypeTryConversion
+  in t_list.c) runs but keeps the encoding unchanged. Encoding: listpack (100 elements, fits in single
+  listpack node under list-max-listpack-size -2; the replacement value is 10B so it stays listpack).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  resources:
+    requests:
+      memory: 1g
+  init_commands:
+  - '"LPUSH" "list:100" "vyoomgwuzv" "xamjodnbpf" "ewomnmugfa" "ljcgdooafo" "pcxdhdjwnf"
+    "djetcyfxuc" "licotqplim" "alqlzsvuuz" "ijsmoyesvd" "whmotknaff" "rkaznetutk"
+    "ksqpdywgdd" "gorgpnnqwr" "gekntrykfh" "rjkknoigmu" "luemuetmia" "gxephxbdru"
+    "ncjfckgkcl" "hhjclfbbka" "cgoeihlnei" "zwnitejtpg" "upodnpqenn" "mibvtmqxcy"
+    "htvbwmfyic" "rqvryfvlie" "nxcdcaqgit" "gfdqdrondm" "lysbgqqfqw" "nxzsnkmxvi"
+    "nsxaigrnje" "cwaveajmcz" "xsepfhdizi" "owtkxlzaci" "agsdggdghc" "tcjvjofxtd"
+    "kgqrovsxce" "ouuybhtvyb" "ueyrvldzwl" "vpbkvwgxsf" "pytrnqdhvs" "qbiwbqiubb"
+    "ssjqrsluod" "urvgxwbiiz" "ujrxcmpvsq" "mtccjerdon" "xczfmrxrja" "imyizmhzjk"
+    "oguwnmniig" "mxwgdcutnb" "pqyurbvifk" "ccagtnjilc" "mbxohpancs" "lgrkndhekf"
+    "eqlgkwosie" "jxoxtnzujs" "lbtpbknelm" "ichqzmiyot" "mbgehjiauu" "aovfsvbwjg"
+    "nmgxcctxpn" "vyqqkuszzh" "rojeolnopp" "ibhohmfxzt" "qbyhorvill" "nhfnbxqgol"
+    "wkbasfyzqz" "mjjuylgssm" "imdqxmkzdj" "oapbvnisyq" "bqntlsaqjb" "ocrcszcznp"
+    "hhniikmtsx" "hlpdstpvzw" "wqiwdbncmt" "vymjzlzqcn" "hhjchwjlmc" "ypfeltycpy"
+    "qjyeqcfhjj" "uapsgmizgh" "owbbdezgxn" "qrosceblyo" "sahqeskveq" "dapacykoah"
+    "wvcnqbvlnf" "perfwnpvkl" "ulbrotlhze" "fhuvzpxjbc" "holjcdpijr" "onzjrteqmu"
+    "pquewclxuy" "vpmpffdoqz" "eouliovvra" "vxcbagyymm" "jekkafodvk" "ypekeuutef"
+    "dlbqcynhrn" "erxulvebrj" "qwxrsgafzy" "dlsjwmqzhx" "exvhmqxvvp"'
+  dataset_name: 1key-list-100-elements
+  dataset_description: This dataset contains 1 list key with 100 elements.
+tested-groups:
+- list
+tested-commands:
+- lset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="LSET list:100 50 abcdefghij"  --hide-histogram --test-time 180
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 34

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lset-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lset-quicklist.yml
@@ -1,0 +1,44 @@
+version: 0.4
+name: memtier_benchmark-1key-list-10K-elements-lset-quicklist
+description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST contains 10000
+  string elements in it (quicklist encoded, spanning multiple listpack nodes under
+  list-max-listpack-size -2) and we replace an element in the middle using LSET with a small value.
+  This exercises the SHRINKING branch of the per-call encoding-conversion check
+  (listTypeTryConversionRaw in t_list.c): on a quicklist the shrink-check runs on every LSET even
+  though the list stays quicklist. Encoding: quicklist (10,000 elements).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10000
+      --key-minimum 1 -n allkeys --key-prefix "hello" --command-key-pattern S -c 1
+      -t 1 --pipeline 50
+  resources:
+    requests:
+      cpus: '2'
+      memory: 1g
+  dataset_name: 1key-list-10K-elements-string
+  dataset_description: This dataset contains 1 list key with 10,000 string elements.
+tested-groups:
+- list
+tested-commands:
+- lset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="LSET strlist 5000 x"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 34

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lset-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lset-quicklist.yml
@@ -1,11 +1,17 @@
 version: 0.4
 name: memtier_benchmark-1key-list-10K-elements-lset-quicklist
-description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST contains 10000
+description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST contains 9999
   string elements in it (quicklist encoded, spanning multiple listpack nodes under
-  list-max-listpack-size -2) and we replace an element in the middle using LSET with a small value.
-  This exercises the SHRINKING branch of the per-call encoding-conversion check
-  (listTypeTryConversionRaw in t_list.c): on a quicklist the shrink-check runs on every LSET even
-  though the list stays quicklist. Encoding: quicklist (10,000 elements).'
+  list-max-listpack-size -2) and we replace an element in the middle (index 5000) using LSET with a
+  small value. This exercises the SHRINKING branch of the per-call encoding-conversion check
+  (listTypeTryConversionRaw in t_list.c) - on a quicklist the shrink-check runs on every LSET even
+  though the list stays quicklist. Encoding: quicklist (9999 elements). The preload arguments are
+  the ones shared by the whole memtier_benchmark-1key-list-10K-elements-* family (dataset
+  1key-list-10K-elements-string), and with -n allkeys memtier issues key-maximum minus key-minimum
+  requests, so the list holds elements hello1..hello9999 - 9999 rather than a literal 10000. The
+  10K in the test name is the family/dataset label; the element count is kept identical to the
+  sibling LINDEX / LPOS / LINSERT-LREM specs so they all describe the same dataset, and 9999 is
+  far above the quicklist conversion threshold either way.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -22,7 +28,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-string
-  dataset_description: This dataset contains 1 list key with 10,000 string elements.
+  dataset_description: This dataset contains 1 list key with 9999 string elements (hello1..hello9999).
 tested-groups:
 - list
 tested-commands:


### PR DESCRIPTION
Adds three test-case specs for LSET (issue #422), which was the only list command without benchmark coverage. Its per-call encoding-conversion check (t_list.c:lsetCommand) meant regressions were invisible to the suite.

Scenarios:
- 100-element listpack, LSET in place (no encoding change hot path)
- 10-element listpack LSET with 9000B value forcing listpack->quicklist (GROWING branch)
- 10K-element quicklist LSET with small value (SHRINKING branch)

Verified locally: all three run end-to-end against Redis 7.4.9, encodings confirmed via OBJECT ENCODING, LSET traffic confirmed in result stats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only new benchmark YAML definitions; no production code, auth, or infrastructure changes.
> 
> **Overview**
> Adds **three new memtier_benchmark test-suite YAML specs** so **`LSET`** is covered in the Redis benchmarks suite (closes the gap called out in #422).
> 
> The specs target **`listTypeTryConversion`** behavior on **`LSET`**: a **100-element listpack** with in-place small replacement (encoding unchanged), a **10-element listpack** forced to **quicklist** via a **9000B** value (GROWING conversion), and a **~10K-element quicklist** with a small **LSET** (SHRINKING check path). The large-list case reuses the existing **`1key-list-10K-elements-string`** preload pattern used by sibling list benchmarks.
> 
> All three follow the usual **oss-standalone** topology, **gcc/dockerhub** build variants, and **priority 34**—benchmark-only additions with no runner or Redis code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518da2b89e6e2098b011b097299ac99236016eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->