### PR TITLE
test-suites: add stream consumer-group PEL coverage (XPENDING / XCLAIM / XACK)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xack.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xack.yml
@@ -1,0 +1,68 @@
+version: 0.4
+name: memtier_benchmark-stream-100Kentries-pel-xack
+description: >
+  Measures the XACK (acknowledge / remove-from-PEL) settlement hot path as a
+  fixed-work drain of a large, pre-populated consumer-group PEL. Pre-loads 100K
+  stream entries with deterministic IDs (1-0..100000-0) via XADD, creates one
+  consumer group, and delivers all 100K entries to consumer1 via XREADGROUP (no
+  ACK), so the group PEL starts fully populated. The benchmark then acknowledges
+  every pending entry exactly once: `XACK stream-key g1 <id>` with the target ID
+  walked sequentially over [1,100000] via the __key__-0 pattern (`P`), `-n 100000`.
+  Because each ID is acked once, EVERY call is a hit that performs the real
+  settlement work — unlink the streamNACK from both the group `pel` rax and the
+  owning consumer `pel` rax. A single client (`-c 1 -t 1`) is used deliberately:
+  XACK is destructive, so concurrent clients over the same ID range would race
+  and collapse into the O(1) already-acked miss path; a single sequential drainer
+  keeps the run a clean 100%-hit measurement of the settlement path. `--pipeline 16`
+  amortises the client/server round-trip so the reported Ops/sec reflects
+  server-side XACK cost rather than network latency. This is fixed-work (not
+  `--test-time`) because XACK cannot be a steady-state workload — its targets are
+  consumed; the model mirrors a real consumer draining its pending backlog. This
+  is the first benchmark coverage of the XACK path. Primary metric is Ops/sec.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key __key__-0 field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum=100000 --key-prefix="" -n 100000 -c 1 -t 1 --hide-histogram'
+  init_commands:
+    - XGROUP CREATE stream-key g1 0 MKSTREAM
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: stream-100k-det-ids-pel-100k-1group-1consumer
+  dataset_description: A stream with 100K deterministic-ID entries (1-0..100000-0) and one consumer group whose single consumer holds all 100K entries in its PEL (unacked). Designed to measure the XACK settlement path as a single-pass drain of a large populated PEL.
+tested-commands:
+  - xack
+tested-groups:
+  - stream
+redis-topologies:
+  - oss-standalone
+build-variants:
+  - gcc:15.2.0-amd64-debian-bookworm-default
+  - gcc:15.2.0-arm64-debian-bookworm-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size 100
+    --command="XACK stream-key g1 __key__-0" --command-key-pattern="P" --key-minimum=1 --key-maximum=100000 --key-prefix=""
+    --pipeline 16
+    --hide-histogram
+    -n 100000
+    -c 1
+    -t 1
+  resources:
+    requests:
+      cpus: "4"
+      memory: 2g
+priority: 95

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xclaim.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xclaim.yml
@@ -1,0 +1,64 @@
+version: 0.4
+name: memtier_benchmark-stream-100Kentries-pel-xclaim
+description: >
+  Measures the XCLAIM (claim/transfer) hot path over a large, pre-populated
+  consumer-group PEL. Pre-loads 100K stream entries with deterministic IDs
+  (1-0..100000-0) via XADD, creates one consumer group, and delivers all 100K
+  entries to consumer1 via XREADGROUP (no ACK), so the group PEL starts fully
+  populated. The benchmark runs
+  `XCLAIM stream-key g1 consumer2 0 <id>` with the target ID drawn uniformly at
+  random from [1,100000] via the __key__-0 pattern. min-idle-time 0 always
+  matches, so each call performs the full streamNACK lookup + owner move
+  (consumer1/consumer2 PEL update) + delivery-count/idle refresh. XCLAIM does NOT
+  remove entries from the group PEL, so this workload is NON-depleting: the PEL
+  stays at 100K for the entire run and every call hits a live pending entry
+  (re-claiming an entry already owned by consumer2 still does the full lookup +
+  update path). This is the first benchmark coverage of the XCLAIM path. Primary
+  metric is Ops/sec. Underlying structure exercised: streamNACK lookup in the
+  group `pel` rax, per-consumer `pel` rax move, and consumer create/lookup.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key __key__-0 field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum=100000 --key-prefix="" -n 100000 -c 1 -t 1 --hide-histogram'
+  init_commands:
+    - XGROUP CREATE stream-key g1 0 MKSTREAM
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: stream-100k-det-ids-pel-100k-1group-1consumer
+  dataset_description: A stream with 100K deterministic-ID entries (1-0..100000-0) and one consumer group whose single consumer holds all 100K entries in its PEL (unacked). Designed to measure the XCLAIM claim/transfer path against a large populated PEL.
+tested-commands:
+  - xclaim
+tested-groups:
+  - stream
+redis-topologies:
+  - oss-standalone
+build-variants:
+  - gcc:15.2.0-amd64-debian-bookworm-default
+  - gcc:15.2.0-arm64-debian-bookworm-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size 100
+    --command="XCLAIM stream-key g1 consumer2 0 __key__-0" --command-key-pattern="R" --key-minimum=1 --key-maximum=100000 --key-prefix=""
+    --hide-histogram
+    --test-time 120
+    -c 50
+    -t 4
+  resources:
+    requests:
+      cpus: "4"
+      memory: 2g
+priority: 95

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xpending-idle-scan.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xpending-idle-scan.yml
@@ -1,0 +1,65 @@
+version: 0.4
+name: memtier_benchmark-stream-100Kentries-pel-xpending-idle-scan
+description: >
+  Measures the PEL-size-proportional forward-scan cost of the XPENDING IDLE range
+  form. Pre-loads 100K stream entries with deterministic IDs (1-0..100000-0) via
+  XADD, creates one consumer group, and delivers all 100K entries to a single
+  consumer via XREADGROUP (no ACK), so the group PEL holds 100K pending entries.
+  The benchmark runs `XPENDING stream-key g1 IDLE 3600000 - + 1000`. The IDLE
+  threshold (3,600,000 ms = 1 h) is set far above any idle-time reachable within
+  the run (entries are at most ~a few minutes idle), so the predicate matches
+  NOTHING and every call must walk the entire 100K-entry group PEL from `-` to
+  `+` before returning empty. This isolates the pure forward-scan cost of the PEL
+  rax and makes it proportional to PEL size (unlike a low-IDLE call, which
+  collects `count` matches and stops after O(count) work). Verified locally to be
+  ~80x slower than the count-bounded IDLE 0 form on a 50K PEL. Primary metric is
+  Ops/sec (lower = more expensive scan). Entries are never acked or claimed, so
+  the PEL stays fully populated and the full scan runs on every call. Underlying
+  structure exercised: full forward iteration of the group `pel` rax with the
+  streamNACK idle-time predicate.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key __key__-0 field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum=100000 --key-prefix="" -n 100000 -c 1 -t 1 --hide-histogram'
+  init_commands:
+    - XGROUP CREATE stream-key g1 0 MKSTREAM
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: stream-100k-det-ids-pel-100k-1group-1consumer
+  dataset_description: A stream with 100K deterministic-ID entries (1-0..100000-0) and one consumer group whose single consumer holds all 100K entries in its PEL (unacked). Designed to measure the XPENDING IDLE full-PEL forward scan against a large populated PEL.
+tested-commands:
+  - xpending
+tested-groups:
+  - stream
+redis-topologies:
+  - oss-standalone
+build-variants:
+  - gcc:15.2.0-amd64-debian-bookworm-default
+  - gcc:15.2.0-arm64-debian-bookworm-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size 100
+    --command="XPENDING stream-key g1 IDLE 3600000 - + 1000" --command-key-pattern="P"
+    --hide-histogram
+    --test-time 120
+    -c 50
+    -t 4
+  resources:
+    requests:
+      cpus: "4"
+      memory: 2g
+priority: 95

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xpending-summary.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-stream-100Kentries-pel-xpending-summary.yml
@@ -1,0 +1,63 @@
+version: 0.4
+name: memtier_benchmark-stream-100Kentries-pel-xpending-summary
+description: >
+  Baseline reference for the XPENDING summary form over a large, pre-populated
+  consumer-group PEL. Pre-loads 100K stream entries with deterministic IDs
+  (1-0..100000-0) via XADD, creates one consumer group, and delivers all 100K
+  entries to a single consumer via XREADGROUP (no ACK), so the group PEL holds
+  100K pending entries for the whole run. The benchmark runs the summary form
+  `XPENDING stream-key g1`, which returns the total pending count, the min/max
+  pending IDs and the per-consumer breakdown. This form is O(1) on the group
+  (it reads the PEL rax size + first/last IDs and iterates the small consumer
+  set), so at pipeline=1 it is round-trip-bound and serves as the cheap baseline
+  against which the PEL-size-proportional IDLE scan (companion
+  `...-pel-xpending-idle-scan` spec) is contrasted; primary metric is Ops/sec.
+  No entries are acked or claimed, so the PEL stays fully populated. Underlying
+  structure exercised: the group `pel` rax (size + endpoints) and per-consumer
+  aggregation.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "XADD stream-key __key__-0 field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum=100000 --key-prefix="" -n 100000 -c 1 -t 1 --hide-histogram'
+  init_commands:
+    - XGROUP CREATE stream-key g1 0 MKSTREAM
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+    - XREADGROUP GROUP g1 consumer1 COUNT 20000 STREAMS stream-key >
+  resources:
+    requests:
+      memory: 4g
+  dataset_name: stream-100k-det-ids-pel-100k-1group-1consumer
+  dataset_description: A stream with 100K deterministic-ID entries (1-0..100000-0) and one consumer group whose single consumer holds all 100K entries in its PEL (unacked). Designed to measure XPENDING against a large populated PEL.
+tested-commands:
+  - xpending
+tested-groups:
+  - stream
+redis-topologies:
+  - oss-standalone
+build-variants:
+  - gcc:15.2.0-amd64-debian-bookworm-default
+  - gcc:15.2.0-arm64-debian-bookworm-default
+  - dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: >
+    --data-size 100
+    --command="XPENDING stream-key g1" --command-key-pattern="P"
+    --hide-histogram
+    --test-time 120
+    -c 50
+    -t 4
+  resources:
+    requests:
+      cpus: "4"
+      memory: 2g
+priority: 95


