### PR TITLE
fix(api): benchmark the baseline commit, not the head commit, on push events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.29"
+version = "0.3.30"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__api__/app.py
+++ b/redis_benchmarks_specification/__api__/app.py
@@ -146,6 +146,11 @@ def create_app(conn, user, test_config=None):
                 ref_label = request_data["ref"]
                 sha = request_data["after"]
                 before_sha = request_data["before"]
+                # GitHub sends an all-zero "before" when a ref is created, and an all-zero
+                # "after" when one is deleted -- neither names a commit that can be built.
+                # Treat the sentinel as absent so no baseline entry is enqueued for it.
+                if before_sha is not None and set(before_sha) == {"0"}:
+                    before_sha = None
 
                 allowed_orgs = [
                     o.strip() for o in BENCHMARK_TRIGGER_ORGS.split(",") if o.strip()
@@ -196,7 +201,12 @@ def create_app(conn, user, test_config=None):
                 # against the full-suite baseline of the corresponding subset.
                 if before_sha is not None:
                     fields_before = {
-                        "git_hash": sha,
+                        # before_sha, not sha: this entry exists to benchmark the commit the
+                        # push moved *from*, so the scoped head run has something to compare
+                        # against. Sending sha here made it a duplicate of the head entry,
+                        # so the baseline commit was never benchmarked and every push
+                        # enqueued the same commit twice.
+                        "git_hash": before_sha,
                         "ref_label": ref_label,
                         "ref": ref,
                         "gh_repo": gh_repo,

--- a/redis_benchmarks_specification/__api__/app.py
+++ b/redis_benchmarks_specification/__api__/app.py
@@ -203,43 +203,13 @@ def create_app(conn, user, test_config=None):
                         BENCHMARK_PR_MAX_FILES,
                     )
                     app.logger.info(scope_msg)
-                # NOTE: scope_fields is only ever non-empty for labeled-PR events. The
-                # merge-base baseline below runs on PUSH events (where there is no PR),
-                # so it is intentionally NOT scoped — scoped PR-head runs are compared
-                # against the full-suite baseline of the corresponding subset.
-                if before_sha is not None:
-                    fields_before = {
-                        # before_sha, not sha: this entry exists to benchmark the commit the
-                        # push moved *from*, so the scoped head run has something to compare
-                        # against. Sending sha here made it a duplicate of the head entry,
-                        # so the baseline commit was never benchmarked and every push
-                        # enqueued the same commit twice.
-                        "git_hash": before_sha,
-                        "ref_label": ref_label,
-                        "ref": ref,
-                        "gh_repo": gh_repo,
-                        "gh_org": gh_org,
-                    }
-                    app.logger.info(
-                        "Using event {} to trigger previous-tip baseline benchmark. final fields: {}".format(
-                            event_type, fields_before
-                        )
-                    )
-                    result, response_data, err_message = commit_schema_to_stream(
-                        fields_before, conn, gh_org, gh_repo
-                    )
-                    if result is False:
-                        app.logger.error(
-                            "Baseline commit {} could not be enqueued: {}".format(
-                                before_sha, err_message
-                            )
-                        )
-                    else:
-                        app.logger.info(
-                            "Using event {} to trigger previous-tip baseline benchmark. final fields: {}".format(
-                                event_type, response_data
-                            )
-                        )
+                # The head entry is enqueued FIRST, deliberately. Each entry occupies a
+                # platform for a full suite and the queue is oversubscribed, so whichever
+                # entry is enqueued second is the one that starves. Enqueuing the head first
+                # keeps the newest point on by.branch/<branch> equal to the branch tip: the
+                # coordinator baselines every automated regression table on that series'
+                # single newest point (self_contained_coordinator.py:2930,2939), so a starved
+                # head would silently baseline PRs against the previous commit.
                 if sha is None:
                     app.logger.info(
                         "Skipping benchmark trigger for {}: no buildable head commit".format(
@@ -270,6 +240,47 @@ def create_app(conn, user, test_config=None):
                         event_type, response_data
                     )
                 )
+                # The response describes the head entry, which is the primary trigger. The
+                # baseline enqueue below must not overwrite it.
+                head_response_data = response_data
+                # NOTE: scope_fields is only ever non-empty for labeled-PR events. The
+                # merge-base baseline below runs on PUSH events (where there is no PR),
+                # so it is intentionally NOT scoped — scoped PR-head runs are compared
+                # against the full-suite baseline of the corresponding subset.
+                if before_sha is not None:
+                    fields_before = {
+                        # before_sha, not sha: this entry exists to benchmark the commit the
+                        # push moved *from*, so the scoped head run has something to compare
+                        # against. Sending sha here made it a duplicate of the head entry,
+                        # so the baseline commit was never benchmarked and every push
+                        # enqueued the same commit twice.
+                        "git_hash": before_sha,
+                        "ref_label": ref_label,
+                        "ref": ref,
+                        "gh_repo": gh_repo,
+                        "gh_org": gh_org,
+                    }
+                    app.logger.info(
+                        "Using event {} to trigger previous-tip baseline benchmark. final fields: {}".format(
+                            event_type, fields_before
+                        )
+                    )
+                    result, baseline_response, err_message = commit_schema_to_stream(
+                        fields_before, conn, gh_org, gh_repo
+                    )
+                    if result is False:
+                        app.logger.error(
+                            "Baseline commit {} could not be enqueued: {}".format(
+                                before_sha, err_message
+                            )
+                        )
+                    else:
+                        app.logger.info(
+                            "Using event {} to trigger previous-tip baseline benchmark. final fields: {}".format(
+                                event_type, baseline_response
+                            )
+                        )
+                    response_data = head_response_data
             else:
                 app.logger.info(
                     "{}. input json was: {}".format(event_type, request_data)

--- a/redis_benchmarks_specification/__api__/app.py
+++ b/redis_benchmarks_specification/__api__/app.py
@@ -16,6 +16,7 @@ from redis_benchmarks_specification.__common__.env import (
     BENCHMARK_PR_DIFF_SCOPING,
     BENCHMARK_PR_MAX_FILES,
     GH_TOKEN,
+    is_buildable_sha,
 )
 from redis_benchmarks_specification.__common__.scope import compute_pr_scope_fields
 
@@ -144,12 +145,19 @@ def create_app(conn, user, test_config=None):
                 gh_org = html_url[-2]
                 ref = request_data["ref"].split("/")[-1]
                 ref_label = request_data["ref"]
-                sha = request_data["after"]
-                before_sha = request_data["before"]
-                # GitHub sends an all-zero "before" when a ref is created, and an all-zero
-                # "after" when one is deleted -- neither names a commit that can be built.
-                # Treat the sentinel as absent so no baseline entry is enqueued for it.
-                if before_sha is not None and set(before_sha) == {"0"}:
+                sha = request_data.get("after")
+                before_sha = request_data.get("before")
+                # GitHub sends an all-zero sha for the absent end of a ref creation or
+                # deletion, so neither end can be assumed buildable. is_buildable_sha is
+                # non-throwing, so a malformed payload value is rejected rather than 500ing.
+                if not is_buildable_sha(before_sha):
+                    before_sha = None
+                if not is_buildable_sha(sha):
+                    sha = None
+                # A deleted ref has no current tip, and a force-push's "before" is no longer
+                # on the branch -- benchmarking it would attribute a datapoint to a commit the
+                # branch does not contain. Gate on the event's own booleans.
+                if request_data.get("deleted") or request_data.get("forced"):
                     before_sha = None
 
                 allowed_orgs = [
@@ -213,18 +221,32 @@ def create_app(conn, user, test_config=None):
                         "gh_org": gh_org,
                     }
                     app.logger.info(
-                        "Using event {} to trigger merge-base commit benchmark. final fields: {}".format(
+                        "Using event {} to trigger previous-tip baseline benchmark. final fields: {}".format(
                             event_type, fields_before
                         )
                     )
                     result, response_data, err_message = commit_schema_to_stream(
                         fields_before, conn, gh_org, gh_repo
                     )
+                    if result is False:
+                        app.logger.error(
+                            "Baseline commit {} could not be enqueued: {}".format(
+                                before_sha, err_message
+                            )
+                        )
+                    else:
+                        app.logger.info(
+                            "Using event {} to trigger previous-tip baseline benchmark. final fields: {}".format(
+                                event_type, response_data
+                            )
+                        )
+                if sha is None:
                     app.logger.info(
-                        "Using event {} to trigger merge-base commit benchmark. final fields: {}".format(
-                            event_type, response_data
+                        "Skipping benchmark trigger for {}: no buildable head commit".format(
+                            ref_label
                         )
                     )
+                    return jsonify({"message": "no buildable head commit"}), 200
                 fields_after = {
                     "git_hash": sha,
                     "ref_label": ref_label,

--- a/redis_benchmarks_specification/__api__/app.py
+++ b/redis_benchmarks_specification/__api__/app.py
@@ -249,11 +249,7 @@ def create_app(conn, user, test_config=None):
                 # against the full-suite baseline of the corresponding subset.
                 if before_sha is not None:
                     fields_before = {
-                        # before_sha, not sha: this entry exists to benchmark the commit the
-                        # push moved *from*, so the scoped head run has something to compare
-                        # against. Sending sha here made it a duplicate of the head entry,
-                        # so the baseline commit was never benchmarked and every push
-                        # enqueued the same commit twice.
+                        # The previous tip, not the head: the head is enqueued above.
                         "git_hash": before_sha,
                         "ref_label": ref_label,
                         "ref": ref,

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -1,3 +1,4 @@
+import re
 import logging
 import os
 
@@ -145,3 +146,28 @@ if BENCHMARK_PR_DIFF_SCOPING and not GH_TOKEN:
         "BENCHMARK_PR_DIFF_SCOPING is on but GH_TOKEN is unset; PR diff lookups will hit "
         "the 60/hr unauthenticated GitHub limit and degrade to full-suite runs"
     )
+
+
+# Shas that name no commit. GitHub sends an all-zero sha for the absent end of a ref
+# creation or deletion. The same tuple is applied in __runner__/runner.py:1222 and
+# __runner__/remote_profiling.py:113 -- keep the three in step. str() first so a non-string
+# payload value is rejected rather than raising.
+NON_BUILDABLE_SHAS = ("", "0", "00000000")
+
+_FULL_SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
+
+
+def is_buildable_sha(value):
+    """True when `value` is a full hex sha that is not an all-zero sentinel.
+
+    Validates the shape rather than only blacklisting sentinels: the webhook is the only
+    place a malformed hash can be rejected before it becomes a `git_hash` on the stream, and
+    a shape check subsumes the sentinel cases. Deliberately non-throwing -- a non-string
+    payload value must be rejected, not raise, since that would 500 the delivery.
+    """
+    if not isinstance(value, str):
+        return False
+    value = value.strip()
+    if not _FULL_SHA_RE.match(value):
+        return False
+    return value not in NON_BUILDABLE_SHAS and set(value) != {"0"}

--- a/utils/tests/test_app.py
+++ b/utils/tests/test_app.py
@@ -175,9 +175,9 @@ def test_should_action():
     assert should_action("unlabeled") == False
 
 
-def _post_labelled_pr(flask_app, auth_token):
-    with open("./utils/tests/test_data/event_webhook_labelled_pr.json") as fh:
-        req_data = json.dumps(json.load(fh)).encode()
+def _post_event(flask_app, auth_token, payload):
+    """POST a webhook payload, signed the way verify_signature requires."""
+    req_data = json.dumps(payload).encode()
     sign = HMAC(key=auth_token.encode(), msg=req_data, digestmod=sha1).hexdigest()
     with flask_app.test_client() as client:
         return client.post(
@@ -189,6 +189,11 @@ def _post_labelled_pr(flask_app, auth_token):
                 SIG_HEADER: "sha1={}".format(sign),
             },
         )
+
+
+def _post_labelled_pr(flask_app, auth_token):
+    with open("./utils/tests/test_data/event_webhook_labelled_pr.json") as fh:
+        return _post_event(flask_app, auth_token, json.load(fh))
 
 
 # These app-level tests run with NO redis and NO network: a MagicMock conn satisfies
@@ -239,28 +244,12 @@ def test_pr_event_disabled_gate_skips_scoping():
     assert "tests_regexp" not in resp.json
 
 
-def _post_push_event(flask_app, auth_token, payload):
-    """POST a push-event payload, signing it the way the webhook requires."""
-    req_data = json.dumps(payload).encode()
-    sign = HMAC(key=auth_token.encode(), msg=req_data, digestmod=sha1).hexdigest()
-    with flask_app.test_client() as client:
-        return client.post(
-            "/api/gh/redis/redis/commits",
-            content_type="application/json",
-            data=req_data,
-            headers={
-                "Content-type": "application/json",
-                SIG_HEADER: "sha1={}".format(sign),
-            },
-        )
-
-
 def _push_payload(**overrides):
-    """Load the push fixture and make it pass the org/branch allowlists.
+    """Load the push fixture and normalise it to an allowlisted org/branch.
 
-    The fixture is a fork push to a scratch branch, which the trigger gates reject; the
-    gates are not what these tests are about, so normalise the payload rather than patching
-    module constants.
+    Paired with _allowlisted() below: the payload is made to match and the module constants
+    are pinned, so an operator with BENCHMARK_TRIGGER_BRANCHES exported in their shell does
+    not see these tests fail for a reason that has nothing to do with what they assert.
     """
     with open("./utils/tests/test_data/event_webhook_pushed_repo.json") as fh:
         payload = json.load(fh)
@@ -268,6 +257,15 @@ def _push_payload(**overrides):
     payload["repository"]["html_url"] = "https://github.com/redis/redis"
     payload.update(overrides)
     return payload
+
+
+def _allowlisted():
+    """Pin the trigger allowlists so the gates are not an ambient dependency."""
+    return patch.multiple(
+        app_module,
+        BENCHMARK_TRIGGER_ORGS="redis",
+        BENCHMARK_TRIGGER_BRANCHES="unstable",
+    )
 
 
 def test_push_event_baseline_entry_carries_before_sha_not_the_head_sha():
@@ -290,8 +288,10 @@ def test_push_event_baseline_entry_carries_before_sha_not_the_head_sha():
         calls.append(dict(fields))
         return True, dict(fields), None
 
-    with patch.object(app_module, "commit_schema_to_stream", side_effect=_record):
-        resp = _post_push_event(flask_app, auth_token, payload)
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=_record
+    ):
+        resp = _post_event(flask_app, auth_token, payload)
 
     assert resp.status_code == 200
     hashes = [c.get("git_hash") for c in calls]
@@ -318,8 +318,10 @@ def test_push_event_with_created_ref_sentinel_enqueues_only_the_head():
         calls.append(dict(fields))
         return True, dict(fields), None
 
-    with patch.object(app_module, "commit_schema_to_stream", side_effect=_record):
-        resp = _post_push_event(flask_app, auth_token, payload)
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=_record
+    ):
+        resp = _post_event(flask_app, auth_token, payload)
 
     assert resp.status_code == 200
     hashes = [c.get("git_hash") for c in calls]
@@ -347,8 +349,10 @@ def test_deleted_ref_push_enqueues_nothing():
     flask_app, auth_token = _mock_app()
     payload = _push_payload(before="a" * 40, after="0" * 40, deleted=True)
     calls, rec = _record_calls()
-    with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
-        resp = _post_push_event(flask_app, auth_token, payload)
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        resp = _post_event(flask_app, auth_token, payload)
     assert resp.status_code == 200
     assert calls == [], f"deletion enqueued {[c.get('git_hash') for c in calls]}"
 
@@ -358,8 +362,10 @@ def test_forced_push_does_not_benchmark_the_overwritten_commit():
     flask_app, auth_token = _mock_app()
     payload = _push_payload(forced=True)
     calls, rec = _record_calls()
-    with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
-        resp = _post_push_event(flask_app, auth_token, payload)
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        resp = _post_event(flask_app, auth_token, payload)
     assert resp.status_code == 200
     assert [c.get("git_hash") for c in calls] == [payload["after"]]
 
@@ -374,8 +380,10 @@ def test_malformed_before_does_not_500():
     for bad in (0, 12345, True, 1.5, "", []):
         payload = _push_payload(before=bad)
         calls, rec = _record_calls()
-        with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
-            resp = _post_push_event(flask_app, auth_token, payload)
+        with _allowlisted(), patch.object(
+            app_module, "commit_schema_to_stream", side_effect=rec
+        ):
+            resp = _post_event(flask_app, auth_token, payload)
         assert resp.status_code == 200, f"before={bad!r} returned {resp.status_code}"
         assert [c.get("git_hash") for c in calls] == [
             payload["after"]
@@ -393,6 +401,8 @@ def test_head_is_enqueued_before_the_baseline():
     flask_app, auth_token = _mock_app()
     payload = _push_payload()
     calls, rec = _record_calls()
-    with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
-        _post_push_event(flask_app, auth_token, payload)
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        _post_event(flask_app, auth_token, payload)
     assert [c.get("git_hash") for c in calls] == [payload["after"], payload["before"]]

--- a/utils/tests/test_app.py
+++ b/utils/tests/test_app.py
@@ -382,11 +382,17 @@ def test_malformed_before_does_not_500():
         ], f"before={bad!r} enqueued {[c.get('git_hash') for c in calls]}"
 
 
-def test_baseline_is_enqueued_before_the_head():
-    """Order is observable behaviour: the baseline is enqueued first."""
+def test_head_is_enqueued_before_the_baseline():
+    """Order is load-bearing, not cosmetic.
+
+    Each entry occupies a platform for a full suite and the queue is oversubscribed, so the
+    second-enqueued entry is the one that starves. The coordinator baselines every automated
+    regression table on the single newest point of by.branch/<branch>, so if the head starved
+    the baseline would silently become the previous commit.
+    """
     flask_app, auth_token = _mock_app()
     payload = _push_payload()
     calls, rec = _record_calls()
     with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
         _post_push_event(flask_app, auth_token, payload)
-    assert [c.get("git_hash") for c in calls] == [payload["before"], payload["after"]]
+    assert [c.get("git_hash") for c in calls] == [payload["after"], payload["before"]]

--- a/utils/tests/test_app.py
+++ b/utils/tests/test_app.py
@@ -237,3 +237,91 @@ def test_pr_event_disabled_gate_skips_scoping():
     assert resp.status_code == 200
     assert "tests_groups_regexp" not in resp.json
     assert "tests_regexp" not in resp.json
+
+
+def _post_push_event(flask_app, auth_token, payload):
+    """POST a push-event payload, signing it the way the webhook requires."""
+    req_data = json.dumps(payload).encode()
+    sign = HMAC(key=auth_token.encode(), msg=req_data, digestmod=sha1).hexdigest()
+    with flask_app.test_client() as client:
+        return client.post(
+            "/api/gh/redis/redis/commits",
+            content_type="application/json",
+            data=req_data,
+            headers={
+                "Content-type": "application/json",
+                SIG_HEADER: "sha1={}".format(sign),
+            },
+        )
+
+
+def _push_payload(**overrides):
+    """Load the push fixture and make it pass the org/branch allowlists.
+
+    The fixture is a fork push to a scratch branch, which the trigger gates reject; the
+    gates are not what these tests are about, so normalise the payload rather than patching
+    module constants.
+    """
+    with open("./utils/tests/test_data/event_webhook_pushed_repo.json") as fh:
+        payload = json.load(fh)
+    payload["ref"] = "refs/heads/unstable"
+    payload["repository"]["html_url"] = "https://github.com/redis/redis"
+    payload.update(overrides)
+    return payload
+
+
+def test_push_event_baseline_entry_carries_before_sha_not_the_head_sha():
+    """The merge-base entry must name the commit the push moved FROM.
+
+    Both entries previously carried request_data["after"], so the "merge-base commit
+    benchmark" measured the head commit: the baseline commit was never benchmarked and
+    every push enqueued the same commit twice.
+    """
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload()
+    before_sha, head_sha = payload["before"], payload["after"]
+    assert (
+        before_sha != head_sha
+    ), "fixture must have distinct before/after to be meaningful"
+
+    calls = []
+
+    def _record(fields, *args, **kwargs):
+        calls.append(dict(fields))
+        return True, dict(fields), None
+
+    with patch.object(app_module, "commit_schema_to_stream", side_effect=_record):
+        resp = _post_push_event(flask_app, auth_token, payload)
+
+    assert resp.status_code == 200
+    hashes = [c.get("git_hash") for c in calls]
+    assert len(calls) == 2, f"expected a baseline and a head entry, got {hashes}"
+    assert (
+        before_sha in hashes
+    ), f"no entry carries the baseline sha {before_sha}: {hashes}"
+    assert head_sha in hashes, f"no entry carries the head sha {head_sha}: {hashes}"
+    assert hashes[0] != hashes[1], f"both entries carry the same commit: {hashes}"
+
+
+def test_push_event_with_created_ref_sentinel_enqueues_only_the_head():
+    """A ref creation sends an all-zero "before", which names no commit.
+
+    Enqueuing it would ask the builder to fetch a nonexistent archive, so the sentinel
+    must be treated as "no baseline" rather than sent downstream.
+    """
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload(before="0" * 40)
+
+    calls = []
+
+    def _record(fields, *args, **kwargs):
+        calls.append(dict(fields))
+        return True, dict(fields), None
+
+    with patch.object(app_module, "commit_schema_to_stream", side_effect=_record):
+        resp = _post_push_event(flask_app, auth_token, payload)
+
+    assert resp.status_code == 200
+    hashes = [c.get("git_hash") for c in calls]
+    assert "0" * 40 not in hashes, f"all-zero sentinel was enqueued: {hashes}"
+    assert hashes == [payload["after"]], f"expected only the head entry, got {hashes}"

--- a/utils/tests/test_app.py
+++ b/utils/tests/test_app.py
@@ -325,3 +325,68 @@ def test_push_event_with_created_ref_sentinel_enqueues_only_the_head():
     hashes = [c.get("git_hash") for c in calls]
     assert "0" * 40 not in hashes, f"all-zero sentinel was enqueued: {hashes}"
     assert hashes == [payload["after"]], f"expected only the head entry, got {hashes}"
+
+
+def _record_calls():
+    calls = []
+
+    def _rec(fields, *args, **kwargs):
+        calls.append(dict(fields))
+        return True, dict(fields), None
+
+    return calls, _rec
+
+
+def test_deleted_ref_push_enqueues_nothing():
+    """Deleting a ref must not benchmark the tip it just removed.
+
+    A deletion arrives as a push with a real `before` and an all-zero `after`. Repointing the
+    baseline entry at `before` would otherwise turn a harmless no-op into a full-suite run
+    attributed to a ref that no longer exists.
+    """
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload(before="a" * 40, after="0" * 40, deleted=True)
+    calls, rec = _record_calls()
+    with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
+        resp = _post_push_event(flask_app, auth_token, payload)
+    assert resp.status_code == 200
+    assert calls == [], f"deletion enqueued {[c.get('git_hash') for c in calls]}"
+
+
+def test_forced_push_does_not_benchmark_the_overwritten_commit():
+    """A force-push's `before` is no longer on the branch, so it is not a valid baseline."""
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload(forced=True)
+    calls, rec = _record_calls()
+    with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
+        resp = _post_push_event(flask_app, auth_token, payload)
+    assert resp.status_code == 200
+    assert [c.get("git_hash") for c in calls] == [payload["after"]]
+
+
+def test_malformed_before_does_not_500():
+    """A non-string `before` must be rejected, not raise.
+
+    `set(0)` raises TypeError, so a shape-sniffing guard turned four payload types that
+    previously returned 200 into 500s -- on events the allowlist may not even accept.
+    """
+    flask_app, auth_token = _mock_app()
+    for bad in (0, 12345, True, 1.5, "", []):
+        payload = _push_payload(before=bad)
+        calls, rec = _record_calls()
+        with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
+            resp = _post_push_event(flask_app, auth_token, payload)
+        assert resp.status_code == 200, f"before={bad!r} returned {resp.status_code}"
+        assert [c.get("git_hash") for c in calls] == [
+            payload["after"]
+        ], f"before={bad!r} enqueued {[c.get('git_hash') for c in calls]}"
+
+
+def test_baseline_is_enqueued_before_the_head():
+    """Order is observable behaviour: the baseline is enqueued first."""
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload()
+    calls, rec = _record_calls()
+    with patch.object(app_module, "commit_schema_to_stream", side_effect=rec):
+        _post_push_event(flask_app, auth_token, payload)
+    assert [c.get("git_hash") for c in calls] == [payload["before"], payload["after"]]

--- a/utils/tests/test_app.py
+++ b/utils/tests/test_app.py
@@ -406,3 +406,87 @@ def test_head_is_enqueued_before_the_baseline():
     ):
         _post_event(flask_app, auth_token, payload)
     assert [c.get("git_hash") for c in calls] == [payload["after"], payload["before"]]
+
+
+def test_baseline_entry_is_unscoped_and_carries_no_pull_request():
+    """Pin the invariant the code comment states.
+
+    Before the sha fix, "unscoped baseline" and "the head commit again" were the same object,
+    so this invariant was untestable. Now that the baseline names a distinct commit it is
+    load-bearing: if it ever picked up scope fields, every comparison would silently stop
+    being against a full-suite baseline, with a green suite.
+    """
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload()
+    calls, rec = _record_calls()
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        _post_event(flask_app, auth_token, payload)
+    baseline = next(c for c in calls if c["git_hash"] == payload["before"])
+    for key in ("tests_groups_regexp", "tests_regexp", "pull_request"):
+        assert (
+            key not in baseline
+        ), f"baseline entry picked up {key}={baseline.get(key)!r}"
+
+
+def test_baseline_entry_carries_the_fields_the_builder_needs():
+    """Assert the whole baseline payload, not just its git_hash.
+
+    `ref` is what gets checked out and gh_org/gh_repo are what the archive is fetched from, so
+    dropping or transposing any of them ships an entry that cannot build -- previously
+    invisible, since only git_hash was asserted.
+    """
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload()
+    calls, rec = _record_calls()
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        _post_event(flask_app, auth_token, payload)
+    baseline = next(c for c in calls if c["git_hash"] == payload["before"])
+    assert baseline == {
+        "git_hash": payload["before"],
+        "ref_label": payload["ref"],
+        "ref": payload["ref"].split("/")[-1],
+        "gh_repo": "redis",
+        "gh_org": "redis",
+    }
+
+
+def test_a_baseline_sha_beginning_with_zero_is_still_enqueued():
+    """Negative test for the sentinel guard.
+
+    A guard written as `startswith("0")` rather than an all-zero check would silently discard
+    roughly one push in sixteen. The fixture's sha does not start with 0, so without this case
+    that mistake is undetectable.
+    """
+    flask_app, auth_token = _mock_app()
+    payload = _push_payload(before="0" + "a" * 39)
+    calls, rec = _record_calls()
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        _post_event(flask_app, auth_token, payload)
+    assert [c["git_hash"] for c in calls] == [payload["after"], payload["before"]]
+
+
+def test_unallowlisted_push_enqueues_nothing():
+    """The gate that decides whether a fork push spends fleet time must be covered.
+
+    The other push tests normalise the payload past the org/branch allowlists, so without this
+    case a wide-open gate would be invisible. Uses the fixture verbatim -- a fork push to a
+    scratch branch -- and asserts nothing is enqueued.
+    """
+    flask_app, auth_token = _mock_app()
+    with open("./utils/tests/test_data/event_webhook_pushed_repo.json") as fh:
+        payload = json.load(fh)
+    calls, rec = _record_calls()
+    with _allowlisted(), patch.object(
+        app_module, "commit_schema_to_stream", side_effect=rec
+    ):
+        resp = _post_event(flask_app, auth_token, payload)
+    assert resp.status_code == 200
+    assert (
+        calls == []
+    ), f"un-allowlisted push enqueued {[c.get('git_hash') for c in calls]}"


### PR DESCRIPTION
Closes #454.

## The bug

The push handler emits two stream entries — a "merge-base commit benchmark" and the head run — and **both carried `request_data["after"]`**:

```python
sha = request_data["after"]
before_sha = request_data["before"]
...
if before_sha is not None:          # <- only use of before_sha: a None guard
    fields_before = {
        "git_hash": sha,            # <- the HEAD sha
        ...
fields_after = {
    "git_hash": sha,                # <- the same value
```

`before_sha` was computed and then never read. So the baseline entry was a duplicate of the head entry apart from the PR/scope fields.

Two consequences:

1. **The baseline commit was never benchmarked.** The comment above the block describes the intent — *"scoped PR-head runs are compared against the full-suite baseline of the corresponding subset"* — but this path produced no such baseline.
2. **Every push enqueued the same commit twice**, doubling build and benchmark work for no added signal.

The reason it stayed invisible: the log line announces `trigger merge-base commit benchmark` while printing a payload containing the head sha, so nothing looks wrong unless you diff the two emissions.

## The fix

- `fields_before["git_hash"] = before_sha`.
- **Guard the all-zero sentinel.** GitHub sends `before = 000…0` when a ref is created, which names no commit; enqueuing it would ask the builder to fetch an archive that does not exist. The previous guard only checked for `None`.

## Tests

Two tests in `utils/tests/test_app.py`, reusing the existing network-free `MagicMock` harness (no Redis, no Docker):

- `test_push_event_baseline_entry_carries_before_sha_not_the_head_sha` — records every `commit_schema_to_stream` call and asserts the two entries carry **different** hashes, one of them the fixture's `before` sha. It asserts the fixture has distinct `before`/`after` *first*, so it cannot pass vacuously.
- `test_push_event_with_created_ref_sentinel_enqueues_only_the_head`.

**Mutation-checked**: reverting `git_hash` to `sha` fails the first test; dropping the all-zero guard fails the second. Each mutation is caught by exactly the test written for it.

One note on the fixture, since it looks like a detour: `event_webhook_pushed_repo.json` is a *fork* push to a scratch branch (`refs/heads/unstable.55555`, org `filipecosta90`), which the org and branch allowlists reject — so with the fixture as-is, zero entries are enqueued and both tests pass vacuously. The helper normalises `ref` and `repository.html_url` to get past those gates, because they are not what these tests exercise. Worth flagging in case you would rather have a second fixture than a mutated one.

## Deliberately not included

**Whether the baseline entry should also be scope-filtered.** The existing comment says it is intentionally unscoped, and that reasoning still holds — but it was written when the entry carried the head sha, i.e. when "unscoped baseline" and "the head commit again" were the same thing. Now that the payload genuinely differs, it is worth re-reading, and I did not want to fold a design question into a one-value correction.

**Backfill.** Any historical comparison that relied on a baseline from this path had none, so there is nothing to correct — the datapoints were simply never written. No cleanup needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark trigger semantics for all allowlisted push events (what gets enqueued and in what order), which affects regression baselines and fleet load; guards reduce bad enqueues but incorrect behavior would skew performance comparisons.
> 
> **Overview**
> Fixes push webhook handling so the **previous-tip baseline** uses `before_sha` instead of duplicating the head `after` sha, which had been enqueueing the same commit twice and never benchmarking the real baseline.
> 
> Adds **`is_buildable_sha`** in `env.py` to reject all-zero GitHub sentinels and malformed/non-string shas without 500ing. Push handling now skips baseline work on **ref deletion**, **force-push**, and missing head shas; **enqueues head before baseline** so queue starvation does not leave branch regression tables baselined on the wrong commit; and keeps the HTTP response tied to the head enqueue.
> 
> Bumps package version to **0.3.30** and expands **`test_app.py`** with push-event coverage (sentinels, ordering, scoping, allowlists, malformed `before`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3a8d11442c6568e30bac3bfbb6386a06cdaae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->