### PR TITLE
fix(compare): reject mutually exclusive selectors on both sides, and report them accurately

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -184,6 +184,24 @@ redis-benchmarks-compare \
     --running_platform arm-aws-m8g.metal-24xl
 ```
 
+### Identifying each side of a comparison
+
+Each side must be identified exactly one way. The five selectors per side are mutually
+exclusive, and supplying two is an error naming both:
+
+| Selector | Identifies the side by |
+|----------|-----------------------|
+| `--<side>-branch` | git branch |
+| `--<side>-tag` | released version |
+| `--<side>-hash` | commit hash |
+| `--<side>-target-version` | version target |
+| `--<side>-target-branch` | branch target |
+
+`--baseline-branch` falls back to a configured default when no other baseline selector is
+given, so `--baseline-hash <hash>` on its own is enough. Passing a selector as an empty
+string means "not supplied", so `--baseline-branch ''` is also accepted as a way to clear
+the default explicitly.
+
 ### New flags
 
 | Flag | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.29"
+version = "0.3.30"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.30"
+version = "0.3.29"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -334,6 +334,12 @@ def compare_command_logic(args, project_name, project_version):
     if baseline_branch == "":
         baseline_branch = None
     comparison_branch = args.comparison_branch
+    # Mirror the baseline normalization above. Selecting a side by hash means clearing its
+    # branch with '', and only the baseline side was normalized -- so '' reached the selector
+    # resolver as a supplied value and, once the comparison-side exclusion is enforced, a
+    # documented invocation would be rejected while being told it had selected a branch.
+    if comparison_branch == "":
+        comparison_branch = None
     simplify_table = args.simple_table
     print_regressions_only = args.print_regressions_only
     print_improvements_only = args.print_improvements_only
@@ -485,6 +491,28 @@ def compare_command_logic(args, project_name, project_version):
         logging.info(
             "Auto-enabling environment comparison mode due to comma-separated deployment names"
         )
+
+    # Validate the selectors here so the CLI still exits 1 with an accurate message, while the
+    # resolver itself only raises. get_by_strings is also reached from compute_regression_table,
+    # which the coordinator daemon calls inside an `except Exception` it documents as
+    # best-effort observability -- and SystemExit is not an Exception, so exiting down there
+    # escaped that guard, killed the daemon and left the stream un-ACKed.
+    try:
+        get_by_strings(
+            baseline_branch,
+            comparison_branch,
+            baseline_tag,
+            comparison_tag,
+            baseline_target_version,
+            comparison_target_version,
+            baseline_hash,
+            comparison_hash,
+            baseline_target_branch,
+            comparison_target_branch,
+        )
+    except ValueError as selector_error:
+        logging.error(str(selector_error))
+        sys.exit(1)
 
     if compare_by_env:
         logging.info("Environment comparison mode enabled")
@@ -968,8 +996,13 @@ def compute_env_comparison_table(
     running_platform_comparison=None,
     baseline_target_version=None,
     comparison_target_version=None,
-    comparison_hash=None,
+    # Declared baseline-first to match this function's only caller, which passes all of these
+    # positionally. The previous order was comparison_hash then baseline_hash, so the caller's
+    # --baseline-hash bound to comparison_hash and vice versa; the values were then forwarded
+    # to get_by_strings under the swapped local names, transposing the two sides of every
+    # --compare-by-env comparison filtered by hash.
     baseline_hash=None,
+    comparison_hash=None,
     baseline_github_repo="redis",
     comparison_github_repo="redis",
     baseline_target_branch=None,
@@ -1269,8 +1302,13 @@ def compute_regression_table(
     running_platform_comparison=None,
     baseline_target_version=None,
     comparison_target_version=None,
-    comparison_hash=None,
+    # Baseline-first, matching this function's only caller, which passes positionally. The
+    # previous order was comparison-first while the forward to get_by_strings below was ALSO
+    # comparison-first, so the two inversions cancelled and positional callers were correct --
+    # but any keyword caller, or any refactor of either list alone, silently transposed the two
+    # sides of the comparison. Both are now canonical so neither can drift alone.
     baseline_hash=None,
+    comparison_hash=None,
     baseline_github_repo="redis",
     comparison_github_repo="redis",
     baseline_target_branch=None,
@@ -1310,8 +1348,8 @@ def compute_regression_table(
         comparison_tag,
         baseline_target_version,
         comparison_target_version,
-        comparison_hash,
         baseline_hash,
+        comparison_hash,
         baseline_target_branch,
         comparison_target_branch,
     )
@@ -1600,11 +1638,6 @@ def compute_regression_table(
     )
 
 
-def get_by_error(name, by_str_arr):
-    by_string = ",".join(by_str_arr)
-    return f"--{name}-branch, --{name}-tag, --{name}-target-branch, --{name}-hash, and --{name}-target-version are mutually exclusive. You selected a total of {len(by_str_arr)}: {by_string}. Pick one..."
-
-
 # (flag suffix, label reported as by_str). Order fixes which selector is named first in an
 # error and is otherwise immaterial, since at most one may be supplied.
 _SELECTORS = (
@@ -1616,31 +1649,62 @@ _SELECTORS = (
 )
 
 
+def _selector_flags(name):
+    """The CLI flag for every selector, derived from _SELECTORS so there is a single ordering."""
+    return [
+        "--{}-{}".format(name, suffix.replace("_", "-")) for suffix, _ in _SELECTORS
+    ]
+
+
+def get_by_error(name, suffixes):
+    """Name the offenders by their CLI flag.
+
+    The by_str labels are datasink label names ("version" for --<name>-tag, "target+version"
+    for --<name>-target-version) and were previously reported verbatim, so a user who passed
+    --baseline-tag was told they had selected "version" -- a word absent from their command
+    line. The labels cannot be renamed; they are the filter keys used downstream.
+    """
+    by_string = ",".join("--{}-{}".format(name, s.replace("_", "-")) for s in suffixes)
+    flags = _selector_flags(name)
+    flag_list = ", ".join(flags[:-1]) + ", and " + flags[-1]
+    return f"{flag_list} are mutually exclusive. You selected a total of {len(suffixes)}: {by_string}. Pick one..."
+
+
 def _resolve_by(name, supplied):
     """Pick the single selector for one side, or exit with an accurate error.
 
-    `supplied` maps selector suffix -> value (None when absent).
+    `supplied` maps every selector suffix in _SELECTORS to its value, using None -- or "" -- for
+    "not supplied". Returns (value, by_str) for the one selector supplied, where by_str is the
+    datasink label that value filters on. Exits if none or more than one is supplied.
 
-    Every selector is collected before anything is reported, so the error names all of them
-    and the count matches. The previous per-selector chain appended to the error list only
-    inside its own failure branch, so whichever selector was supplied *first* was never
-    recorded: any pair not involving --*-branch reported "a total of 1" and named the wrong
-    flag. The --*-hash arm additionally had its exclusion check commented out (#312, a squash
-    with no rationale for it), so on the comparison side four pairs were accepted silently and
-    the hash quietly won by being last in the chain.
+    Both defects this replaces were silent: the per-selector chain recorded an offender only
+    inside its own failure branch, so any pair not involving --*-branch reported "a total of 1"
+    and named the wrong flag; and the --*-hash arm's exclusion check had been commented out in
+    d62497b (WIP boxplot work later squashed into #312, unrelated to selector semantics), so on
+    the comparison side four pairs were accepted silently and the hash won by being last.
     """
-    chosen = [(label, supplied.get(suffix)) for suffix, label in _SELECTORS]
-    chosen = [(label, value) for label, value in chosen if value is not None]
+    # Indexed, not .get(): a selector present in _SELECTORS but absent from a call-site dict is
+    # a programming error, and .get() would turn it into a selector that can never be supplied
+    # while the error message still advertised its flag.
+    chosen = [(suffix, label, supplied[suffix]) for suffix, label in _SELECTORS]
+    # An empty string means "not supplied". compare_command_logic defaults --baseline-branch to
+    # "unstable", so filtering the baseline by hash requires passing --baseline-branch '' to
+    # clear it; that is a documented idiom and the same is done on the comparison side. Only
+    # the baseline was normalized (compare_command_logic), so enforcing the exclusion on a bare
+    # `is not None` would reject the comparison form that callers actually use, and would report
+    # a count of 2 for the one selector they passed.
+    chosen = [
+        (suffix, label, value)
+        for suffix, label, value in chosen
+        if value is not None and value != ""
+    ]
     if len(chosen) > 1:
-        logging.error(get_by_error(name, [label for label, _ in chosen]))
-        exit(1)
+        raise ValueError(get_by_error(name, [suffix for suffix, _, _ in chosen]))
     if not chosen:
-        flags = ", ".join(
-            "--{}-{}".format(name, s.replace("_", "-")) for s, _ in _SELECTORS
+        raise ValueError(
+            "You need to provide one of ( {} )".format(", ".join(_selector_flags(name)))
         )
-        logging.error("You need to provide one of ( {} )".format(flags))
-        exit(1)
-    label, value = chosen[0]
+    _, label, value = chosen[0]
     return value, label
 
 

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -435,16 +435,16 @@ def compare_command_logic(args, project_name, project_version):
     # escaped that guard, killed the daemon and left the stream un-ACKed.
     try:
         get_by_strings(
-            baseline_branch,
-            comparison_branch,
-            baseline_tag,
-            comparison_tag,
-            baseline_target_version,
-            comparison_target_version,
-            baseline_hash,
-            comparison_hash,
-            baseline_target_branch,
-            comparison_target_branch,
+            baseline_branch=baseline_branch,
+            comparison_branch=comparison_branch,
+            baseline_tag=baseline_tag,
+            comparison_tag=comparison_tag,
+            baseline_target_version=baseline_target_version,
+            comparison_target_version=comparison_target_version,
+            baseline_hash=baseline_hash,
+            comparison_hash=comparison_hash,
+            baseline_target_branch=baseline_target_branch,
+            comparison_target_branch=comparison_target_branch,
         )
     except ValueError as selector_error:
         logging.error(str(selector_error))
@@ -1089,16 +1089,16 @@ def compute_env_comparison_table(
 
     # Build baseline and comparison strings
     baseline_str, by_str_baseline, comparison_str, by_str_comparison = get_by_strings(
-        baseline_branch,
-        comparison_branch,
-        baseline_tag,
-        comparison_tag,
-        baseline_target_version,
-        comparison_target_version,
-        baseline_hash,
-        comparison_hash,
-        baseline_target_branch,
-        comparison_target_branch,
+        baseline_branch=baseline_branch,
+        comparison_branch=comparison_branch,
+        baseline_tag=baseline_tag,
+        comparison_tag=comparison_tag,
+        baseline_target_version=baseline_target_version,
+        comparison_target_version=comparison_target_version,
+        baseline_hash=baseline_hash,
+        comparison_hash=comparison_hash,
+        baseline_target_branch=baseline_target_branch,
+        comparison_target_branch=comparison_target_branch,
     )
 
     test_filter = "test_name"
@@ -1368,16 +1368,16 @@ def compute_regression_table(
         "Using a time-delta from {} to {}".format(from_human_str, to_human_str)
     )
     baseline_str, by_str_baseline, comparison_str, by_str_comparison = get_by_strings(
-        baseline_branch,
-        comparison_branch,
-        baseline_tag,
-        comparison_tag,
-        baseline_target_version,
-        comparison_target_version,
-        baseline_hash,
-        comparison_hash,
-        baseline_target_branch,
-        comparison_target_branch,
+        baseline_branch=baseline_branch,
+        comparison_branch=comparison_branch,
+        baseline_tag=baseline_tag,
+        comparison_tag=comparison_tag,
+        baseline_target_version=baseline_target_version,
+        comparison_target_version=comparison_target_version,
+        baseline_hash=baseline_hash,
+        comparison_hash=comparison_hash,
+        baseline_target_branch=baseline_target_branch,
+        comparison_target_branch=comparison_target_branch,
     )
     logging.info(f"Using baseline filter {by_str_baseline}={baseline_str}")
     logging.info(f"Using comparison filter {by_str_comparison}={comparison_str}")
@@ -1737,10 +1737,11 @@ def _resolve_by(name, supplied):
 
 
 def get_by_strings(
-    baseline_branch,
-    comparison_branch,
-    baseline_tag,
-    comparison_tag,
+    *,
+    baseline_branch=None,
+    comparison_branch=None,
+    baseline_tag=None,
+    comparison_tag=None,
     baseline_target_version=None,
     comparison_target_version=None,
     baseline_hash=None,
@@ -1748,6 +1749,14 @@ def get_by_strings(
     baseline_target_branch=None,
     comparison_target_branch=None,
 ):
+    """Resolve how each side of the comparison is identified.
+
+    Keyword-only by design. Every caller previously passed ten bare positionals, and a
+    transposition there is invisible: it does not change the arity, the types, or the shape of
+    the result -- it just compares the wrong two things, or names the wrong side in an error.
+    That is precisely how the two hash arguments came to be crossed on one path. Keyword-only
+    makes the mistake unwritable rather than merely tested for.
+    """
     baseline_str, by_str_baseline = _resolve_by(
         "baseline",
         {

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -392,7 +392,7 @@ def compare_command_logic(args, project_name, project_version):
 
     if metric_name is None:
         logging.error(
-            "You need to provider either "
+            "You need to provide either "
             + " --metric_name or provide a defaults file via --defaults_filename that contains exporter.redistimeseries.comparison.metrics array. Exiting..."
         )
         sys.exit(1)

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -254,6 +254,17 @@ def list_available_deployments(rts, args):
     print()
 
 
+def absent_if_empty(value):
+    """An empty selector means "not supplied".
+
+    Selecting a side by hash requires clearing the branch that defaults to unstable, and "" is
+    how callers do it. Several downstream checks test `is not None`, so leaving "" in place makes
+    an unsupplied selector look supplied: it reaches the resolver as a conflict, and it reaches
+    the grafana link builder as an empty query parameter.
+    """
+    return None if value == "" else value
+
+
 def compare_command_logic(args, project_name, project_version):
 
     logger = logging.getLogger()
@@ -331,21 +342,14 @@ def compare_command_logic(args, project_name, project_version):
             )
         )
         baseline_branch = default_baseline_branch
-    if baseline_branch == "":
-        baseline_branch = None
-    comparison_branch = args.comparison_branch
-    # Mirror the baseline normalization above. Selecting a side by hash means clearing its
-    # branch with '', and only the baseline side was normalized -- so '' reached the selector
-    # resolver as a supplied value and, once the comparison-side exclusion is enforced, a
-    # documented invocation would be rejected while being told it had selected a branch.
-    if comparison_branch == "":
-        comparison_branch = None
+    baseline_branch = absent_if_empty(baseline_branch)
+    comparison_branch = absent_if_empty(args.comparison_branch)
     simplify_table = args.simple_table
     print_regressions_only = args.print_regressions_only
     print_improvements_only = args.print_improvements_only
     skip_unstable = args.skip_unstable
-    baseline_tag = args.baseline_tag
-    comparison_tag = args.comparison_tag
+    baseline_tag = absent_if_empty(args.baseline_tag)
+    comparison_tag = absent_if_empty(args.comparison_tag)
     last_n_baseline = args.last_n
     last_n_comparison = args.last_n
     if last_n_baseline < 0:
@@ -394,16 +398,16 @@ def compare_command_logic(args, project_name, project_version):
     triggering_env_baseline = args.triggering_env_baseline or args.triggering_env
     triggering_env_comparison = args.triggering_env_comparison or args.triggering_env
 
-    baseline_target_version = args.baseline_target_version
-    comparison_target_version = args.comparison_target_version
-    baseline_target_branch = args.baseline_target_branch
-    comparison_target_branch = args.comparison_target_branch
+    baseline_target_version = absent_if_empty(args.baseline_target_version)
+    comparison_target_version = absent_if_empty(args.comparison_target_version)
+    baseline_target_branch = absent_if_empty(args.baseline_target_branch)
+    comparison_target_branch = absent_if_empty(args.comparison_target_branch)
     baseline_github_repo = args.baseline_github_repo
     comparison_github_repo = args.comparison_github_repo
     baseline_github_org = args.baseline_github_org
     comparison_github_org = args.comparison_github_org
-    baseline_hash = args.baseline_hash
-    comparison_hash = args.comparison_hash
+    baseline_hash = absent_if_empty(args.baseline_hash)
+    comparison_hash = absent_if_empty(args.comparison_hash)
 
     # Log platform and environment information
     if running_platform_baseline == running_platform_comparison:
@@ -865,11 +869,13 @@ def prepare_regression_comment(
 
         if grafana_link_base is not None:
             grafana_link = "{}/".format(grafana_link_base)
-            if baseline_tag is not None and comparison_tag is not None:
+            # Truthiness, not `is not None`: an empty tag would otherwise contribute an
+            # empty var-version parameter and a second "?" to the link posted on the PR.
+            if baseline_tag and comparison_tag:
                 grafana_link += "?var-version={}&var-version={}".format(
                     baseline_tag, comparison_tag
                 )
-            if baseline_branch is not None and comparison_branch is not None:
+            if baseline_branch and comparison_branch:
                 grafana_link += "?var-branch={}&var-branch={}".format(
                     baseline_branch, comparison_branch
                 )
@@ -996,7 +1002,7 @@ def compute_env_comparison_table(
     running_platform_comparison=None,
     baseline_target_version=None,
     comparison_target_version=None,
-    # Declared baseline-first to match this function's only caller, which passes all of these
+    # Declared baseline-first to match the in-module caller, which passes all of these
     # positionally. The previous order was comparison_hash then baseline_hash, so the caller's
     # --baseline-hash bound to comparison_hash and vice versa; the values were then forwarded
     # to get_by_strings under the swapped local names, transposing the two sides of every
@@ -1302,7 +1308,8 @@ def compute_regression_table(
     running_platform_comparison=None,
     baseline_target_version=None,
     comparison_target_version=None,
-    # Baseline-first, matching this function's only caller, which passes positionally. The
+    # Baseline-first, matching the in-module caller, which passes positionally. (The
+    # coordinator also calls this, but by keyword, so it is unaffected either way.) The
     # previous order was comparison-first while the forward to get_by_strings below was ALSO
     # comparison-first, so the two inversions cancelled and positional callers were correct --
     # but any keyword caller, or any refactor of either list alone, silently transposed the two

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -1605,6 +1605,45 @@ def get_by_error(name, by_str_arr):
     return f"--{name}-branch, --{name}-tag, --{name}-target-branch, --{name}-hash, and --{name}-target-version are mutually exclusive. You selected a total of {len(by_str_arr)}: {by_string}. Pick one..."
 
 
+# (flag suffix, label reported as by_str). Order fixes which selector is named first in an
+# error and is otherwise immaterial, since at most one may be supplied.
+_SELECTORS = (
+    ("branch", "branch"),
+    ("tag", "version"),
+    ("target_version", "target+version"),
+    ("target_branch", "target+branch"),
+    ("hash", "hash"),
+)
+
+
+def _resolve_by(name, supplied):
+    """Pick the single selector for one side, or exit with an accurate error.
+
+    `supplied` maps selector suffix -> value (None when absent).
+
+    Every selector is collected before anything is reported, so the error names all of them
+    and the count matches. The previous per-selector chain appended to the error list only
+    inside its own failure branch, so whichever selector was supplied *first* was never
+    recorded: any pair not involving --*-branch reported "a total of 1" and named the wrong
+    flag. The --*-hash arm additionally had its exclusion check commented out (#312, a squash
+    with no rationale for it), so on the comparison side four pairs were accepted silently and
+    the hash quietly won by being last in the chain.
+    """
+    chosen = [(label, supplied.get(suffix)) for suffix, label in _SELECTORS]
+    chosen = [(label, value) for label, value in chosen if value is not None]
+    if len(chosen) > 1:
+        logging.error(get_by_error(name, [label for label, _ in chosen]))
+        exit(1)
+    if not chosen:
+        flags = ", ".join(
+            "--{}-{}".format(name, s.replace("_", "-")) for s, _ in _SELECTORS
+        )
+        logging.error("You need to provide one of ( {} )".format(flags))
+        exit(1)
+    label, value = chosen[0]
+    return value, label
+
+
 def get_by_strings(
     baseline_branch,
     comparison_branch,
@@ -1617,120 +1656,26 @@ def get_by_strings(
     baseline_target_branch=None,
     comparison_target_branch=None,
 ):
-    baseline_covered = False
-    comparison_covered = False
-    by_str_baseline = ""
-    by_str_comparison = ""
-    baseline_str = ""
-    comparison_str = ""
-    baseline_by_arr = []
-    comparison_by_arr = []
-
-    ################# BASELINE BY ....
-
-    if baseline_branch is not None:
-        by_str_baseline = "branch"
-        baseline_covered = True
-        baseline_str = baseline_branch
-        baseline_by_arr.append(by_str_baseline)
-
-    if baseline_tag is not None:
-        by_str_baseline = "version"
-        if baseline_covered:
-            baseline_by_arr.append(by_str_baseline)
-            logging.error(get_by_error("baseline", baseline_by_arr))
-            exit(1)
-        baseline_covered = True
-        baseline_str = baseline_tag
-
-    if baseline_target_version is not None:
-        by_str_baseline = "target+version"
-        if baseline_covered:
-            baseline_by_arr.append(by_str_baseline)
-            logging.error(get_by_error("baseline", baseline_by_arr))
-            exit(1)
-        baseline_covered = True
-        baseline_str = baseline_target_version
-
-    if baseline_hash is not None:
-        by_str_baseline = "hash"
-        if baseline_covered:
-            baseline_by_arr.append(by_str_baseline)
-            logging.error(get_by_error("baseline", baseline_by_arr))
-            exit(1)
-        baseline_covered = True
-        baseline_str = baseline_hash
-    if baseline_target_branch is not None:
-        by_str_baseline = "target+branch"
-        if baseline_covered:
-            baseline_by_arr.append(by_str_baseline)
-            logging.error(get_by_error("baseline", baseline_by_arr))
-            exit(1)
-        baseline_covered = True
-        baseline_str = baseline_target_branch
-
-    ################# COMPARISON BY ....
-
-    if comparison_branch is not None:
-        by_str_comparison = "branch"
-        comparison_covered = True
-        comparison_str = comparison_branch
-
-    if comparison_tag is not None:
-        # check if we had already covered comparison
-        if comparison_covered:
-            logging.error(
-                "--comparison-branch and --comparison-tag, --comparison-hash, --comparison-target-branch, and --comparison-target-table are mutually exclusive. Pick one..."
-            )
-            exit(1)
-        comparison_covered = True
-        by_str_comparison = "version"
-        comparison_str = comparison_tag
-    if comparison_target_version is not None:
-        # check if we had already covered comparison
-        if comparison_covered:
-            logging.error(
-                "--comparison-branch, --comparison-tag, --comparison-hash, --comparison-target-branch, and --comparison-target-table are mutually exclusive. Pick one..."
-            )
-            exit(1)
-        comparison_covered = True
-        by_str_comparison = "target+version"
-        comparison_str = comparison_target_version
-
-    if comparison_target_branch is not None:
-        # check if we had already covered comparison
-        if comparison_covered:
-            logging.error(
-                "--comparison-branch, --comparison-tag, --comparison-hash, --comparison-target-branch, and --comparison-target-table are mutually exclusive. Pick one..."
-            )
-            exit(1)
-        comparison_covered = True
-        by_str_comparison = "target+branch"
-        comparison_str = comparison_target_branch
-
-    if comparison_hash is not None:
-        # check if we had already covered comparison
-        # if comparison_covered:
-        #     logging.error(
-        #         "--comparison-branch, --comparison-tag, --comparison-hash, --comparison-target-branch, and --comparison-target-table are mutually exclusive. Pick one..."
-        #     )
-        #     exit(1)
-        comparison_covered = True
-        by_str_comparison = "hash"
-        comparison_str = comparison_hash
-
-    if baseline_covered is False:
-        logging.error(
-            "You need to provider either "
-            + "( --baseline-branch, --baseline-tag, --baseline-hash, --baseline-target-branch or --baseline-target-version ) "
-        )
-        exit(1)
-    if comparison_covered is False:
-        logging.error(
-            "You need to provider either "
-            + "( --comparison-branch, --comparison-tag, --comparison-hash, --comparison-target-branch or --comparison-target-version ) "
-        )
-        exit(1)
+    baseline_str, by_str_baseline = _resolve_by(
+        "baseline",
+        {
+            "branch": baseline_branch,
+            "tag": baseline_tag,
+            "target_version": baseline_target_version,
+            "target_branch": baseline_target_branch,
+            "hash": baseline_hash,
+        },
+    )
+    comparison_str, by_str_comparison = _resolve_by(
+        "comparison",
+        {
+            "branch": comparison_branch,
+            "tag": comparison_tag,
+            "target_version": comparison_target_version,
+            "target_branch": comparison_target_branch,
+            "hash": comparison_hash,
+        },
+    )
     return baseline_str, by_str_baseline, comparison_str, by_str_comparison
 
 

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -335,7 +335,26 @@ def compare_command_logic(args, project_name, project_version):
     from_date = args.from_date
     to_date = args.to_date
     baseline_branch = args.baseline_branch
-    if baseline_branch is None and default_baseline_branch is not None:
+    # Only fall back to the configured default when the user identified the baseline no other
+    # way. Injecting it unconditionally manufactured a second selector, so `--baseline-hash X`
+    # was rejected for conflicting with a `--baseline-branch` the user never typed -- the same
+    # kind of untruth about someone's own command line that this resolver is being fixed for. It
+    # is also why clearing the branch with '' was needed to select by hash; that still works, but
+    # is no longer required.
+    explicit_baseline_selectors = [
+        absent_if_empty(value)
+        for value in (
+            args.baseline_tag,
+            args.baseline_hash,
+            args.baseline_target_version,
+            args.baseline_target_branch,
+        )
+    ]
+    if (
+        baseline_branch is None
+        and default_baseline_branch is not None
+        and all(value is None for value in explicit_baseline_selectors)
+    ):
         logging.info(
             "Given --baseline-branch was null using the default baseline branch {}".format(
                 default_baseline_branch
@@ -376,7 +395,7 @@ def compare_command_logic(args, project_name, project_version):
             "You need to provider either "
             + " --metric_name or provide a defaults file via --defaults_filename that contains exporter.redistimeseries.comparison.metrics array. Exiting..."
         )
-        exit(1)
+        sys.exit(1)
     else:
         logging.info("Using metric {}".format(metric_name))
 
@@ -408,6 +427,28 @@ def compare_command_logic(args, project_name, project_version):
     comparison_github_org = args.comparison_github_org
     baseline_hash = absent_if_empty(args.baseline_hash)
     comparison_hash = absent_if_empty(args.comparison_hash)
+
+    # Validate the selectors here so the CLI still exits 1 with an accurate message, while the
+    # resolver itself only raises. get_by_strings is also reached from compute_regression_table,
+    # which the coordinator daemon calls inside an `except Exception` it documents as
+    # best-effort observability -- and SystemExit is not an Exception, so exiting down there
+    # escaped that guard, killed the daemon and left the stream un-ACKed.
+    try:
+        get_by_strings(
+            baseline_branch,
+            comparison_branch,
+            baseline_tag,
+            comparison_tag,
+            baseline_target_version,
+            comparison_target_version,
+            baseline_hash,
+            comparison_hash,
+            baseline_target_branch,
+            comparison_target_branch,
+        )
+    except ValueError as selector_error:
+        logging.error(str(selector_error))
+        sys.exit(1)
 
     # Log platform and environment information
     if running_platform_baseline == running_platform_comparison:
@@ -495,28 +536,6 @@ def compare_command_logic(args, project_name, project_version):
         logging.info(
             "Auto-enabling environment comparison mode due to comma-separated deployment names"
         )
-
-    # Validate the selectors here so the CLI still exits 1 with an accurate message, while the
-    # resolver itself only raises. get_by_strings is also reached from compute_regression_table,
-    # which the coordinator daemon calls inside an `except Exception` it documents as
-    # best-effort observability -- and SystemExit is not an Exception, so exiting down there
-    # escaped that guard, killed the daemon and left the stream un-ACKed.
-    try:
-        get_by_strings(
-            baseline_branch,
-            comparison_branch,
-            baseline_tag,
-            comparison_tag,
-            baseline_target_version,
-            comparison_target_version,
-            baseline_hash,
-            comparison_hash,
-            baseline_target_branch,
-            comparison_target_branch,
-        )
-    except ValueError as selector_error:
-        logging.error(str(selector_error))
-        sys.exit(1)
 
     if compare_by_env:
         logging.info("Environment comparison mode enabled")
@@ -1682,7 +1701,9 @@ def _resolve_by(name, supplied):
 
     `supplied` maps every selector suffix in _SELECTORS to its value, using None -- or "" -- for
     "not supplied". Returns (value, by_str) for the one selector supplied, where by_str is the
-    datasink label that value filters on. Exits if none or more than one is supplied.
+    datasink label that value filters on. Raises ValueError if none or more than one is supplied,
+    and KeyError if `supplied` omits a selector _SELECTORS lists -- that is a call-site bug, not
+    user input, so it is deliberately not folded into the user-facing error.
 
     Both defects this replaces were silent: the per-selector chain recorded an offender only
     inside its own failure branch, so any pair not involving --*-branch reported "a total of 1"

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -76,7 +76,7 @@ def test_every_pair_of_selectors_is_rejected_with_an_accurate_count(caplog, side
     a, b = pair
     result, text = _call(caplog, **{f"{side}_{a}": "AAA", f"{side}_{b}": "BBB"})
     assert result is None, f"{side} {a}+{b} was accepted instead of rejected"
-    match = re.search(r"total of (\d+): ([^.]*)", text)
+    match = re.search(r"total of (\d+): (.*?)\. Pick", text)
     assert match, f"no count in error for {side} {a}+{b}: {text!r}"
     assert int(match.group(1)) == 2, f"{side} {a}+{b} reported {match.group(1)}, not 2"
     named = [n.strip() for n in match.group(2).split(",")]
@@ -351,20 +351,23 @@ def test_the_cli_translates_a_selector_error_into_exit_1():
         for n in ast.walk(tree)
         if isinstance(n, ast.FunctionDef) and n.name == "compare_command_logic"
     )
-    handlers = [
-        h
+    codes = [
+        c.args[0].value
         for node in ast.walk(fn)
         if isinstance(node, ast.Try)
         for h in node.handlers
         if getattr(h.type, "id", None) == "ValueError"
-        and any(
-            isinstance(c, ast.Call)
-            and getattr(getattr(c.func, "value", None), "id", None) == "sys"
-            and getattr(c.func, "attr", None) == "exit"
-            for c in ast.walk(h)
-        )
+        for c in ast.walk(h)
+        if isinstance(c, ast.Call)
+        and getattr(getattr(c.func, "value", None), "id", None) == "sys"
+        and getattr(c.func, "attr", None) == "exit"
+        and c.args
+        and isinstance(c.args[0], ast.Constant)
     ]
-    assert handlers, "no ValueError handler in compare_command_logic calls sys.exit"
+    assert codes, "no ValueError handler in compare_command_logic calls sys.exit"
+    # the code itself, not just that it exits: `set -e` and every CI step branch on it, so
+    # exiting 0 while printing an error is indistinguishable from a successful comparison
+    assert all(code == 1 for code in codes), f"selector errors exit with {codes}, not 1"
 
 
 def test_no_selector_is_reassigned_between_validation_and_the_table_calls():
@@ -411,3 +414,45 @@ def test_no_selector_is_reassigned_between_validation_and_the_table_calls():
         and validated_at < node.lineno < last_table_call
     ]
     assert not reassigned, f"selectors reassigned after validation: {reassigned}"
+
+
+def test_the_by_str_labels_match_what_the_ingest_side_writes():
+    """These labels are TimeSeries label names, not display strings.
+
+    by_str is interpolated straight into a query filter, so renaming one makes every query for
+    that selector return zero series -- indistinguishable from "this version was never
+    benchmarked". Asserting them against LABELS above would be tautological: LABELS is a copy of
+    _SELECTORS, so the natural single edit renames both and ships green. This checks the other
+    side of the wire instead.
+
+    `hash` is excluded deliberately: it is written by redisbench-admin, not by this repo, so
+    there is nothing local to compare it against.
+    """
+    import inspect
+
+    import redis_benchmarks_specification.__common__.timeseries as ts_mod
+    from redis_benchmarks_specification.__compare__.compare import _SELECTORS
+
+    ingest = inspect.getsource(ts_mod)
+    labels = {label for _, label in _SELECTORS}
+
+    for plain in ("version", "branch"):
+        assert plain in labels, f"_SELECTORS no longer resolves anything to '{plain}'"
+        assert (
+            f'labels["{plain}"]' in ingest or f'["labels"]["{plain}"]' in ingest
+        ), f"the ingest side no longer writes a '{plain}' label"
+
+    # target+<key> is built by joining, so match the construction rather than a literal
+    assert '"{}+{}".format("target", break_by_key)' in ingest, (
+        "the ingest side no longer builds target+<key> labels; the two target selectors "
+        "would query a label that is never written"
+    )
+    for composed in ("target+version", "target+branch"):
+        assert (
+            composed in labels
+        ), f"_SELECTORS no longer resolves anything to '{composed}'"
+        prefix, _, key = composed.partition("+")
+        assert prefix == "target" and key in (
+            "version",
+            "branch",
+        ), f"'{composed}' is not a target+<key> pair the ingest side can produce"

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -456,3 +456,75 @@ def test_the_by_str_labels_match_what_the_ingest_side_writes():
             "version",
             "branch",
         ), f"'{composed}' is not a target+<key> pair the ingest side can produce"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("", None),
+        (None, None),
+        ("unstable", "unstable"),
+        (" ", " "),
+        ("0", "0"),
+    ],
+)
+def test_absent_if_empty(value, expected):
+    """Only the empty string becomes absent.
+
+    A space is not "absent" -- silently trimming it would be a new untruth of the same kind this
+    module is being fixed for -- and "0" is a legitimate value.
+    """
+    from redis_benchmarks_specification.__compare__.compare import absent_if_empty
+
+    assert absent_if_empty(value) is expected or absent_if_empty(value) == expected
+
+
+def test_every_selector_is_normalized_before_use():
+    """All ten selectors must go through absent_if_empty, not just the two branches.
+
+    Downstream code tests `is not None` in places the resolver never sees -- the grafana link
+    built into the PR comment, and the pull-request zset write -- so normalizing only the
+    branches left an empty tag looking supplied. That combination was previously refused outright
+    and became reachable once the resolver started treating "" as absent, which is exactly the
+    kind of second-order effect a partial normalization produces.
+    """
+    import ast
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    fn = next(
+        n
+        for n in ast.walk(ast.parse(inspect.getsource(mod)))
+        if isinstance(n, ast.FunctionDef) and n.name == "compare_command_logic"
+    )
+    normalized = {
+        target.id
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and getattr(node.value.func, "id", None) == "absent_if_empty"
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    expected = {f"{side}_{suffix}" for side in SIDES for suffix in SUFFIXES}
+    assert not expected - normalized, f"not normalized: {sorted(expected - normalized)}"
+
+
+def test_the_grafana_link_never_carries_an_empty_selector():
+    """An empty tag used to add a bare var-version and a second "?" to a link posted on the PR."""
+    import inspect
+
+    from redis_benchmarks_specification.__compare__.compare import (
+        prepare_regression_comment,
+    )
+
+    src = inspect.getsource(prepare_regression_comment)
+    assert "if baseline_tag and comparison_tag:" in src, (
+        "the tag pair is gated on `is not None`, so an empty tag contributes an empty "
+        "var-version parameter to the link"
+    )
+    assert "if baseline_branch and comparison_branch:" in src, (
+        "the branch pair is gated on `is not None`, so an empty branch contributes an empty "
+        "var-branch parameter to the link"
+    )

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -351,11 +351,25 @@ def test_the_cli_translates_a_selector_error_into_exit_1():
         for n in ast.walk(tree)
         if isinstance(n, ast.FunctionDef) and n.name == "compare_command_logic"
     )
-    codes = [
-        c.args[0].value
+    guards = [
+        node
         for node in ast.walk(fn)
         if isinstance(node, ast.Try)
-        for h in node.handlers
+        and any(getattr(h.type, "id", None) == "ValueError" for h in node.handlers)
+    ]
+    assert len(guards) == 1, "expected exactly one selector-validation guard"
+    # The guard must wrap the validation call itself. Asserting only that some handler exists
+    # would still pass with the call moved out of the try, which is the regression this prevents:
+    # the tables would then raise uncaught and the user would get a traceback.
+    guarded = [
+        c
+        for c in ast.walk(guards[0])
+        if isinstance(c, ast.Call) and getattr(c.func, "id", None) == "get_by_strings"
+    ]
+    assert guarded, "the ValueError guard does not wrap a get_by_strings call"
+    codes = [
+        c.args[0].value
+        for h in guards[0].handlers
         if getattr(h.type, "id", None) == "ValueError"
         for c in ast.walk(h)
         if isinstance(c, ast.Call)
@@ -364,7 +378,7 @@ def test_the_cli_translates_a_selector_error_into_exit_1():
         and c.args
         and isinstance(c.args[0], ast.Constant)
     ]
-    assert codes, "no ValueError handler in compare_command_logic calls sys.exit"
+    assert codes, "the ValueError handler does not call sys.exit"
     # the code itself, not just that it exits: `set -e` and every CI step branch on it, so
     # exiting 0 while printing an error is indistinguishable from a successful comparison
     assert all(code == 1 for code in codes), f"selector errors exit with {codes}, not 1"
@@ -527,4 +541,43 @@ def test_the_grafana_link_never_carries_an_empty_selector():
     assert "if baseline_branch and comparison_branch:" in src, (
         "the branch pair is gated on `is not None`, so an empty branch contributes an empty "
         "var-branch parameter to the link"
+    )
+
+
+def test_the_default_baseline_branch_is_not_injected_over_an_explicit_selector():
+    """A default must not manufacture a conflict with a flag the user never typed.
+
+    compare_command_logic falls back to a configured default baseline branch. Applying it
+    unconditionally meant `--baseline-hash X` alone resolved to branch+hash and was rejected for
+    conflicting with a --baseline-branch that appeared nowhere on the command line. That is why
+    clearing the branch with '' was needed to select by hash at all.
+    """
+    import ast
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    fn = next(
+        n
+        for n in ast.walk(ast.parse(inspect.getsource(mod)))
+        if isinstance(n, ast.FunctionDef) and n.name == "compare_command_logic"
+    )
+    guarded = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(c, ast.Name) and c.id == "explicit_baseline_selectors"
+            for c in ast.walk(node.test)
+        )
+        and any(
+            isinstance(t, ast.Name) and t.id == "baseline_branch"
+            for b in node.body
+            if isinstance(b, ast.Assign)
+            for t in b.targets
+        )
+    ]
+    assert guarded, (
+        "the default-baseline-branch fallback is not gated on the absence of an explicit "
+        "baseline selector, so it can manufacture a conflict the user did not create"
     )

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -197,28 +197,6 @@ def test_an_empty_string_does_not_count_toward_the_exclusion(caplog, side):
     assert expected in text, text
 
 
-def test_env_comparison_table_binds_the_hashes_to_the_sides_its_caller_intends():
-    """The positional hash arguments must not be transposed.
-
-    compute_env_comparison_table is called with every argument positional. Its signature
-    declared comparison_hash before baseline_hash while the caller passes baseline first, so
-    each hash bound to the opposite parameter and was forwarded to get_by_strings under the
-    swapped name -- transposing the two sides of any --compare-by-env comparison filtered by
-    hash. Asserted on the signature because that is where the contract lives; the call site is
-    a 40-argument positional list that cannot be exercised without a live datasink.
-    """
-    import inspect
-
-    from redis_benchmarks_specification.__compare__.compare import (
-        compute_env_comparison_table,
-    )
-
-    names = list(inspect.signature(compute_env_comparison_table).parameters)
-    assert names.index("baseline_hash") < names.index("comparison_hash")
-    # the pair the caller supplies immediately before them, to catch a drift in either list
-    assert names.index("comparison_target_version") + 1 == names.index("baseline_hash")
-
-
 def test_every_selector_names_a_flag_the_parser_actually_accepts():
     """_SELECTORS drives the error text, so a selector with no flag advertises a lie.
 
@@ -274,47 +252,9 @@ def test_hash_parameters_are_declared_baseline_first(func_name):
 
     names = list(inspect.signature(getattr(mod, func_name)).parameters)
     assert names.index("baseline_hash") < names.index("comparison_hash")
-
-
-def test_the_hashes_reach_get_by_strings_on_the_side_the_cli_supplied_them():
-    """End-to-end wiring check across both hops, read from the source.
-
-    The call sites are 47- and 48-argument positional lists that cannot run without a live
-    datasink, so the binding is resolved statically: caller local -> parameter -> forwarded
-    argument -> get_by_strings parameter. This is the check that would have caught the
-    transposition; a signature-order assertion alone would not, since the forward can move too.
-    """
-    import ast
-    import inspect
-
-    import redis_benchmarks_specification.__compare__.compare as mod
-
-    tree = ast.parse(inspect.getsource(mod))
-    funcs = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
-
-    def positional_args(inside, callee):
-        for node in ast.walk(funcs[inside]):
-            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == callee:
-                assert not node.keywords, f"{inside} -> {callee} mixes keywords"
-                return [a.id if isinstance(a, ast.Name) else None for a in node.args]
-        raise AssertionError(f"no call to {callee} inside {inside}")
-
-    def params(name):
-        args = funcs[name].args
-        return [a.arg for a in args.posonlyargs + args.args]
-
-    gbs = params("get_by_strings")
-    for table in ("compute_env_comparison_table", "compute_regression_table"):
-        outer = dict(
-            zip(params(table), positional_args("compare_command_logic", table))
-        )
-        forwarded = dict(zip(gbs, positional_args(table, "get_by_strings")))
-        for side in SIDES:
-            local = forwarded[f"{side}_hash"]
-            assert outer[local] == f"{side}_hash", (
-                f"{table}: get_by_strings.{side}_hash resolves to the caller's "
-                f"{outer[local]}, not {side}_hash"
-            )
+    # adjacency too: the caller supplies these two immediately after the target-version pair, so
+    # a parameter inserted between them would shift every later slot by one
+    assert names.index("comparison_target_version") + 1 == names.index("baseline_hash")
 
 
 def test_rejection_raises_rather_than_exiting():
@@ -581,3 +521,57 @@ def test_the_default_baseline_branch_is_not_injected_over_an_explicit_selector()
         "the default-baseline-branch fallback is not gated on the absence of an explicit "
         "baseline selector, so it can manufacture a conflict the user did not create"
     )
+
+
+def test_get_by_strings_is_keyword_only():
+    """A transposition must be unwritable, not merely tested for.
+
+    Ten same-typed positional arguments where crossing two changes nothing observable -- not the
+    arity, not the types, not the shape of the result, only which two things get compared -- is
+    how the hash pair came to be crossed on one path. Keyword-only removes the class rather than
+    policing it, which also means the call sites can be read without counting slots.
+    """
+    with pytest.raises(TypeError):
+        get_by_strings("BASE", "CMP")
+
+
+def test_every_get_by_strings_call_site_passes_keywords():
+    """The keyword-only signature is only load-bearing if nothing tries to route around it.
+
+    A caller building a dict and splatting it would compile fine and reintroduce the ordering
+    question one level up.
+    """
+    import ast
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    calls = [
+        node
+        for node in ast.walk(ast.parse(inspect.getsource(mod)))
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "get_by_strings"
+    ]
+    assert len(calls) == 3, f"expected 3 call sites, found {len(calls)}"
+    for call in calls:
+        assert (
+            not call.args
+        ), f"line {call.lineno}: positional args to a keyword-only function"
+        assert all(
+            kw.arg is not None for kw in call.keywords
+        ), f"line {call.lineno}: **splat bypasses the keyword-only signature"
+        supplied = {kw.arg for kw in call.keywords}
+        expected = {f"{side}_{suffix}" for side in SIDES for suffix in SUFFIXES}
+        assert (
+            supplied == expected
+        ), f"line {call.lineno}: passes {sorted(supplied ^ expected)}"
+        # Every keyword must be bound to the identically-named local. Keyword-only stops a slot
+        # being crossed accidentally, but `baseline_hash=comparison_hash` is still writable, and
+        # it is the same wrong-two-things outcome with none of the visual tell of a miscounted
+        # positional list.
+        crossed = [
+            (kw.arg, kw.value.id)
+            for kw in call.keywords
+            if isinstance(kw.value, ast.Name) and kw.value.id != kw.arg
+        ]
+        assert not crossed, f"line {call.lineno}: bound to the wrong local: {crossed}"

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -26,7 +26,7 @@ from redis_benchmarks_specification.__compare__.compare import get_by_strings
 SUFFIXES = ("branch", "tag", "target_version", "target_branch", "hash")
 SIDES = ("baseline", "comparison")
 ALL_KWARGS = tuple(f"{side}_{suffix}" for side in SIDES for suffix in SUFFIXES)
-# label reported for each suffix, per the flag names in the error text
+# datasink label each suffix resolves to -- returned as by_str and used as a TSDB filter key
 LABELS = {
     "branch": "branch",
     "tag": "version",
@@ -36,20 +36,33 @@ LABELS = {
 }
 
 
+def _flag(side, suffix):
+    """The CLI flag for a selector -- what the error names, as opposed to its datasink label."""
+    return "--{}-{}".format(side, suffix.replace("_", "-"))
+
+
 def _call(caplog, **kwargs):
-    """Invoke get_by_strings with every selector defaulted to None, returning logged text."""
+    """Invoke get_by_strings with every selector defaulted to None.
+
+    Returns (result, message). A rejected call yields (None, the ValueError's message): the
+    resolver raises rather than exiting, so that the coordinator daemon -- which calls into this
+    module inside an `except Exception` it documents as best-effort -- can log and continue. A
+    SystemExit would not be caught by that guard.
+    """
     payload = {name: None for name in ALL_KWARGS}
     payload.update(kwargs)
-    # each side needs one selector or it exits for being empty, which is a different test
-    if not any(k.startswith("baseline") and payload[k] for k in ALL_KWARGS):
+    # Each side needs one selector or it exits for being empty, which is a different test.
+    # Gated on `is not None`, not truthiness: "" is a value a caller really passes (to clear
+    # the defaulted --baseline-branch), so a truthiness gate would silently overwrite it and
+    # make the empty-string semantics untestable.
+    if all(payload[k] is None for k in ALL_KWARGS if k.startswith("baseline")):
         payload["baseline_branch"] = "BASE"
-    if not any(k.startswith("comparison") and payload[k] for k in ALL_KWARGS):
+    if all(payload[k] is None for k in ALL_KWARGS if k.startswith("comparison")):
         payload["comparison_branch"] = "CMP"
-    with caplog.at_level(logging.ERROR):
-        try:
-            return get_by_strings(**payload), caplog.text
-        except SystemExit:
-            return None, caplog.text
+    try:
+        return get_by_strings(**payload), ""
+    except ValueError as exc:
+        return None, str(exc)
 
 
 @pytest.mark.parametrize("side", SIDES)
@@ -68,7 +81,7 @@ def test_every_pair_of_selectors_is_rejected_with_an_accurate_count(caplog, side
     assert int(match.group(1)) == 2, f"{side} {a}+{b} reported {match.group(1)}, not 2"
     named = [n.strip() for n in match.group(2).split(",")]
     assert sorted(named) == sorted(
-        [LABELS[a], LABELS[b]]
+        [_flag(side, a), _flag(side, b)]
     ), f"{side} {a}+{b} named {named}"
 
 
@@ -96,10 +109,9 @@ def test_no_selector_on_a_side_is_rejected(caplog, side):
     payload = {name: None for name in ALL_KWARGS}
     other = "comparison" if side == "baseline" else "baseline"
     payload[f"{other}_branch"] = "OTHER"
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(SystemExit):
-            get_by_strings(**payload)
-    assert "You need to provide one of" in caplog.text
+    with pytest.raises(ValueError) as excinfo:
+        get_by_strings(**payload)
+    assert "You need to provide one of" in str(excinfo.value)
 
 
 @settings(max_examples=300, deadline=None)
@@ -120,21 +132,236 @@ def test_any_number_of_selectors_above_one_is_rejected_with_a_matching_count(
     payload[f"{other}_branch"] = "OTHER"
     for suffix in chosen:
         payload[f"{side}_{suffix}"] = "V"
-    records = []
-    handler = logging.Handler()
-    handler.emit = lambda record: records.append(record.getMessage())
-    root = logging.getLogger()
-    root.addHandler(handler)
+    if len(chosen) == 1:
+        assert get_by_strings(**payload) is not None
+        return
+    with pytest.raises(ValueError) as excinfo:
+        get_by_strings(**payload)
+    match = re.search(r"total of (\d+):", str(excinfo.value))
+    assert match and int(match.group(1)) == len(
+        chosen
+    ), f"{len(chosen)} selectors reported as {match.group(1) if match else None}"
+
+
+@pytest.mark.parametrize("side", SIDES)
+def test_an_empty_branch_alongside_a_hash_is_accepted(caplog, side):
+    """`--<side>-branch '' --<side>-hash X` must resolve to the hash, not error.
+
+    compare_command_logic defaults --baseline-branch to "unstable", so selecting by hash means
+    clearing it with ''. The documented fleet invocations pass that form on both sides, and only
+    the baseline was normalized to None before reaching here -- so enforcing the exclusion on a
+    bare `is not None` rejected the comparison form that every caller uses.
+    """
+    other = "comparison" if side == "baseline" else "baseline"
+    result, text = _call(
+        caplog,
+        **{f"{side}_branch": "", f"{side}_hash": "H" * 40, f"{other}_branch": "OTHER"},
+    )
+    assert result is not None, f"rejected the documented idiom: {text}"
+    by_str = result[1] if side == "baseline" else result[3]
+    value = result[0] if side == "baseline" else result[2]
+    assert (value, by_str) == ("H" * 40, "hash")
+
+
+@pytest.mark.parametrize("side", SIDES)
+def test_every_selector_empty_on_one_side_is_reported_as_empty(caplog, side):
+    """All five selectors passed as "" is indistinguishable from passing none of them.
+
+    Otherwise "" would count toward the exclusion and a caller clearing two defaults would be
+    told they selected two things.
+    """
+    payload = {f"{side}_{suffix}": "" for suffix in SUFFIXES}
+    other = "comparison" if side == "baseline" else "baseline"
+    payload[f"{other}_branch"] = "OTHER"
+    result, text = _call(caplog, **payload)
+    assert result is None
+    assert "You need to provide one of" in text
+    assert "mutually exclusive" not in text
+
+
+@pytest.mark.parametrize("side", SIDES)
+def test_an_empty_string_does_not_count_toward_the_exclusion(caplog, side):
+    """ "" plus two real selectors reports 2, not 3."""
+    other = "comparison" if side == "baseline" else "baseline"
+    result, text = _call(
+        caplog,
+        **{
+            f"{side}_branch": "",
+            f"{side}_tag": "T",
+            f"{side}_hash": "H" * 40,
+            f"{other}_branch": "OTHER",
+        },
+    )
+    assert result is None
+    expected = "a total of 2: {},{}".format(_flag(side, "tag"), _flag(side, "hash"))
+    assert expected in text, text
+
+
+def test_env_comparison_table_binds_the_hashes_to_the_sides_its_caller_intends():
+    """The positional hash arguments must not be transposed.
+
+    compute_env_comparison_table is called with every argument positional. Its signature
+    declared comparison_hash before baseline_hash while the caller passes baseline first, so
+    each hash bound to the opposite parameter and was forwarded to get_by_strings under the
+    swapped name -- transposing the two sides of any --compare-by-env comparison filtered by
+    hash. Asserted on the signature because that is where the contract lives; the call site is
+    a 40-argument positional list that cannot be exercised without a live datasink.
+    """
+    import inspect
+
+    from redis_benchmarks_specification.__compare__.compare import (
+        compute_env_comparison_table,
+    )
+
+    names = list(inspect.signature(compute_env_comparison_table).parameters)
+    assert names.index("baseline_hash") < names.index("comparison_hash")
+    # the pair the caller supplies immediately before them, to catch a drift in either list
+    assert names.index("comparison_target_version") + 1 == names.index("baseline_hash")
+
+
+def test_every_selector_names_a_flag_the_parser_actually_accepts():
+    """_SELECTORS drives the error text, so a selector with no flag advertises a lie.
+
+    Nothing else links the two lists: adding a selector here would name a flag argparse does not
+    define, sending the user to a nonexistent option.
+    """
+    import argparse
+
+    from redis_benchmarks_specification.__compare__.args import create_compare_arguments
+    from redis_benchmarks_specification.__compare__.compare import _selector_flags
+
+    parser = create_compare_arguments(argparse.ArgumentParser())
+    known = {opt for action in parser._actions for opt in action.option_strings}
+    for side in SIDES:
+        missing = [f for f in _selector_flags(side) if f not in known]
+        assert not missing, f"{side}: error text names undefined flags {missing}"
+
+
+def test_a_selector_missing_from_the_call_site_is_a_hard_error():
+    """The resolver indexes `supplied` rather than using .get().
+
+    With .get(), a selector listed in _SELECTORS but absent from a call-site dict resolves to
+    None forever -- unsupplyable, while the error message still offers its flag.
+    """
+    from redis_benchmarks_specification.__compare__.compare import (
+        _SELECTORS,
+        _resolve_by,
+    )
+
+    complete = {suffix: None for suffix, _ in _SELECTORS}
+    complete["branch"] = "BASE"
+    for suffix, _ in _SELECTORS:
+        partial = {k: v for k, v in complete.items() if k != suffix}
+        with pytest.raises(KeyError):
+            _resolve_by("baseline", partial)
+
+
+@pytest.mark.parametrize(
+    "func_name", ("compute_env_comparison_table", "compute_regression_table")
+)
+def test_hash_parameters_are_declared_baseline_first(func_name):
+    """Both tables are called with every argument positional, so declaration order is the wiring.
+
+    Each previously declared comparison_hash before baseline_hash. compute_env_comparison_table
+    forwarded them baseline-first, so its two sides were transposed outright;
+    compute_regression_table forwarded them comparison-first, so the inversions cancelled and it
+    was correct by accident -- but a keyword caller, or an edit to either list alone, silently
+    swapped the sides. Canonical order in both means neither can drift on its own.
+    """
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    names = list(inspect.signature(getattr(mod, func_name)).parameters)
+    assert names.index("baseline_hash") < names.index("comparison_hash")
+
+
+def test_the_hashes_reach_get_by_strings_on_the_side_the_cli_supplied_them():
+    """End-to-end wiring check across both hops, read from the source.
+
+    The call sites are 47- and 48-argument positional lists that cannot run without a live
+    datasink, so the binding is resolved statically: caller local -> parameter -> forwarded
+    argument -> get_by_strings parameter. This is the check that would have caught the
+    transposition; a signature-order assertion alone would not, since the forward can move too.
+    """
+    import ast
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    tree = ast.parse(inspect.getsource(mod))
+    funcs = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
+
+    def positional_args(inside, callee):
+        for node in ast.walk(funcs[inside]):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == callee:
+                assert not node.keywords, f"{inside} -> {callee} mixes keywords"
+                return [a.id if isinstance(a, ast.Name) else None for a in node.args]
+        raise AssertionError(f"no call to {callee} inside {inside}")
+
+    def params(name):
+        args = funcs[name].args
+        return [a.arg for a in args.posonlyargs + args.args]
+
+    gbs = params("get_by_strings")
+    for table in ("compute_env_comparison_table", "compute_regression_table"):
+        outer = dict(
+            zip(params(table), positional_args("compare_command_logic", table))
+        )
+        forwarded = dict(zip(gbs, positional_args(table, "get_by_strings")))
+        for side in SIDES:
+            local = forwarded[f"{side}_hash"]
+            assert outer[local] == f"{side}_hash", (
+                f"{table}: get_by_strings.{side}_hash resolves to the caller's "
+                f"{outer[local]}, not {side}_hash"
+            )
+
+
+def test_rejection_raises_rather_than_exiting():
+    """SystemExit here would kill the coordinator daemon.
+
+    compute_regression_table reaches this resolver, and the coordinator calls it inside an
+    `except Exception` whose comment states the regression comment is best-effort so a data-shape
+    problem cannot abort the per-test loop. SystemExit does not derive from Exception, so it
+    escaped that guard, took the daemon down and left the stream un-ACKed. The CLI still exits 1;
+    compare_command_logic translates this.
+    """
+    payload = {name: None for name in ALL_KWARGS}
+    payload["baseline_branch"] = "B"
+    payload["baseline_hash"] = "H" * 40
+    payload["comparison_branch"] = "C"
+    with pytest.raises(ValueError):
+        get_by_strings(**payload)
     try:
-        if len(chosen) == 1:
-            assert get_by_strings(**payload) is not None
-        else:
-            with pytest.raises(SystemExit):
-                get_by_strings(**payload)
-            text = "\n".join(records)
-            match = re.search(r"total of (\d+):", text)
-            assert match and int(match.group(1)) == len(
-                chosen
-            ), f"{len(chosen)} selectors reported as {match.group(1) if match else None}"
-    finally:
-        root.removeHandler(handler)
+        get_by_strings(**payload)
+    except BaseException as exc:  # noqa: BLE001 - asserting the exception's own type
+        assert not isinstance(exc, SystemExit), "SystemExit escapes the daemon's guard"
+
+
+def test_the_cli_translates_a_selector_error_into_exit_1():
+    """compare_command_logic must keep the CLI's exit code despite the resolver only raising."""
+    import ast
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    tree = ast.parse(inspect.getsource(mod))
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "compare_command_logic"
+    )
+    handlers = [
+        h
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Try)
+        for h in node.handlers
+        if getattr(h.type, "id", None) == "ValueError"
+        and any(
+            isinstance(c, ast.Call)
+            and getattr(getattr(c.func, "value", None), "id", None) == "sys"
+            and getattr(c.func, "attr", None) == "exit"
+            for c in ast.walk(h)
+        )
+    ]
+    assert handlers, "no ValueError handler in compare_command_logic calls sys.exit"

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -41,7 +41,29 @@ def _flag(side, suffix):
     return "--{}-{}".format(side, suffix.replace("_", "-"))
 
 
-def _call(caplog, **kwargs):
+def _assert_offers_every_flag_in_exclusion(text, side):
+    """The exclusion message lists all five flags before naming the offenders."""
+    missing = [
+        _flag(side, suffix) for suffix in SUFFIXES if _flag(side, suffix) not in text
+    ]
+    assert not missing, f"exclusion message does not list {missing}: {text!r}"
+
+
+def _assert_offers_every_flag(text, side):
+    """Both messages must enumerate all five options for the side.
+
+    Asserting only that the text starts with "You need to provide one of" passes on
+    "You need to provide one of (  )" and on a list truncated to a single flag. A message that
+    silently offers fewer options than exist is the defect this module is being fixed for.
+    """
+    assert "You need to provide one of" in text
+    missing = [
+        _flag(side, suffix) for suffix in SUFFIXES if _flag(side, suffix) not in text
+    ]
+    assert not missing, f"message does not offer {missing}: {text!r}"
+
+
+def _call(**kwargs):
     """Invoke get_by_strings with every selector defaulted to None.
 
     Returns (result, message). A rejected call yields (None, the ValueError's message): the
@@ -67,18 +89,19 @@ def _call(caplog, **kwargs):
 
 @pytest.mark.parametrize("side", SIDES)
 @pytest.mark.parametrize("pair", list(itertools.combinations(SUFFIXES, 2)))
-def test_every_pair_of_selectors_is_rejected_with_an_accurate_count(caplog, side, pair):
+def test_every_pair_of_selectors_is_rejected_with_an_accurate_count(side, pair):
     """Two selectors on one side must exit, naming both, with a count of 2.
 
     Parametrized over all 10 pairs x both sides: 6 of 10 baseline pairs previously reported
     "a total of 1", and 4 of 10 comparison pairs were not rejected at all.
     """
     a, b = pair
-    result, text = _call(caplog, **{f"{side}_{a}": "AAA", f"{side}_{b}": "BBB"})
+    result, text = _call(**{f"{side}_{a}": "AAA", f"{side}_{b}": "BBB"})
     assert result is None, f"{side} {a}+{b} was accepted instead of rejected"
     match = re.search(r"total of (\d+): (.*?)\. Pick", text)
     assert match, f"no count in error for {side} {a}+{b}: {text!r}"
     assert int(match.group(1)) == 2, f"{side} {a}+{b} reported {match.group(1)}, not 2"
+    _assert_offers_every_flag_in_exclusion(text, side)
     named = [n.strip() for n in match.group(2).split(",")]
     assert sorted(named) == sorted(
         [_flag(side, a), _flag(side, b)]
@@ -87,11 +110,9 @@ def test_every_pair_of_selectors_is_rejected_with_an_accurate_count(caplog, side
 
 @pytest.mark.parametrize("side", SIDES)
 @pytest.mark.parametrize("suffix", SUFFIXES)
-def test_a_single_selector_is_accepted_and_reported_with_its_own_label(
-    caplog, side, suffix
-):
+def test_a_single_selector_is_accepted_and_reported_with_its_own_label(side, suffix):
     """Exactly one selector must be accepted, and its value and label returned."""
-    result, _ = _call(caplog, **{f"{side}_{suffix}": "PICKED"})
+    result, _ = _call(**{f"{side}_{suffix}": "PICKED"})
     assert result is not None, f"{side} {suffix} alone was rejected"
     baseline_str, by_baseline, comparison_str, by_comparison = result
     value, label = (
@@ -104,14 +125,14 @@ def test_a_single_selector_is_accepted_and_reported_with_its_own_label(
 
 
 @pytest.mark.parametrize("side", SIDES)
-def test_no_selector_on_a_side_is_rejected(caplog, side):
+def test_no_selector_on_a_side_is_rejected(side):
     """A side with nothing supplied must exit rather than compare against nothing."""
     payload = {name: None for name in ALL_KWARGS}
     other = "comparison" if side == "baseline" else "baseline"
     payload[f"{other}_branch"] = "OTHER"
     with pytest.raises(ValueError) as excinfo:
         get_by_strings(**payload)
-    assert "You need to provide one of" in str(excinfo.value)
+    _assert_offers_every_flag(str(excinfo.value), side)
 
 
 @settings(max_examples=300, deadline=None)
@@ -144,7 +165,7 @@ def test_any_number_of_selectors_above_one_is_rejected_with_a_matching_count(
 
 
 @pytest.mark.parametrize("side", SIDES)
-def test_an_empty_branch_alongside_a_hash_is_accepted(caplog, side):
+def test_an_empty_branch_alongside_a_hash_is_accepted(side):
     """`--<side>-branch '' --<side>-hash X` must resolve to the hash, not error.
 
     compare_command_logic defaults --baseline-branch to "unstable", so selecting by hash means
@@ -154,7 +175,6 @@ def test_an_empty_branch_alongside_a_hash_is_accepted(caplog, side):
     """
     other = "comparison" if side == "baseline" else "baseline"
     result, text = _call(
-        caplog,
         **{f"{side}_branch": "", f"{side}_hash": "H" * 40, f"{other}_branch": "OTHER"},
     )
     assert result is not None, f"rejected the documented idiom: {text}"
@@ -164,7 +184,7 @@ def test_an_empty_branch_alongside_a_hash_is_accepted(caplog, side):
 
 
 @pytest.mark.parametrize("side", SIDES)
-def test_every_selector_empty_on_one_side_is_reported_as_empty(caplog, side):
+def test_every_selector_empty_on_one_side_is_reported_as_empty(side):
     """All five selectors passed as "" is indistinguishable from passing none of them.
 
     Otherwise "" would count toward the exclusion and a caller clearing two defaults would be
@@ -173,18 +193,17 @@ def test_every_selector_empty_on_one_side_is_reported_as_empty(caplog, side):
     payload = {f"{side}_{suffix}": "" for suffix in SUFFIXES}
     other = "comparison" if side == "baseline" else "baseline"
     payload[f"{other}_branch"] = "OTHER"
-    result, text = _call(caplog, **payload)
+    result, text = _call(**payload)
     assert result is None
-    assert "You need to provide one of" in text
+    _assert_offers_every_flag(text, side)
     assert "mutually exclusive" not in text
 
 
 @pytest.mark.parametrize("side", SIDES)
-def test_an_empty_string_does_not_count_toward_the_exclusion(caplog, side):
+def test_an_empty_string_does_not_count_toward_the_exclusion(side):
     """ "" plus two real selectors reports 2, not 3."""
     other = "comparison" if side == "baseline" else "baseline"
     result, text = _call(
-        caplog,
         **{
             f"{side}_branch": "",
             f"{side}_tag": "T",
@@ -213,25 +232,6 @@ def test_every_selector_names_a_flag_the_parser_actually_accepts():
     for side in SIDES:
         missing = [f for f in _selector_flags(side) if f not in known]
         assert not missing, f"{side}: error text names undefined flags {missing}"
-
-
-def test_a_selector_missing_from_the_call_site_is_a_hard_error():
-    """The resolver indexes `supplied` rather than using .get().
-
-    With .get(), a selector listed in _SELECTORS but absent from a call-site dict resolves to
-    None forever -- unsupplyable, while the error message still offers its flag.
-    """
-    from redis_benchmarks_specification.__compare__.compare import (
-        _SELECTORS,
-        _resolve_by,
-    )
-
-    complete = {suffix: None for suffix, _ in _SELECTORS}
-    complete["branch"] = "BASE"
-    for suffix, _ in _SELECTORS:
-        partial = {k: v for k, v in complete.items() if k != suffix}
-        with pytest.raises(KeyError):
-            _resolve_by("baseline", partial)
 
 
 @pytest.mark.parametrize(
@@ -272,10 +272,6 @@ def test_rejection_raises_rather_than_exiting():
     payload["comparison_branch"] = "C"
     with pytest.raises(ValueError):
         get_by_strings(**payload)
-    try:
-        get_by_strings(**payload)
-    except BaseException as exc:  # noqa: BLE001 - asserting the exception's own type
-        assert not isinstance(exc, SystemExit), "SystemExit escapes the daemon's guard"
 
 
 def test_the_cli_translates_a_selector_error_into_exit_1():

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -365,3 +365,49 @@ def test_the_cli_translates_a_selector_error_into_exit_1():
         )
     ]
     assert handlers, "no ValueError handler in compare_command_logic calls sys.exit"
+
+
+def test_no_selector_is_reassigned_between_validation_and_the_table_calls():
+    """The up-front validation is only meaningful if it inspects the values the tables receive.
+
+    compare_command_logic validates the selectors once, then calls one of the two table functions
+    much later. A reassignment in between would leave the validation checking stale values, and a
+    conflict reaching the resolver at runtime would surface as an uncaught ValueError -- a
+    traceback rather than the clean exit 1 the validation exists to produce.
+    """
+    import ast
+    import inspect
+
+    import redis_benchmarks_specification.__compare__.compare as mod
+
+    fn = next(
+        n
+        for n in ast.walk(ast.parse(inspect.getsource(mod)))
+        if isinstance(n, ast.FunctionDef) and n.name == "compare_command_logic"
+    )
+    guards = [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Try)
+        and any(getattr(h.type, "id", None) == "ValueError" for h in n.handlers)
+    ]
+    assert len(guards) == 1, "expected exactly one selector-validation guard"
+    validated_at = guards[0].end_lineno
+    last_table_call = max(
+        n.lineno
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call)
+        and getattr(n.func, "id", "")
+        in ("compute_env_comparison_table", "compute_regression_table")
+    )
+    selectors = {f"{side}_{suffix}" for side in SIDES for suffix in SUFFIXES}
+    reassigned = [
+        (node.lineno, target.id)
+        for node in ast.walk(fn)
+        if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign))
+        for target in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        if isinstance(target, ast.Name)
+        and target.id in selectors
+        and validated_at < node.lineno < last_table_call
+    ]
+    assert not reassigned, f"selectors reassigned after validation: {reassigned}"

--- a/utils/tests/test_compare_selectors.py
+++ b/utils/tests/test_compare_selectors.py
@@ -1,0 +1,140 @@
+"""Property tests for baseline/comparison selector resolution in the compare tool.
+
+`get_by_strings` picks the single thing each side of a comparison is identified by. Two
+defects made it unreliable, and both were silent:
+
+* the error list was appended to only inside each selector's own failure branch, so whichever
+  selector was supplied first went unrecorded -- any pair not involving `--*-branch` reported
+  "a total of 1" and named the wrong flag;
+* the `--comparison-hash` exclusion check was commented out, so four comparison pairs were
+  accepted with no error at all and the hash quietly won by being last in the chain. A wrong
+  selector here silently compares the wrong two things, which is worse than refusing to run.
+
+Offline; no Redis, no Docker.
+"""
+
+import itertools
+import logging
+import re
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from redis_benchmarks_specification.__compare__.compare import get_by_strings
+
+SUFFIXES = ("branch", "tag", "target_version", "target_branch", "hash")
+SIDES = ("baseline", "comparison")
+ALL_KWARGS = tuple(f"{side}_{suffix}" for side in SIDES for suffix in SUFFIXES)
+# label reported for each suffix, per the flag names in the error text
+LABELS = {
+    "branch": "branch",
+    "tag": "version",
+    "target_version": "target+version",
+    "target_branch": "target+branch",
+    "hash": "hash",
+}
+
+
+def _call(caplog, **kwargs):
+    """Invoke get_by_strings with every selector defaulted to None, returning logged text."""
+    payload = {name: None for name in ALL_KWARGS}
+    payload.update(kwargs)
+    # each side needs one selector or it exits for being empty, which is a different test
+    if not any(k.startswith("baseline") and payload[k] for k in ALL_KWARGS):
+        payload["baseline_branch"] = "BASE"
+    if not any(k.startswith("comparison") and payload[k] for k in ALL_KWARGS):
+        payload["comparison_branch"] = "CMP"
+    with caplog.at_level(logging.ERROR):
+        try:
+            return get_by_strings(**payload), caplog.text
+        except SystemExit:
+            return None, caplog.text
+
+
+@pytest.mark.parametrize("side", SIDES)
+@pytest.mark.parametrize("pair", list(itertools.combinations(SUFFIXES, 2)))
+def test_every_pair_of_selectors_is_rejected_with_an_accurate_count(caplog, side, pair):
+    """Two selectors on one side must exit, naming both, with a count of 2.
+
+    Parametrized over all 10 pairs x both sides: 6 of 10 baseline pairs previously reported
+    "a total of 1", and 4 of 10 comparison pairs were not rejected at all.
+    """
+    a, b = pair
+    result, text = _call(caplog, **{f"{side}_{a}": "AAA", f"{side}_{b}": "BBB"})
+    assert result is None, f"{side} {a}+{b} was accepted instead of rejected"
+    match = re.search(r"total of (\d+): ([^.]*)", text)
+    assert match, f"no count in error for {side} {a}+{b}: {text!r}"
+    assert int(match.group(1)) == 2, f"{side} {a}+{b} reported {match.group(1)}, not 2"
+    named = [n.strip() for n in match.group(2).split(",")]
+    assert sorted(named) == sorted(
+        [LABELS[a], LABELS[b]]
+    ), f"{side} {a}+{b} named {named}"
+
+
+@pytest.mark.parametrize("side", SIDES)
+@pytest.mark.parametrize("suffix", SUFFIXES)
+def test_a_single_selector_is_accepted_and_reported_with_its_own_label(
+    caplog, side, suffix
+):
+    """Exactly one selector must be accepted, and its value and label returned."""
+    result, _ = _call(caplog, **{f"{side}_{suffix}": "PICKED"})
+    assert result is not None, f"{side} {suffix} alone was rejected"
+    baseline_str, by_baseline, comparison_str, by_comparison = result
+    value, label = (
+        (baseline_str, by_baseline)
+        if side == "baseline"
+        else (comparison_str, by_comparison)
+    )
+    assert value == "PICKED"
+    assert label == LABELS[suffix]
+
+
+@pytest.mark.parametrize("side", SIDES)
+def test_no_selector_on_a_side_is_rejected(caplog, side):
+    """A side with nothing supplied must exit rather than compare against nothing."""
+    payload = {name: None for name in ALL_KWARGS}
+    other = "comparison" if side == "baseline" else "baseline"
+    payload[f"{other}_branch"] = "OTHER"
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit):
+            get_by_strings(**payload)
+    assert "You need to provide one of" in caplog.text
+
+
+@settings(max_examples=300, deadline=None)
+@given(
+    chosen=st.lists(st.sampled_from(SUFFIXES), min_size=1, max_size=5, unique=True),
+    side=st.sampled_from(SIDES),
+)
+def test_any_number_of_selectors_above_one_is_rejected_with_a_matching_count(
+    chosen, side
+):
+    """For any subset of selectors, accept exactly when the subset has size 1.
+
+    Generated rather than enumerated because the count must equal the number supplied for
+    every subset size, not only for pairs.
+    """
+    payload = {name: None for name in ALL_KWARGS}
+    other = "comparison" if side == "baseline" else "baseline"
+    payload[f"{other}_branch"] = "OTHER"
+    for suffix in chosen:
+        payload[f"{side}_{suffix}"] = "V"
+    records = []
+    handler = logging.Handler()
+    handler.emit = lambda record: records.append(record.getMessage())
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        if len(chosen) == 1:
+            assert get_by_strings(**payload) is not None
+        else:
+            with pytest.raises(SystemExit):
+                get_by_strings(**payload)
+            text = "\n".join(records)
+            match = re.search(r"total of (\d+):", text)
+            assert match and int(match.group(1)) == len(
+                chosen
+            ), f"{len(chosen)} selectors reported as {match.group(1) if match else None}"
+    finally:
+        root.removeHandler(handler)


### PR DESCRIPTION
Rewritten from scratch. The previous description covered two of the changes below and carried two false claims (a stale test count, and a version bump that had been dropped). In a PR about a tool telling users untrue things, that was the wrong thing to leave standing.

Every claim here is verified by execution; each behavioural change was checked by re-applying the defect it fixes.

---

## The two defects this started as

**Six of ten baseline selector pairs reported a miscounted error.** `--baseline-tag X --baseline-hash Y` said *"You selected a total of 1: hash"*. The error list was appended to only inside each selector's own failure branch, so whichever selector came first went unrecorded.

**Four of ten comparison pairs were accepted silently.** The `--comparison-hash` exclusion check was commented out, so the hash quietly won by being last in the chain. Provenance: `d62497b`, a WIP boxplot commit later squashed into #312 — +550 lines of unrelated chart code touching no selector semantics. An accident, not a deliberate escape hatch.

Both are fixed by one table-driven resolver shared by both sides. All 20 pairs are now rejected with an accurate count, naming the flags the user actually typed.

---

## What else is in here, and why

Each of these was found by review of an earlier commit in this PR. Listing them because a reviewer should not have to read the comment thread to learn what they are approving.

**1. An empty selector now means "not supplied" — everywhere.** Selecting a side by hash requires clearing the branch that defaults to `unstable`, and `''` is how callers do that. Only the baseline side was normalized, so enforcing the exclusion rejected `--comparison-hash H --comparison-branch ''` — the form the documented recipes use — while claiming a branch had been selected. All ten selectors now route through one `absent_if_empty` helper. Only `""` becomes absent; a space stays a space, since silently trimming would be a new untruth of the same kind.

**2. `--compare-by-env` was comparing the wrong two commits.** `compute_env_comparison_table` declared `comparison_hash` before `baseline_hash` while its caller passes 47 arguments positionally, baseline first, and then forwarded them baseline-first. So `--baseline-hash` became the comparison filter: **every `--compare-by-env` comparison filtered by hash had its two sides inverted, and its regression signs with them.** `compute_regression_table` had the same inverted declaration *and* an inverted forward, so the errors cancelled and it was correct by accident.

This is the one item here that silently corrupted results rather than producing a bad message, and it is the one an operator might later need to find. **If you would rather it landed under its own title, say so and I will split it out — it is a two-line signature change plus a test, and nothing else here depends on it.** I have kept it bundled because it was found by reviewing this diff and is in the function this PR rewrites, but that is a packaging judgment and it is yours to make.

**3. `exit(1)` from the resolver could stop the coordinator daemon.** `compute_regression_table` reaches the resolver, and the coordinator calls it inside an `except Exception` that its own comment at `self_contained_coordinator.py:2958-2961` declares best-effort, so a data-shape problem cannot abort the per-test loop. **`SystemExit` does not derive from `Exception`**, so it escaped that guard, stopped the daemon and left the stream un-ACKed.

Reproduction: `builder_schema.py:234` initialises `git_branch = None`, and the coordinator passes `comparison_tag=None`, so a tag-only or ref build leaves the comparison side with no selector at all — the empty-side path. Confirmed by driving the real coordinator argument set: on `main` the `SystemExit` escapes and the loop stops; with this change the `ValueError` is caught and the loop continues.

The resolver now raises; `compare_command_logic` validates up front and translates to `exit 1`, so the CLI is unchanged. **This is the highest-consequence fix in the PR and it is not what the title describes.**

**4. The default baseline branch was manufacturing conflicts.** `--baseline-hash X` on its own was rejected for conflicting with a `--baseline-branch` **the user never typed** — injected from the defaults file. That is the same untruth the PR is about, one layer out, and it is *why* clearing the branch with `''` was ever needed. The fallback now applies only when no other baseline selector was supplied. Nothing working changes: `--baseline-tag X` alone is rejected on `main` too, so this only converts false errors into correct behaviour.

**5. `get_by_strings` is keyword-only.** Ten same-typed positional arguments where crossing two changes nothing observable — not the arity, not the types, not the shape of the result, only which two things get compared — is how item 2 happened. Keyword-only makes it unwritable rather than tested for, and it closed a gap this PR had introduced: transposing the hashes at the new validation call site previously survived the entire suite while naming the wrong side's flags.

**6. Errors name flags, not datasink labels.** Passing `--baseline-tag` used to report `version` — a word absent from the command line. The labels are TimeSeries filter keys and cannot be renamed, so the two roles are now separate.

**7. `docs/CLI.md`** documents the five selectors, the default fallback and the empty-string form. The code comments called that idiom "documented" when nothing in the repo recorded it.

---

## Behaviour changes worth a changelog line

- `--compare-by-env` filtered by hash previously inverted the two sides (item 2).
- The coordinator no longer dies on a selector error (item 3).
- `--baseline-hash X` alone now works (item 4).
- **A datasink write changed.** For `--comparison-branch '' --comparison-hash H` on an actionable PR, the pull-request performance ZSET previously received a literal `""` member; it is now skipped. Garbage write replaced with none — but it is a write-path change in a PR framed as a selector fix.
- The error text changed in three ways: the flag order in the prefix, offenders named as flags, and `"You need to provider either"` → `"You need to provide one of"`. Nothing in the repo parses stderr; no test, doc, script or workflow matches these strings.

## Not fixed here

`--*-target-version` and `--*-target-branch` build a filter that can never match — the stored label value is `"<value> <target_name>"`, so `target+version=8.3.240` matches nothing while `target+version=8.3.240 redis` matches. Pre-existing, and only preserved by this PR, so it is **#462**.

## Version

`pyproject.toml` is left at `0.3.29`. Bumps land as their own commit here and #459 did not bump. **But note this matters operationally:** coordinators install a pinned version, so item 3 — the daemon fix — reaches nothing until a release. Happy to bump if you would rather it ship with this.

## Tests

**56, where this layer previously had zero** — `pytest utils/tests/test_compare*.py` collected nothing before. Offline, no Redis, no Docker. `black` clean; no new `flake8` findings.

The suite could not originally see most of what is above: it gated its own notion of "supplied" on truthiness while the code used `is not None`, so `""` was silently rewritten; and it called the resolver by keyword while production reached it through 47-argument positional lists. Both are fixed.

Every behavioural change was verified by re-applying its defect, with the mutation asserted to have actually landed in the file first — twice in this PR a mutation silently failed to match and reported a false "survived".