### PR DESCRIPTION
## Summary

Adds first-time benchmark coverage for the stream **consumer-group settlement / inspection** commands — `XPENDING`, `XCLAIM`, `XACK` — over a **pre-populated PEL**. Closes #443.

Today the stream family is well covered on the producer/consumer path (`XADD`/`XREADGROUP`/`XDEL` via the `*-xreadgroup-*` and `*-cgroups-*` suites) but has **zero** coverage for the PEL settlement/inspection path. Grep confirms it: `xpending`, `xack`, `xclaim` appear in **0** specs before this PR.

## Shared setup (all 4 specs)

- Preload **100K entries with deterministic IDs** `1-0..100000-0` via `XADD stream-key __key__-0` (`P` pattern, single client so IDs don't collide) — the same proven pattern as `memtier_benchmark-stream-50-cgroups-xadd-xreadgroup-xdel.yml`.
- `init_commands` run **after** preload, so they fill the PEL: `XGROUP CREATE` + `XREADGROUP … COUNT 20000 ×5` (no ACK) → one group whose single consumer holds all 100K entries pending.
- `keyspacelen: 1` (one stream key), standalone, priority 95, `gcc-15.2.0` amd64/arm64 + dockerhub.

## The four specs

| Spec | Client command | What it measures |
|---|---|---|
| `…-pel-xpending-summary` | `XPENDING stream-key g1` | O(1) summary form — round-trip-bound **baseline** for the scan contrast |
| `…-pel-xpending-idle-scan` | `XPENDING stream-key g1 IDLE 3600000 - + 1000` | **Full-PEL forward scan**: the 1 h IDLE threshold matches nothing, so every call walks all 100K NACKs → cost ∝ PEL size (measured ~80–150× slower than the count-bounded `IDLE 0` form) |
| `…-pel-xclaim` | `XCLAIM stream-key g1 consumer2 0 <id∈[1,100000]>` | Claim/transfer hot path. `min-idle 0` always matches; XCLAIM never removes, so this is **non-depleting** — the PEL stays at 100K for the whole `--test-time` run |
| `…-pel-xack` | `XACK stream-key g1 <id∈[1,100000]>`, `-n 100000 -c 1 -t 1 --pipeline 16` | **Fixed-work single-pass drain**: each ID acked exactly once → 100% hits on the real settlement path (unlink from group + consumer PEL rax), PEL 100000→0 |

## Design notes

- **`XACK` is fixed-work, not `--test-time`.** XACK is destructive — under a steady-state run its targets are consumed within seconds and the rest of the run measures the O(1) already-acked miss path. A single-client `-n` drain keeps it a clean 100%-hit measurement of the settlement path (memtier emits the same result JSON as a timed run, as the preload step already relies on). Concurrent drainers would collide into the miss path, hence one client.
- **`XPENDING` scan cost is forced with a high `IDLE` threshold**, not by returning a large reply — this isolates the PEL forward-scan (proportional to PEL size) rather than the count-bounded reply build.
- **Each spec measures exactly one command** (`tested-commands` matches the single client command); XADD/XGROUP/XREADGROUP are setup only. Splitting XCLAIM and XACK into separate specs is deliberate: memtier's `--key-minimum/--key-maximum` are **global**, so a single spec cannot give two commands disjoint ID ranges.
- The issue mentioned an optional `preload_pause_seconds` coordinator knob. It's intentionally **not** needed here: the `init_commands`-after-preload ordering populates the PEL declaratively, and the idle-scan spec forces a full scan via the IDLE threshold rather than by aging entries — so all four specs run on the currently-deployed coordinator with no engine change.

## Validation

- `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` → passes (exit 0); `name:` equals filename for all four.
- Functionally verified end-to-end against a local server at 100K scale: PEL populates to 100000; summary is fast; idle-scan is ~80–150× slower (full scan); XCLAIM leaves the PEL at 100K (non-depleting); XACK drains 100000→0 at 100% hits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark YAML additions only; no Redis or coordinator code changes, only new CI benchmark coverage.
> 
> **Overview**
> Adds **four new memtier benchmark specs** that cover Redis stream **consumer-group PEL** inspection and settlement (`XPENDING`, `XCLAIM`, `XACK`) for the first time in this repo.
> 
> All specs share the same **100K-entry stream** setup: deterministic `XADD` IDs, `XGROUP CREATE`, then five `XREADGROUP` batches (no ACK) so one consumer holds a full **100K-entry PEL**. They target **oss-standalone**, priority **95**, and the usual gcc/dockerhub build matrix.
> 
> The measured workloads differ by command: **`…-xpending-summary`** runs the O(1) `XPENDING` summary as a cheap baseline; **`…-xpending-idle-scan`** uses `XPENDING … IDLE 3600000` so every call does a **full PEL forward scan**; **`…-xclaim`** runs steady-state random `XCLAIM` transfers (non-depleting PEL); **`…-xack`** is a **fixed-work** single-client sequential drain (`-n 100000`, pipeline 16) so each `XACK` hits real settlement work without racing on already-acked IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b76c2b2dc9416aaf6385c99cb360ce1a64338c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->