### PR TITLE
ci: wire tox job to matrix.os so the os axis actually takes effect

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,7 +19,7 @@ jobs:
       USING_COVERAGE_OS: "ubuntu-latest"
       TOX_DOCKER_GATEWAY: localhost
 
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
     name: os ${{ matrix.os }} python ${{ matrix.python-version }} Linting, testing, and compliance
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Fixes #451.

`tox.yml` declares a two-value `os` matrix axis but hard-codes `runs-on: "ubuntu-latest"`. `matrix.os` was referenced only in the job `name` and in the codecov upload condition, so all six jobs ran on `ubuntu-latest`:

- three of the six configurations were duplicates — roughly 2× runner minutes for no extra coverage;
- `ubuntu-24.04` was never actually exercised;
- the checks list showed an `ubuntu-24.04` job as green, which read as coverage that did not exist.

One line: `runs-on: ${{ matrix.os }}`.

Worth flagging for the reviewer: this genuinely doubles the distinct configurations being tested, so it is possible `ubuntu-24.04` surfaces a pre-existing failure that was previously invisible. That would be the fix doing its job, but it may need a follow-up rather than a revert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line workflow fix with no application or secrets changes; main effect is more CI surface area on ubuntu-24.04, which may expose existing environment issues.
> 
> **Overview**
> **Fixes #451.** The tox workflow defined an `os` matrix (`ubuntu-latest`, `ubuntu-24.04`) but every job used `runs-on: "ubuntu-latest"`, so half the matrix was redundant and `ubuntu-24.04` never ran despite appearing in job names.
> 
> **`runs-on` is now `${{ matrix.os }}`**, so all six Python × OS combinations run on the intended runner. That removes duplicate jobs, stops wasting runner minutes, and actually exercises `ubuntu-24.04`. Codecov upload is unchanged (still gated on `USING_COVERAGE_OS` / `ubuntu-latest` only).
> 
> **Reviewer note:** distinct coverage doubles on the OS axis; a failure on `ubuntu-24.04` may be newly visible rather than introduced by this line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd86cb8118f53c0a526969828d9beb4babc8650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->