### PR TITLE
fix: decode boolean flags instead of calling bool() on their string form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.29"
+version = "0.3.30"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.30"
+version = "0.3.31"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -158,7 +158,7 @@ def spec_cli_args(parser):
     )
     parser.add_argument("--id", type=str, default="dockerhub")
     parser.add_argument("--mnt_point", type=str, default="")
-    parser.add_argument("--trigger-unstable-commits", type=bool, default=True)
+    parser.add_argument("--trigger-unstable-commits", type=parse_bool_arg, default=True)
     parser.add_argument(
         "--docker-dont-air-gap",
         default=False,

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -5,8 +5,8 @@
 #
 import datetime
 import os
-from distutils.util import strtobool
 from redis_benchmarks_specification.__common__.env import (
+    parse_bool_arg,
     GH_REDIS_SERVER_HOST,
     GH_TOKEN,
     GH_REDIS_SERVER_PORT,
@@ -75,7 +75,7 @@ def spec_cli_args(parser):
     )
     parser.add_argument(
         "--use-git-timestamp",
-        type=lambda x: bool(strtobool(x)),
+        type=parse_bool_arg,
         default=True,
         help="Use git timestamp",
     )

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -6,7 +6,7 @@
 import datetime
 import os
 from redis_benchmarks_specification.__common__.env import (
-    parse_bool_arg,
+    parse_bool,
     GH_REDIS_SERVER_HOST,
     GH_TOKEN,
     GH_REDIS_SERVER_PORT,
@@ -75,7 +75,7 @@ def spec_cli_args(parser):
     )
     parser.add_argument(
         "--use-git-timestamp",
-        type=parse_bool_arg,
+        type=parse_bool,
         default=True,
         help="Use git timestamp",
     )
@@ -158,7 +158,7 @@ def spec_cli_args(parser):
     )
     parser.add_argument("--id", type=str, default="dockerhub")
     parser.add_argument("--mnt_point", type=str, default="")
-    parser.add_argument("--trigger-unstable-commits", type=parse_bool_arg, default=True)
+    parser.add_argument("--trigger-unstable-commits", type=parse_bool, default=True)
     parser.add_argument(
         "--docker-dont-air-gap",
         default=False,

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -118,6 +118,16 @@ def parse_bool(value, default=False):
             return True
         if normalized in FALSE_STRINGS:
             return False
+        # Warn rather than fall back quietly. The previous bool() read every non-empty string as
+        # True, so an unrecognised truthy-looking value like "2" or "enabled" silently flips to
+        # this default -- and where the flag gates recording benchmark results, that turns a
+        # misconfiguration into missing data rather than an error.
+        logging.warning(
+            "Unrecognised boolean %r; expected one of %s. Using %r.",
+            value,
+            ", ".join(TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f)),
+            default,
+        )
         return default
     if isinstance(value, (int, float)):
         return bool(value)

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -165,7 +165,14 @@ PULL_REQUEST_TRIGGER_LABEL = os.getenv(
 # store_true flag, so a stray truthy read cannot be overridden on the command line -- setting
 # DATASINK_PUSH_RTS=0 would enable pushing forever. Note the sibling PUSH_RTS in __compare__/args
 # already reads 0 correctly, via int().
-DATASINK_RTS_PUSH = parse_bool(os.getenv("DATASINK_PUSH_RTS"), default=False)
+_DATASINK_PUSH_RTS_RAW = os.getenv("DATASINK_PUSH_RTS")
+# The default deliberately reproduces the old bool() reading -- any non-empty string is True -- so
+# an unrecognised value cannot flip this off. When the flag is False the datasink connection is
+# None and nothing is exported, so a wrong answer in that direction means benchmark results stop
+# being recorded with nothing to indicate why. Only recognised falsy spellings change meaning.
+DATASINK_RTS_PUSH = parse_bool(
+    _DATASINK_PUSH_RTS_RAW, default=bool(_DATASINK_PUSH_RTS_RAW)
+)
 DATASINK_RTS_AUTH = os.getenv("DATASINK_RTS_AUTH", None)
 DATASINK_RTS_USER = os.getenv("DATASINK_RTS_USER", None)
 DATASINK_RTS_HOST = os.getenv("DATASINK_RTS_HOST", "localhost")

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -151,7 +151,11 @@ def parse_bool_arg(value):
 PULL_REQUEST_TRIGGER_LABEL = os.getenv(
     "PULL_REQUEST_TRIGGER_LABEL", "action:run-benchmark"
 )
-DATASINK_RTS_PUSH = bool(os.getenv("DATASINK_PUSH_RTS", False))
+# parse_bool, not bool(): this is the default of a --datasink_push_results_redistimeseries
+# store_true flag, so a stray truthy read cannot be overridden on the command line -- setting
+# DATASINK_PUSH_RTS=0 would enable pushing forever. Note the sibling PUSH_RTS in __compare__/args
+# already reads 0 correctly, via int().
+DATASINK_RTS_PUSH = parse_bool(os.getenv("DATASINK_PUSH_RTS"), default=False)
 DATASINK_RTS_AUTH = os.getenv("DATASINK_RTS_AUTH", None)
 DATASINK_RTS_USER = os.getenv("DATASINK_RTS_USER", None)
 DATASINK_RTS_HOST = os.getenv("DATASINK_RTS_HOST", "localhost")

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -87,6 +87,66 @@ REDIS_BINS_EXPIRE_SECS = int(
     os.getenv("REDIS_BINS_EXPIRE_SECS", "{}".format(24 * 7 * 60 * 60))
 )
 
+TRUE_STRINGS = ("1", "true", "t", "yes", "y", "on")
+FALSE_STRINGS = ("0", "false", "f", "no", "n", "off", "")
+
+
+def parse_bool(value, default=False):
+    """Decode a boolean that has been through a string round-trip.
+
+    Booleans reach us as strings: written to the commits/builds streams with str(), and read from
+    the environment. A bare bool() on that is wrong in the one direction that matters -- every
+    non-empty string is truthy, so "False", "0" and "no" all decode to True and the flag is stuck
+    on. bytes are accepted because stream reads are not always decoded first.
+
+    An unrecognised string returns `default` rather than guessing, since guessing is what bool()
+    already does. Callers that need to distinguish "absent" from "unparseable" should check
+    membership before calling.
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode()
+        except UnicodeDecodeError:
+            return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in TRUE_STRINGS:
+            return True
+        if normalized in FALSE_STRINGS:
+            return False
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def parse_bool_arg(value):
+    """argparse `type=` for a boolean flag.
+
+    Same accepted spellings as parse_bool, but unrecognised input raises so argparse turns it into
+    a usage error instead of silently substituting a default -- on a command line, a typo should be
+    reported, not guessed at. The empty string is rejected for the same reason.
+
+    Accepts exactly the spellings distutils.util.strtobool did, which this replaces: distutils was
+    removed from the standard library in 3.12 and only resolves today via a setuptools shim, so
+    importing it made the CLI fail at import time in any environment without setuptools.
+    """
+    normalized = str(value).strip().lower()
+    if normalized in TRUE_STRINGS:
+        return True
+    if normalized and normalized in FALSE_STRINGS:
+        return False
+    raise ValueError(
+        "invalid boolean {!r}; expected one of {}".format(
+            value, ", ".join(TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f))
+        )
+    )
+
+
 # environment variables
 PULL_REQUEST_TRIGGER_LABEL = os.getenv(
     "PULL_REQUEST_TRIGGER_LABEL", "action:run-benchmark"

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -128,7 +128,9 @@ def parse_bool(value, default=...):
         try:
             value = value.decode()
         except UnicodeDecodeError:
-            value = None
+            # Left as-is rather than blanked to None: blanking erased the offending bytes from the
+            # message, making an undecodable field indistinguishable from an absent one.
+            pass
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in _TRUE_STRINGS:
@@ -137,11 +139,18 @@ def parse_bool(value, default=...):
             return False
         if not normalized:
             # Empty or whitespace-only. On the command line this is what an unset shell variable
-            # expands to -- `--verbose "$VERBOSE"` -- and bool("") was already False there, so the
-            # strict form keeps returning False rather than turning a common accident into a usage
-            # error. For a stream or environment value it means "not supplied", so it takes the
-            # caller's default; several of those flags default True and must not be flipped off by
-            # an absent field.
+            # expands to -- `--verbose "$VERBOSE"` -- so the strict form returns False rather than
+            # turning a common accident into a usage error.
+            #
+            # This is uniform across the nine converted flags, but it was not uniform before: the
+            # eight that used type=bool already read "" as False, while --use-git-timestamp used
+            # strtobool, which raised. So that one flag moves from a usage error to False. It is
+            # unified deliberately -- one rule beats two -- and it is moot in practice, because the
+            # value is discarded downstream regardless (see issue #464).
+            #
+            # For a stream or environment value, empty means "not supplied" and takes the caller's
+            # default; several of those flags default True and must not be flipped off by an absent
+            # field.
             return False if default is ... else default
         value = value.strip()
 
@@ -153,12 +162,17 @@ def parse_bool(value, default=...):
         raise argparse.ArgumentTypeError(
             "invalid boolean {!r}; expected one of {}".format(value, expected)
         )
+    # Warn when something was supplied and not understood -- the previous bool() read every
+    # non-empty string as True, so an unrecognised truthy-looking value like "2" silently flips to
+    # this default, and where the flag gates recording benchmark results that turns a
+    # misconfiguration into missing data rather than an error.
+    #
+    # Silent for None only, which means nothing was supplied. That is the normal case for an unset
+    # environment variable and warning about it would put noise in every run. Undecodable bytes are
+    # deliberately NOT folded into None: they are a supplied value that could not be read, and the
+    # reader needs to see which one.
     if value is not None:
-        # Warn rather than fall back quietly. The previous bool() read every non-empty string as
-        # True, so an unrecognised truthy-looking value like "2" silently flips to this default --
-        # and where the flag gates recording benchmark results, that turns a misconfiguration into
-        # missing data rather than an error.
-        logging.warning(
+        logging.getLogger(__name__).warning(
             "Unrecognised boolean %r; expected one of %s. Using %r.",
             value,
             expected,
@@ -191,9 +205,24 @@ ALLOWED_PROFILERS = "perf:record,vtune"
 PROFILERS_DEFAULT = "perf:record"
 PROFILE_FREQ_DEFAULT = "99"
 PROFILERS_DSO = os.getenv("PROFILERS_DSO", None)
-# parse_bool, not bool(int(...)): the latter raises ValueError at import time on PROFILE=false
-# or off, which aborts every entrypoint. "0" and "1" still work.
-PROFILERS_ENABLED = parse_bool(os.getenv("PROFILE"), default=False)
+# parse_bool, not bool(int(...)): the latter raises ValueError at import time on PROFILE=false or
+# off, which aborts every entrypoint. The default preserves the old reading for anything parse_bool
+# does not recognise -- bool(int(...)) treated EVERY non-zero integer as enabled, so narrowing to
+# the literal "1" would flip PROFILE=2 from on to off and silently stop profiling artifacts being
+# collected. Same policy as DATASINK_PUSH_RTS below: only recognised falsy spellings may change
+# meaning.
+_PROFILE_RAW = os.getenv("PROFILE")
+
+
+def _profile_was_enabled(raw):
+    """The pre-existing bool(int(raw)) reading, for values parse_bool does not recognise."""
+    try:
+        return bool(int(str(raw).strip()))
+    except (TypeError, ValueError):
+        return False
+
+
+PROFILERS_ENABLED = parse_bool(_PROFILE_RAW, default=_profile_was_enabled(_PROFILE_RAW))
 PROFILERS = os.getenv("PROFILERS", PROFILERS_DEFAULT)
 MAX_PROFILERS_PER_TYPE = int(os.getenv("MAX_PROFILERS", 1))
 PROFILE_FREQ = os.getenv("PROFILE_FREQ", PROFILE_FREQ_DEFAULT)

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 
@@ -87,74 +88,83 @@ REDIS_BINS_EXPIRE_SECS = int(
     os.getenv("REDIS_BINS_EXPIRE_SECS", "{}".format(24 * 7 * 60 * 60))
 )
 
-TRUE_STRINGS = ("1", "true", "t", "yes", "y", "on")
-FALSE_STRINGS = ("0", "false", "f", "no", "n", "off", "")
+_TRUE_STRINGS = ("1", "true", "t", "yes", "y", "on")
+_FALSE_STRINGS = ("0", "false", "f", "no", "n", "off")
 
 
-def parse_bool(value, default=False):
+def accepted_bool_spellings():
+    """The spellings parse_bool accepts, for error and warning messages."""
+    return _TRUE_STRINGS + _FALSE_STRINGS
+
+
+def parse_bool(value, default=...):
     """Decode a boolean that has been through a string round-trip.
 
-    Booleans reach us as strings: written to the commits/builds streams with str(), and read from
-    the environment. A bare bool() on that is wrong in the one direction that matters -- every
+    Booleans reach us as strings: written to the commits and builds streams with str(), and read
+    from the environment. A bare bool() on that is wrong in the one direction that matters -- every
     non-empty string is truthy, so "False", "0" and "no" all decode to True and the flag is stuck
     on. bytes are accepted because stream reads are not always decoded first.
 
-    An unrecognised string returns `default` rather than guessing, since guessing is what bool()
-    already does. Callers that need to distinguish "absent" from "unparseable" should check
-    membership before calling.
+    Ellipsis marks "no default given". A module-level object() sentinel would not survive an
+    importlib.reload: the signature default is captured at definition time while the identity test
+    reads the module global, so after a reload the two stop matching and the strict form silently
+    starts returning the sentinel instead of raising. Ellipsis is a builtin singleton, so it cannot
+    drift.
+
+    With no `default`, an unrecognised value raises -- which is why this is the correct callable for
+    argparse's `type=`, where a typo should be a usage error rather than a guess. Pass an explicit
+    `default` to get the value back instead, with a warning; that form is for values that arrive
+    from a stream or the environment, where raising would abort a consumer loop or an import.
+
+    Accepts the spellings distutils.util.strtobool did, plus surrounding whitespace. distutils was
+    removed from the standard library in 3.12 and resolves only via a setuptools shim.
+
+    Deliberately not accepting numbers: parse_bool(2) would have to be True while
+    parse_bool(str(2)) is not, which contradicts the round-trip property this exists to provide.
     """
     if isinstance(value, bool):
         return value
-    if value is None:
-        return default
     if isinstance(value, (bytes, bytearray)):
         try:
             value = value.decode()
         except UnicodeDecodeError:
-            return default
+            value = None
     if isinstance(value, str):
         normalized = value.strip().lower()
-        if normalized in TRUE_STRINGS:
+        if normalized in _TRUE_STRINGS:
             return True
-        if normalized in FALSE_STRINGS:
+        if normalized in _FALSE_STRINGS:
             return False
+        if not normalized:
+            # Empty or whitespace-only. On the command line this is what an unset shell variable
+            # expands to -- `--verbose "$VERBOSE"` -- and bool("") was already False there, so the
+            # strict form keeps returning False rather than turning a common accident into a usage
+            # error. For a stream or environment value it means "not supplied", so it takes the
+            # caller's default; several of those flags default True and must not be flipped off by
+            # an absent field.
+            return False if default is ... else default
+        value = value.strip()
+
+    expected = ", ".join(accepted_bool_spellings())
+    if default is ...:
+        # ArgumentTypeError, not ValueError: argparse reproduces this message verbatim, whereas a
+        # ValueError is replaced with "invalid parse_bool value: ..." -- which names an internal
+        # function and drops the list of spellings the user needs.
+        raise argparse.ArgumentTypeError(
+            "invalid boolean {!r}; expected one of {}".format(value, expected)
+        )
+    if value is not None:
         # Warn rather than fall back quietly. The previous bool() read every non-empty string as
-        # True, so an unrecognised truthy-looking value like "2" or "enabled" silently flips to
-        # this default -- and where the flag gates recording benchmark results, that turns a
-        # misconfiguration into missing data rather than an error.
+        # True, so an unrecognised truthy-looking value like "2" silently flips to this default --
+        # and where the flag gates recording benchmark results, that turns a misconfiguration into
+        # missing data rather than an error.
         logging.warning(
             "Unrecognised boolean %r; expected one of %s. Using %r.",
             value,
-            ", ".join(TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f)),
+            expected,
             default,
         )
-        return default
-    if isinstance(value, (int, float)):
-        return bool(value)
     return default
-
-
-def parse_bool_arg(value):
-    """argparse `type=` for a boolean flag.
-
-    Same accepted spellings as parse_bool, but unrecognised input raises so argparse turns it into
-    a usage error instead of silently substituting a default -- on a command line, a typo should be
-    reported, not guessed at. The empty string is rejected for the same reason.
-
-    Accepts exactly the spellings distutils.util.strtobool did, which this replaces: distutils was
-    removed from the standard library in 3.12 and only resolves today via a setuptools shim, so
-    importing it made the CLI fail at import time in any environment without setuptools.
-    """
-    normalized = str(value).strip().lower()
-    if normalized in TRUE_STRINGS:
-        return True
-    if normalized and normalized in FALSE_STRINGS:
-        return False
-    raise ValueError(
-        "invalid boolean {!r}; expected one of {}".format(
-            value, ", ".join(TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f))
-        )
-    )
 
 
 # environment variables
@@ -164,7 +174,7 @@ PULL_REQUEST_TRIGGER_LABEL = os.getenv(
 # parse_bool, not bool(): this is the default of a --datasink_push_results_redistimeseries
 # store_true flag, so a stray truthy read cannot be overridden on the command line -- setting
 # DATASINK_PUSH_RTS=0 would enable pushing forever. Note the sibling PUSH_RTS in __compare__/args
-# already reads 0 correctly, via int().
+# already reads 0 correctly, though via int(), which raises on a word -- see issue #465.
 _DATASINK_PUSH_RTS_RAW = os.getenv("DATASINK_PUSH_RTS")
 # The default deliberately reproduces the old bool() reading -- any non-empty string is True -- so
 # an unrecognised value cannot flip this off. When the flag is False the datasink connection is
@@ -181,7 +191,9 @@ ALLOWED_PROFILERS = "perf:record,vtune"
 PROFILERS_DEFAULT = "perf:record"
 PROFILE_FREQ_DEFAULT = "99"
 PROFILERS_DSO = os.getenv("PROFILERS_DSO", None)
-PROFILERS_ENABLED = bool(int(os.getenv("PROFILE", 0)))
+# parse_bool, not bool(int(...)): the latter raises ValueError at import time on PROFILE=false
+# or off, which aborts every entrypoint. "0" and "1" still work.
+PROFILERS_ENABLED = parse_bool(os.getenv("PROFILE"), default=False)
 PROFILERS = os.getenv("PROFILERS", PROFILERS_DEFAULT)
 MAX_PROFILERS_PER_TYPE = int(os.getenv("MAX_PROFILERS", 1))
 PROFILE_FREQ = os.getenv("PROFILE_FREQ", PROFILE_FREQ_DEFAULT)
@@ -205,9 +217,12 @@ BENCHMARK_TRIGGER_ORGS = os.getenv("BENCHMARK_TRIGGER_ORGS", "redis")
 # which command groups its diff touches and scope the run instead of executing the full
 # suite. Set BENCHMARK_PR_DIFF_SCOPING to a falsey value (0/false/no/off) to restore
 # full-suite-on-label.
-BENCHMARK_PR_DIFF_SCOPING = os.getenv(
-    "BENCHMARK_PR_DIFF_SCOPING", "1"
-).strip().lower() in ("1", "true", "yes", "on")
+# Was a hand-rolled copy of parse_bool accepting a different set (no "t", no "y"). Kept at
+# default=False so an unrecognised value still disables scoping as before, rather than
+# enabling it.
+BENCHMARK_PR_DIFF_SCOPING = parse_bool(
+    os.getenv("BENCHMARK_PR_DIFF_SCOPING", "1"), default=False
+)
 # PRs changing more than this many files are treated as inherently broad -> full suite
 # (also bounds the synchronous GitHub pagination done inside the webhook request).
 try:

--- a/redis_benchmarks_specification/__compare__/args.py
+++ b/redis_benchmarks_specification/__compare__/args.py
@@ -25,7 +25,22 @@ def get_start_time_vars(start_time=None):
 
 
 PERFORMANCE_GH_TOKEN = os.getenv("PERFORMANCE_GH_TOKEN", None)
-PERFORMANCE_RTS_PUSH = bool(int(os.getenv("PUSH_RTS", "0")))
+# parse_bool, not bool(int(...)): the latter raises ValueError at import time on PUSH_RTS=false,
+# which aborts every command that imports this module. The default preserves the old integer
+# reading so no non-zero value flips to disabled.
+_PUSH_RTS_RAW = os.getenv("PUSH_RTS", "0")
+
+
+def _push_rts_was_enabled(raw):
+    try:
+        return bool(int(str(raw).strip()))
+    except (TypeError, ValueError):
+        return False
+
+
+PERFORMANCE_RTS_PUSH = parse_bool(
+    _PUSH_RTS_RAW, default=_push_rts_was_enabled(_PUSH_RTS_RAW)
+)
 
 
 _, NOW_UTC, _ = get_start_time_vars()

--- a/redis_benchmarks_specification/__compare__/args.py
+++ b/redis_benchmarks_specification/__compare__/args.py
@@ -9,6 +9,7 @@ import datetime
 import os
 
 from redis_benchmarks_specification.__common__.env import (
+    parse_bool_arg,
     SPECS_PATH_TEST_SUITES,
 )
 
@@ -172,12 +173,12 @@ def create_compare_arguments(parser):
     parser.add_argument(
         "--comparison-target-branch", type=str, default=None, required=False
     )
-    parser.add_argument("--print-regressions-only", type=bool, default=False)
-    parser.add_argument("--print-improvements-only", type=bool, default=False)
-    parser.add_argument("--skip-unstable", type=bool, default=False)
-    parser.add_argument("--verbose", type=bool, default=False)
-    parser.add_argument("--simple-table", type=bool, default=False)
-    parser.add_argument("--use_metric_context_path", type=bool, default=False)
+    parser.add_argument("--print-regressions-only", type=parse_bool_arg, default=False)
+    parser.add_argument("--print-improvements-only", type=parse_bool_arg, default=False)
+    parser.add_argument("--skip-unstable", type=parse_bool_arg, default=False)
+    parser.add_argument("--verbose", type=parse_bool_arg, default=False)
+    parser.add_argument("--simple-table", type=parse_bool_arg, default=False)
+    parser.add_argument("--use_metric_context_path", type=parse_bool_arg, default=False)
     parser.add_argument("--testname_regex", type=str, default=".*", required=False)
     parser.add_argument(
         "--command-group-regex",

--- a/redis_benchmarks_specification/__compare__/args.py
+++ b/redis_benchmarks_specification/__compare__/args.py
@@ -9,7 +9,7 @@ import datetime
 import os
 
 from redis_benchmarks_specification.__common__.env import (
-    parse_bool_arg,
+    parse_bool,
     SPECS_PATH_TEST_SUITES,
 )
 
@@ -173,12 +173,12 @@ def create_compare_arguments(parser):
     parser.add_argument(
         "--comparison-target-branch", type=str, default=None, required=False
     )
-    parser.add_argument("--print-regressions-only", type=parse_bool_arg, default=False)
-    parser.add_argument("--print-improvements-only", type=parse_bool_arg, default=False)
-    parser.add_argument("--skip-unstable", type=parse_bool_arg, default=False)
-    parser.add_argument("--verbose", type=parse_bool_arg, default=False)
-    parser.add_argument("--simple-table", type=parse_bool_arg, default=False)
-    parser.add_argument("--use_metric_context_path", type=parse_bool_arg, default=False)
+    parser.add_argument("--print-regressions-only", type=parse_bool, default=False)
+    parser.add_argument("--print-improvements-only", type=parse_bool, default=False)
+    parser.add_argument("--skip-unstable", type=parse_bool, default=False)
+    parser.add_argument("--verbose", type=parse_bool, default=False)
+    parser.add_argument("--simple-table", type=parse_bool, default=False)
+    parser.add_argument("--use_metric_context_path", type=parse_bool, default=False)
     parser.add_argument("--testname_regex", type=str, default=".*", required=False)
     parser.add_argument(
         "--command-group-regex",

--- a/redis_benchmarks_specification/__spec__/args.py
+++ b/redis_benchmarks_specification/__spec__/args.py
@@ -7,7 +7,7 @@ import datetime
 
 
 from redis_benchmarks_specification.__common__.env import (
-    parse_bool_arg,
+    parse_bool,
     GH_REDIS_SERVER_HOST,
     GH_TOKEN,
     GH_REDIS_SERVER_PORT,
@@ -39,7 +39,7 @@ def spec_cli_args(parser):
         default=START_TIME_NOW_UTC,
     )
     parser.add_argument("--redis_repo", type=str, default=None)
-    parser.add_argument("--trigger-unstable-commits", type=parse_bool_arg, default=True)
+    parser.add_argument("--trigger-unstable-commits", type=parse_bool, default=True)
     parser.add_argument(
         "--use-tags",
         default=False,

--- a/redis_benchmarks_specification/__spec__/args.py
+++ b/redis_benchmarks_specification/__spec__/args.py
@@ -7,6 +7,7 @@ import datetime
 
 
 from redis_benchmarks_specification.__common__.env import (
+    parse_bool_arg,
     GH_REDIS_SERVER_HOST,
     GH_TOKEN,
     GH_REDIS_SERVER_PORT,
@@ -38,7 +39,7 @@ def spec_cli_args(parser):
         default=START_TIME_NOW_UTC,
     )
     parser.add_argument("--redis_repo", type=str, default=None)
-    parser.add_argument("--trigger-unstable-commits", type=bool, default=True)
+    parser.add_argument("--trigger-unstable-commits", type=parse_bool_arg, default=True)
     parser.add_argument(
         "--use-tags",
         default=False,

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -154,3 +154,100 @@ def test_every_accepted_spelling_is_lowercase_in_the_tables():
     """Lookup lowercases its input, so an uppercase table entry would be unreachable."""
     for text in itertools.chain(TRUE_STRINGS, FALSE_STRINGS):
         assert text == text.lower(), f"{text!r} can never match"
+
+
+# --- the flags this defect reached ------------------------------------------------------------
+
+COMPARE_BOOL_FLAGS = (
+    "--print-regressions-only",
+    "--print-improvements-only",
+    "--skip-unstable",
+    "--verbose",
+    "--simple-table",
+    "--use_metric_context_path",
+)
+
+
+@pytest.mark.parametrize("flag", COMPARE_BOOL_FLAGS)
+@pytest.mark.parametrize(
+    "text,expected", [("true", True), ("false", False), ("0", False)]
+)
+def test_compare_boolean_flags_honour_a_false_value(flag, text, expected):
+    """`type=bool` called bool() on the raw argv string, so `--skip-unstable false` meant True.
+
+    These six are all consumed by compare_command_logic, and they are the flags the compare CLI is
+    driven with, so a flag that silently inverts changes which rows a comparison prints.
+    """
+    import argparse
+
+    from redis_benchmarks_specification.__compare__.args import create_compare_arguments
+
+    parser = create_compare_arguments(argparse.ArgumentParser())
+    namespace = parser.parse_args([flag, text])
+    assert getattr(namespace, flag.lstrip("-").replace("-", "_")) is expected
+
+
+@pytest.mark.parametrize("flag", COMPARE_BOOL_FLAGS)
+def test_compare_boolean_flags_reject_a_typo(flag):
+    """A misspelled value must be a usage error, not silently False."""
+    import argparse
+
+    from redis_benchmarks_specification.__compare__.args import create_compare_arguments
+
+    parser = create_compare_arguments(argparse.ArgumentParser())
+    with pytest.raises(SystemExit):
+        parser.parse_args([flag, "flase"])
+
+
+def test_no_argument_parser_uses_type_bool():
+    """`type=bool` is never what anyone means.
+
+    argparse hands the `type` callable the raw argv string, so `type=bool` accepts any non-empty
+    value as True -- including "false", "0" and "no". Guarding the whole package because the
+    mistake is easy to reintroduce and impossible to see at the call site.
+    """
+    import pathlib
+
+    package = pathlib.Path("redis_benchmarks_specification")
+    offenders = [
+        f"{path}:{number}"
+        for path in package.rglob("*.py")
+        for number, line in enumerate(path.read_text().splitlines(), start=1)
+        if "type=bool" in line.replace(" ", "")
+    ]
+    assert not offenders, f"type=bool used at {offenders}"
+
+
+def test_datasink_push_env_var_honours_a_falsy_value():
+    """DATASINK_PUSH_RTS=0 previously enabled pushing, with no way to turn it off.
+
+    It is the default of a --datasink_push_results_redistimeseries store_true flag, so once the
+    default reads True the command line cannot override it. Re-imports the module because the value
+    is computed at import time.
+    """
+    import importlib
+    import os
+
+    import redis_benchmarks_specification.__common__.env as env_mod
+
+    original = os.environ.get("DATASINK_PUSH_RTS")
+    try:
+        for raw, expected in (
+            ("0", False),
+            ("false", False),
+            ("no", False),
+            ("1", True),
+            ("true", True),
+        ):
+            os.environ["DATASINK_PUSH_RTS"] = raw
+            reloaded = importlib.reload(env_mod)
+            assert (
+                reloaded.DATASINK_RTS_PUSH is expected
+            ), f"DATASINK_PUSH_RTS={raw!r} read as {reloaded.DATASINK_RTS_PUSH!r}"
+        os.environ.pop("DATASINK_PUSH_RTS")
+        assert importlib.reload(env_mod).DATASINK_RTS_PUSH is False
+    finally:
+        os.environ.pop("DATASINK_PUSH_RTS", None)
+        if original is not None:
+            os.environ["DATASINK_PUSH_RTS"] = original
+        importlib.reload(env_mod)

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -540,10 +540,14 @@ def test_the_other_boolean_environment_variables_use_the_same_decoder(
 def test_the_spec_subpackage_cannot_be_imported():
     """Documents why __spec__/args.py is not covered by introspection above.
 
-    The package contains a subpackage named __spec__, which shadows the module attribute CPython's
-    import machinery reads (`parent.__spec__._uninitialized_submodules`), so importing anything
-    beneath it raises AttributeError. That also means the `redis-benchmarks-spec` console script,
-    whose entrypoint is redis_benchmarks_specification.__spec__.cli:main, cannot start.
+    The package contains a subpackage named __spec__, which shadows the ModuleSpec CPython's import
+    machinery puts on the parent package, so importing anything beneath it raises AttributeError.
+    That also means the `redis-benchmarks-spec` console script, whose entrypoint is
+    redis_benchmarks_specification.__spec__.cli:main, cannot start.
+
+    Broken on every supported version; only the attribute named in the error differs -- 3.10 reports
+    submodule_search_locations, 3.12 reports _uninitialized_submodules. So the assertion matches the
+    shadowed module rather than either internal name.
 
     Pre-existing and out of scope here, but asserted so that fixing it fails this test and prompts
     restoring the coverage that had to be dropped.
@@ -560,4 +564,5 @@ def test_the_spec_subpackage_cannot_be_imported():
         "__spec__ is importable now -- restore it to _all_parsers() and re-enable the "
         "trigger-unstable-commits cases for it"
     )
-    assert "_uninitialized_submodules" in result.stderr
+    assert "AttributeError" in result.stderr, result.stderr
+    assert "__spec__" in result.stderr, result.stderr

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -228,66 +228,6 @@ def test_compare_boolean_flags_reject_a_typo(flag):
         parser.parse_args([flag, "flase"])
 
 
-def test_no_argument_parser_uses_type_bool():
-    """`type=bool` is never what anyone means.
-
-    argparse hands the `type` callable the raw argv string, so `type=bool` accepts any non-empty
-    value as True -- including "false", "0" and "no". Guarding the whole package because the
-    mistake is easy to reintroduce and impossible to see at the call site.
-    """
-    import pathlib
-
-    import redis_benchmarks_specification
-
-    package = pathlib.Path(redis_benchmarks_specification.__file__).parent
-    scanned = list(package.rglob("*.py"))
-    # A guard that cannot see the package must fail, not pass. Derived from __file__ because a
-    # relative path made this succeed vacuously from any directory but the repo root.
-    assert len(scanned) > 20, f"only scanned {len(scanned)} files under {package}"
-    offenders = [
-        f"{path}:{number}"
-        for path in scanned
-        for number, line in enumerate(path.read_text().splitlines(), start=1)
-        if "type=bool" in line.replace(" ", "")
-    ]
-    assert not offenders, f"type=bool used at {offenders}"
-
-
-def test_datasink_push_env_var_honours_a_falsy_value():
-    """DATASINK_PUSH_RTS=0 previously enabled pushing, with no way to turn it off.
-
-    It is the default of a --datasink_push_results_redistimeseries store_true flag, so once the
-    default reads True the command line cannot override it. Re-imports the module because the value
-    is computed at import time.
-    """
-    import importlib
-    import os
-
-    import redis_benchmarks_specification.__common__.env as env_mod
-
-    original = os.environ.get("DATASINK_PUSH_RTS")
-    try:
-        for raw, expected in (
-            ("0", False),
-            ("false", False),
-            ("no", False),
-            ("1", True),
-            ("true", True),
-        ):
-            os.environ["DATASINK_PUSH_RTS"] = raw
-            reloaded = importlib.reload(env_mod)
-            assert (
-                reloaded.DATASINK_RTS_PUSH is expected
-            ), f"DATASINK_PUSH_RTS={raw!r} read as {reloaded.DATASINK_RTS_PUSH!r}"
-        os.environ.pop("DATASINK_PUSH_RTS")
-        assert importlib.reload(env_mod).DATASINK_RTS_PUSH is False
-    finally:
-        os.environ.pop("DATASINK_PUSH_RTS", None)
-        if original is not None:
-            os.environ["DATASINK_PUSH_RTS"] = original
-        importlib.reload(env_mod)
-
-
 @pytest.mark.parametrize("value", ["2", "enabled", "maybe", "None"])
 def test_an_unrecognised_value_warns_rather_than_falling_back_quietly(caplog, value):
     """A silent fallback would turn a misconfiguration into missing data.
@@ -322,32 +262,6 @@ def test_the_warning_names_the_accepted_spellings(caplog):
     text = " ".join(r.getMessage() for r in caplog.records)
     for spelling in accepted_bool_spellings():
         assert spelling in text, f"warning does not mention {spelling!r}"
-
-
-@pytest.mark.parametrize("raw", ["2", "enabled", "on-please", "sure"])
-def test_an_unrecognised_datasink_setting_cannot_turn_pushing_off(raw):
-    """The fix must never be able to stop results reaching the datasink.
-
-    When DATASINK_RTS_PUSH is False the datasink connection is None and nothing is exported, so a
-    wrong answer in that direction means benchmark results silently stop being recorded. The old
-    bool() read any non-empty string as True; the default here reproduces that, so only recognised
-    falsy spellings change meaning. The fleet's actual setting is not visible from here, which is
-    exactly why this direction is pinned rather than assumed.
-    """
-    import importlib
-    import os
-
-    import redis_benchmarks_specification.__common__.env as env_mod
-
-    original = os.environ.get("DATASINK_PUSH_RTS")
-    try:
-        os.environ["DATASINK_PUSH_RTS"] = raw
-        assert importlib.reload(env_mod).DATASINK_RTS_PUSH is True
-    finally:
-        os.environ.pop("DATASINK_PUSH_RTS", None)
-        if original is not None:
-            os.environ["DATASINK_PUSH_RTS"] = original
-        importlib.reload(env_mod)
 
 
 @pytest.mark.parametrize("text", ["", "   ", "\t"])
@@ -403,65 +317,247 @@ def test_the_accepted_spellings_are_exactly_strtobool_s():
             parse_bool(text)
 
 
-def test_the_strict_form_survives_a_module_reload():
-    """A module-level object() sentinel silently breaks the strict form after a reload.
+def _all_parsers():
+    """Every argparse parser the package builds that can actually be imported.
 
-    The signature default is captured once at definition time while the identity test reads the
-    module global, so a reload rebinds one and not the other -- and parse_bool then treats "no
-    default" as "default given" and returns the sentinel instead of raising. Found because the
-    environment-variable tests in this file reload the module, which made the number-rejection
-    tests pass alone and fail in the suite. Ellipsis is a builtin singleton and cannot drift.
+    __spec__/args.py is deliberately absent: the package contains a subpackage literally named
+    __spec__, which shadows the attribute CPython's import machinery reads, so importing anything
+    beneath it raises. See test_the_spec_subpackage_cannot_be_imported.
     """
-    import importlib
+    import argparse
 
-    import redis_benchmarks_specification.__common__.env as env_mod
+    from redis_benchmarks_specification.__cli__.args import spec_cli_args
+    from redis_benchmarks_specification.__compare__.args import create_compare_arguments
 
-    importlib.reload(env_mod)
-    with pytest.raises(argparse.ArgumentTypeError):
-        env_mod.parse_bool("maybe")
-    # and the binding captured before the reload must behave the same way
-    with pytest.raises(argparse.ArgumentTypeError):
-        parse_bool("maybe")
+    return {
+        "compare": create_compare_arguments(argparse.ArgumentParser()),
+        "cli": spec_cli_args(argparse.ArgumentParser()),
+    }
+
+
+def test_no_parser_action_converts_with_builtin_bool():
+    """Introspect what argparse will call, not the characters used to name it.
+
+    A text scan for "type=bool" is the obvious guard and the wrong one: it misses
+    `builtins.bool`, `eval("bool")`, a functools.partial, an alias, a tab, and -- the one that
+    happens without any intent to evade -- a kwarg that black reformats across lines. Reading
+    action.type off the built parser catches all of them, and cannot pass vacuously depending on
+    the working directory the way a relative path scan did.
+    """
+    import functools
+
+    offenders = []
+    for name, parser in _all_parsers().items():
+        for action in parser._actions:
+            converter = action.type
+            if isinstance(converter, functools.partial):
+                converter = converter.func
+            if converter is bool:
+                offenders.append(f"{name}:{action.option_strings}")
+    assert not offenders, f"builtin bool used as an argparse converter: {offenders}"
+
+
+def test_every_boolean_flag_uses_the_canonical_decoder():
+    """Any flag that takes a boolean-looking value must go through parse_bool.
+
+    Otherwise a flag can be added with a hand-rolled converter that accepts a different set, which
+    is how the spellings drifted apart inside env.py in the first place.
+    """
+    known_boolean_flags = {
+        "--print-regressions-only",
+        "--print-improvements-only",
+        "--skip-unstable",
+        "--verbose",
+        "--simple-table",
+        "--use_metric_context_path",
+        "--use-git-timestamp",
+        "--trigger-unstable-commits",
+    }
+    seen = set()
+    for parser in _all_parsers().values():
+        for action in parser._actions:
+            for option in action.option_strings:
+                if option in known_boolean_flags:
+                    seen.add(option)
+                    assert (
+                        action.type is parse_bool
+                    ), f"{option} converts with {action.type!r}, not parse_bool"
+    assert (
+        seen == known_boolean_flags
+    ), f"flags not found in any parser: {known_boolean_flags - seen}"
+
+
+@pytest.mark.parametrize("parser_name", ["cli"])
+@pytest.mark.parametrize(
+    "text,expected", [("false", False), ("0", False), ("true", True)]
+)
+def test_trigger_unstable_commits_honours_a_false_value(parser_name, text, expected):
+    """The two flags that were previously guarded by nothing but a text scan.
+
+    Declared in two separate parsers and read nowhere, so the conversion is a no-op today -- but a
+    dead flag is exactly where a reintroduced defect goes unnoticed.
+    """
+    parser = _all_parsers()[parser_name]
+    assert (
+        parser.parse_args(["--trigger-unstable-commits", text]).trigger_unstable_commits
+        is expected
+    )
+
+
+@pytest.mark.parametrize("parser_name", ["cli"])
+def test_trigger_unstable_commits_rejects_a_typo(parser_name):
+    parser = _all_parsers()[parser_name]
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--trigger-unstable-commits", "flase"])
+
+
+@pytest.mark.parametrize("text", ["FALSE", " false ", "\tFalse\n", "OFF"])
+def test_the_strict_form_tolerates_case_and_padding(text):
+    """The CLI half of the case/padding contract, which was pinned only for the other half."""
+    assert parse_bool(text) is False
+
+
+@pytest.mark.parametrize("value", [bytearray(b"false"), bytearray(b"true")])
+def test_bytearray_is_decoded_like_bytes(value):
+    """Accepted for the stream sites, so it needs a pin rather than an untested branch."""
+    assert parse_bool(value) is (value == bytearray(b"true"))
+
+
+def _env_probe(script, **env):
+    """Run a snippet in a subprocess with the given environment, returning its stdout.
+
+    A subprocess rather than importlib.reload: env.py computes its constants at import time, and
+    reloading it rebinds function objects while every module that did a from-import keeps the old
+    ones. That makes identity checks order-dependent -- a test can pass alone and fail in the suite,
+    which is exactly what happened here -- and it never reaches the from-import copies that are what
+    production actually ships.
+    """
+    import os
+    import subprocess
+    import sys
+
+    environment = dict(os.environ)
+    environment.pop("DATASINK_PUSH_RTS", None)
+    environment.update({key: str(value) for key, value in env.items()})
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=True,
+    )
+    return result.stdout.strip()
 
 
 @pytest.mark.parametrize(
-    "name,default",
-    [("PROFILE", False), ("BENCHMARK_PR_DIFF_SCOPING", True)],
+    "raw,expected",
+    [
+        ("0", "False"),
+        ("false", "False"),
+        ("no", "False"),
+        ("off", "False"),
+        ("1", "True"),
+        ("true", "True"),
+    ],
 )
-def test_the_other_boolean_environment_variables_use_the_same_decoder(name, default):
+def test_datasink_push_env_var_honours_a_falsy_value(raw, expected):
+    """DATASINK_PUSH_RTS=0 previously enabled pushing, with no way to turn it off."""
+    script = (
+        "from redis_benchmarks_specification.__common__.env import DATASINK_RTS_PUSH;"
+        "print(DATASINK_RTS_PUSH)"
+    )
+    assert _env_probe(script, DATASINK_PUSH_RTS=raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["2", "enabled", "on-please", " "])
+def test_an_unrecognised_datasink_setting_cannot_turn_pushing_off(raw):
+    """The fix must never be able to stop results reaching the datasink.
+
+    When this is False the datasink connection is None and nothing is exported, so a wrong answer in
+    that direction means benchmark results silently stop being recorded. The old bool() read any
+    non-empty string as True and the default reproduces that, so only recognised falsy spellings
+    change meaning. The fleet's setting is not visible from here, which is why this is pinned.
+    """
+    script = (
+        "from redis_benchmarks_specification.__common__.env import DATASINK_RTS_PUSH;"
+        "print(DATASINK_RTS_PUSH)"
+    )
+    assert _env_probe(script, DATASINK_PUSH_RTS=raw) == "True"
+
+
+@pytest.mark.parametrize("module", ["__runner__", "__self_contained_coordinator__"])
+@pytest.mark.parametrize("raw,expected", [("0", "False"), ("1", "True")])
+def test_the_datasink_flag_default_the_parsers_ship_follows_the_env_var(
+    module, raw, expected
+):
+    """Assert the argparse default, not the module constant.
+
+    Both of these do `from ...env import DATASINK_RTS_PUSH` and use it as a store_true default, so
+    the constant is copied at import. Asserting the constant would pass while the default the flag
+    actually ships was stale -- and the default is the whole reason this value matters, since a
+    store_true flag cannot turn itself off.
+    """
+    factory = (
+        "create_client_runner_args"
+        if module == "__runner__"
+        else "create_self_contained_coordinator_args"
+    )
+    script = (
+        f"from redis_benchmarks_specification.{module}.args import {factory};"
+        f"p={factory}('probe');"
+        "print(p.parse_args([]).datasink_push_results_redistimeseries)"
+    )
+    assert _env_probe(script, DATASINK_PUSH_RTS=raw) == expected
+
+
+@pytest.mark.parametrize(
+    "name,attribute,raw,expected",
+    [
+        ("PROFILE", "PROFILERS_ENABLED", "false", "False"),
+        ("PROFILE", "PROFILERS_ENABLED", "off", "False"),
+        ("PROFILE", "PROFILERS_ENABLED", "1", "True"),
+        ("PROFILE", "PROFILERS_ENABLED", "t", "True"),
+        ("BENCHMARK_PR_DIFF_SCOPING", "BENCHMARK_PR_DIFF_SCOPING", "0", "False"),
+        ("BENCHMARK_PR_DIFF_SCOPING", "BENCHMARK_PR_DIFF_SCOPING", "t", "True"),
+    ],
+)
+def test_the_other_boolean_environment_variables_use_the_same_decoder(
+    name, attribute, raw, expected
+):
     """One decoder for the whole module, not four idioms in one file.
 
     PROFILE was bool(int(...)), which raises at import time on "false" and aborts every entrypoint.
-    BENCHMARK_PR_DIFF_SCOPING was a hand-rolled copy of parse_bool accepting a different set -- no
-    "t", no "y" -- which is exactly how the spellings drift apart.
+    BENCHMARK_PR_DIFF_SCOPING was a hand-rolled copy accepting a different set -- no "t", no "y" --
+    which is exactly how spellings drift apart.
     """
-    import importlib
-    import os
+    script = (
+        f"from redis_benchmarks_specification.__common__.env import {attribute};"
+        f"print({attribute})"
+    )
+    assert _env_probe(script, **{name: raw}) == expected
 
-    import redis_benchmarks_specification.__common__.env as env_mod
 
-    attribute = {
-        "PROFILE": "PROFILERS_ENABLED",
-        "BENCHMARK_PR_DIFF_SCOPING": "BENCHMARK_PR_DIFF_SCOPING",
-    }[name]
-    original = os.environ.get(name)
-    try:
-        for raw, expected in (
-            ("0", False),
-            ("false", False),
-            ("off", False),
-            ("1", True),
-            ("t", True),
-        ):
-            os.environ[name] = raw
-            reloaded = importlib.reload(env_mod)
-            assert (
-                getattr(reloaded, attribute) is expected
-            ), f"{name}={raw!r} read as {getattr(reloaded, attribute)!r}"
-        os.environ.pop(name)
-        assert getattr(importlib.reload(env_mod), attribute) is default
-    finally:
-        os.environ.pop(name, None)
-        if original is not None:
-            os.environ[name] = original
-        importlib.reload(env_mod)
+def test_the_spec_subpackage_cannot_be_imported():
+    """Documents why __spec__/args.py is not covered by introspection above.
+
+    The package contains a subpackage named __spec__, which shadows the module attribute CPython's
+    import machinery reads (`parent.__spec__._uninitialized_submodules`), so importing anything
+    beneath it raises AttributeError. That also means the `redis-benchmarks-spec` console script,
+    whose entrypoint is redis_benchmarks_specification.__spec__.cli:main, cannot start.
+
+    Pre-existing and out of scope here, but asserted so that fixing it fails this test and prompts
+    restoring the coverage that had to be dropped.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import redis_benchmarks_specification.__spec__.args"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, (
+        "__spec__ is importable now -- restore it to _all_parsers() and re-enable the "
+        "trigger-unstable-commits cases for it"
+    )
+    assert "_uninitialized_submodules" in result.stderr

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -10,6 +10,7 @@ Offline; no Redis, no Docker.
 """
 
 import itertools
+import logging
 
 import pytest
 from hypothesis import given
@@ -251,3 +252,37 @@ def test_datasink_push_env_var_honours_a_falsy_value():
         if original is not None:
             os.environ["DATASINK_PUSH_RTS"] = original
         importlib.reload(env_mod)
+
+
+@pytest.mark.parametrize("value", ["2", "enabled", "maybe", "None"])
+def test_an_unrecognised_value_warns_rather_than_falling_back_quietly(caplog, value):
+    """A silent fallback would turn a misconfiguration into missing data.
+
+    bool() read every non-empty string as True, so an unrecognised truthy-looking value used to
+    enable a flag and now takes the default instead. Where the flag gates whether benchmark results
+    are recorded, flipping it off without saying so is worse than either answer.
+    """
+    with caplog.at_level(logging.WARNING):
+        parse_bool(value)
+    assert any(
+        "Unrecognised boolean" in record.getMessage() for record in caplog.records
+    ), f"no warning for {value!r}"
+
+
+@pytest.mark.parametrize("value", list(TRUE_STRINGS) + [f for f in FALSE_STRINGS if f])
+def test_a_recognised_value_does_not_warn(caplog, value):
+    """Otherwise every normal run logs noise and the real warnings stop being read."""
+    with caplog.at_level(logging.WARNING):
+        parse_bool(value)
+    assert not [
+        r for r in caplog.records if "Unrecognised boolean" in r.getMessage()
+    ], f"spurious warning for {value!r}"
+
+
+def test_the_warning_names_the_accepted_spellings(caplog):
+    """A warning that does not say what was expected sends the reader to the source."""
+    with caplog.at_level(logging.WARNING):
+        parse_bool("enabled")
+    text = " ".join(r.getMessage() for r in caplog.records)
+    for spelling in TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f):
+        assert spelling in text, f"warning does not mention {spelling!r}"

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -1,3 +1,8 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
 """Property tests for boolean decoding of values that have been through a string round-trip.
 
 Booleans reach this package as strings: written to the commits and builds streams with `str()`,
@@ -9,6 +14,7 @@ reads are not always decoded first.
 Offline; no Redis, no Docker.
 """
 
+import argparse
 import itertools
 import logging
 
@@ -17,11 +23,17 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from redis_benchmarks_specification.__common__.env import (
-    FALSE_STRINGS,
-    TRUE_STRINGS,
+    _FALSE_STRINGS,
+    _TRUE_STRINGS,
+    accepted_bool_spellings,
     parse_bool,
-    parse_bool_arg,
 )
+
+# Pinned as literals, deliberately NOT derived from the module. The tables decide what every
+# boolean flag means, and a test that iterates them only asserts that the lookup reads its own
+# table -- moving "off" from one to the other would keep such a suite green.
+EXPECTED_TRUE = ("1", "true", "t", "yes", "y", "on")
+EXPECTED_FALSE = ("0", "false", "f", "no", "n", "off")
 
 
 @given(value=st.booleans())
@@ -30,32 +42,43 @@ def test_a_bool_survives_the_str_round_trip(value):
 
     `str(False)` is `"False"`, and `bool("False")` is `True`. This is the whole defect.
     """
-    assert parse_bool(str(value)) is value
+    assert parse_bool(str(value), default=None) is value
 
 
 @given(value=st.booleans())
 def test_a_bool_survives_the_round_trip_as_bytes(value):
     """Stream reads are not always decoded, so the bytes form must round-trip too."""
-    assert parse_bool(str(value).encode()) is value
+    assert parse_bool(str(value).encode(), default=None) is value
 
 
-@pytest.mark.parametrize("text", TRUE_STRINGS)
+@pytest.mark.parametrize("text", EXPECTED_TRUE)
 def test_true_spellings(text):
     assert parse_bool(text) is True
     assert parse_bool(text.upper()) is True
     assert parse_bool(f"  {text}  ") is True
 
 
-@pytest.mark.parametrize("text", FALSE_STRINGS)
+@pytest.mark.parametrize("text", EXPECTED_FALSE)
 def test_false_spellings(text):
     assert parse_bool(text) is False
     assert parse_bool(text.upper()) is False
     assert parse_bool(f"  {text}  ") is False
 
 
+def test_the_module_tables_match_the_pinned_literals():
+    """The assertion that makes every other spelling test non-vacuous.
+
+    Every parametrized spelling test above iterates the pinned literals, so without this the module
+    could move "off" from one table to the other and the suite would stay green -- it would only be
+    asserting that the lookup reads its own table.
+    """
+    assert _TRUE_STRINGS == EXPECTED_TRUE
+    assert _FALSE_STRINGS == EXPECTED_FALSE
+
+
 def test_true_and_false_spellings_do_not_overlap():
     """A spelling in both tables would make the tables' order decide the answer."""
-    assert not set(TRUE_STRINGS) & set(FALSE_STRINGS)
+    assert not set(EXPECTED_TRUE) & set(EXPECTED_FALSE)
 
 
 @pytest.mark.parametrize("value", [True, False])
@@ -82,45 +105,50 @@ def test_none_returns_the_default(default):
     assert parse_bool(None, default=default) is default
 
 
-@given(number=st.integers())
-def test_numbers_follow_python_truthiness(number):
-    """A stream field written from an int should not become a silent default."""
-    assert parse_bool(number) is bool(number)
-
-
 @given(
     value=st.one_of(
         st.booleans(),
-        st.sampled_from(TRUE_STRINGS + FALSE_STRINGS),
+        st.sampled_from(EXPECTED_TRUE + EXPECTED_FALSE),
         st.integers(min_value=-3, max_value=3),
         st.none(),
     )
 )
 def test_parse_bool_always_returns_a_bool(value):
     """Never a truthy string, never None -- callers use the result in `if` and in f-strings."""
-    assert isinstance(parse_bool(value), bool)
+    assert isinstance(parse_bool(value, default=False), bool)
 
 
-# --- the argparse variant -------------------------------------------------------------------
+# --- the strict form, which is what argparse gets --------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "text", [t for t in TRUE_STRINGS + FALSE_STRINGS if t]  # "" is rejected, see below
-)
-def test_parse_bool_arg_accepts_every_spelling_parse_bool_does(text):
-    """The two must agree, or a flag means one thing on the CLI and another on the stream."""
-    assert parse_bool_arg(text) is parse_bool(text)
+@pytest.mark.parametrize("text", EXPECTED_TRUE + EXPECTED_FALSE)
+def test_the_strict_and_defaulting_forms_agree_on_every_spelling(text):
+    """Omitting `default` must change only what happens to unrecognised input.
+
+    If the two forms disagreed on a recognised spelling, a flag would mean one thing on the command
+    line and another when the same value arrived from a stream.
+    """
+    assert parse_bool(text) is parse_bool(text, default=None)
 
 
-@pytest.mark.parametrize("text", ["maybe", "", "2", "tru", "flase"])
-def test_parse_bool_arg_rejects_unrecognised_input(text):
+@pytest.mark.parametrize("text", ["maybe", "2", "tru", "flase", None])
+def test_omitting_the_default_raises_on_unrecognised_input(text):
     """On a command line a typo should be reported, not guessed at.
 
-    argparse converts ValueError from a `type=` callable into a usage error, so this is what makes
-    `--use-git-timestamp flase` fail loudly instead of silently meaning False.
+    ArgumentTypeError specifically: argparse reproduces its message verbatim, whereas a ValueError
+    is replaced with "invalid parse_bool value: ..." -- which names an internal function and drops
+    the list of spellings the reader needs.
     """
-    with pytest.raises(ValueError):
-        parse_bool_arg(text)
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_bool(text)
+
+
+@pytest.mark.parametrize("text", ["maybe", "2", "tru"])
+def test_the_raised_message_names_every_accepted_spelling(text):
+    with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+        parse_bool(text)
+    for spelling in accepted_bool_spellings():
+        assert spelling in str(excinfo.value), f"message omits {spelling!r}"
 
 
 def test_the_cli_no_longer_imports_distutils():
@@ -153,7 +181,7 @@ def test_use_git_timestamp_flag_parses_false():
 
 def test_every_accepted_spelling_is_lowercase_in_the_tables():
     """Lookup lowercases its input, so an uppercase table entry would be unreachable."""
-    for text in itertools.chain(TRUE_STRINGS, FALSE_STRINGS):
+    for text in itertools.chain(EXPECTED_TRUE, EXPECTED_FALSE):
         assert text == text.lower(), f"{text!r} can never match"
 
 
@@ -209,10 +237,16 @@ def test_no_argument_parser_uses_type_bool():
     """
     import pathlib
 
-    package = pathlib.Path("redis_benchmarks_specification")
+    import redis_benchmarks_specification
+
+    package = pathlib.Path(redis_benchmarks_specification.__file__).parent
+    scanned = list(package.rglob("*.py"))
+    # A guard that cannot see the package must fail, not pass. Derived from __file__ because a
+    # relative path made this succeed vacuously from any directory but the repo root.
+    assert len(scanned) > 20, f"only scanned {len(scanned)} files under {package}"
     offenders = [
         f"{path}:{number}"
-        for path in package.rglob("*.py")
+        for path in scanned
         for number, line in enumerate(path.read_text().splitlines(), start=1)
         if "type=bool" in line.replace(" ", "")
     ]
@@ -263,17 +297,19 @@ def test_an_unrecognised_value_warns_rather_than_falling_back_quietly(caplog, va
     are recorded, flipping it off without saying so is worse than either answer.
     """
     with caplog.at_level(logging.WARNING):
-        parse_bool(value)
+        parse_bool(value, default=False)
     assert any(
         "Unrecognised boolean" in record.getMessage() for record in caplog.records
     ), f"no warning for {value!r}"
 
 
-@pytest.mark.parametrize("value", list(TRUE_STRINGS) + [f for f in FALSE_STRINGS if f])
+@pytest.mark.parametrize(
+    "value", list(EXPECTED_TRUE) + [f for f in EXPECTED_FALSE if f]
+)
 def test_a_recognised_value_does_not_warn(caplog, value):
     """Otherwise every normal run logs noise and the real warnings stop being read."""
     with caplog.at_level(logging.WARNING):
-        parse_bool(value)
+        parse_bool(value, default=False)
     assert not [
         r for r in caplog.records if "Unrecognised boolean" in r.getMessage()
     ], f"spurious warning for {value!r}"
@@ -282,9 +318,9 @@ def test_a_recognised_value_does_not_warn(caplog, value):
 def test_the_warning_names_the_accepted_spellings(caplog):
     """A warning that does not say what was expected sends the reader to the source."""
     with caplog.at_level(logging.WARNING):
-        parse_bool("enabled")
+        parse_bool("enabled", default=False)
     text = " ".join(r.getMessage() for r in caplog.records)
-    for spelling in TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f):
+    for spelling in accepted_bool_spellings():
         assert spelling in text, f"warning does not mention {spelling!r}"
 
 
@@ -311,4 +347,121 @@ def test_an_unrecognised_datasink_setting_cannot_turn_pushing_off(raw):
         os.environ.pop("DATASINK_PUSH_RTS", None)
         if original is not None:
             os.environ["DATASINK_PUSH_RTS"] = original
+        importlib.reload(env_mod)
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\t"])
+def test_an_empty_value_stays_false_on_the_command_line(text):
+    """`--verbose "$VERBOSE"` with the variable unset is the shape that produces this.
+
+    bool("") was already False, so turning it into a usage error would be a regression on the one
+    out-of-table value a shell produces by accident rather than by typo.
+    """
+    assert parse_bool(text) is False
+
+
+@pytest.mark.parametrize("default", [True, False])
+@pytest.mark.parametrize("text", ["", "   ", None])
+def test_an_empty_value_means_absent_for_a_stream_or_environment_value(text, default):
+    """Empty must take the caller's default, not False.
+
+    Several of the flags still to be converted default True, and an absent or empty stream field
+    silently flipping them off would reintroduce this same bug class in the other direction.
+    """
+    assert parse_bool(text, default=default) is default
+
+
+@pytest.mark.parametrize("value", [2, -1, 2.5, 0])
+def test_numbers_are_rejected(value):
+    """Accepting ints would contradict the property this function exists to provide.
+
+    parse_bool(2) would have to be True while parse_bool(str(2)) is not, so the round trip the
+    module is named for would fail over the int domain.
+    """
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_bool(value)
+
+
+def test_the_accepted_spellings_are_exactly_strtobool_s():
+    """Pinned against strtobool itself, which this replaces.
+
+    The PR claims the spellings match; this is that claim as a test rather than as prose. Skipped
+    only where distutils is genuinely unavailable, which is the situation being fixed.
+    """
+    strtobool = pytest.importorskip("distutils.util").strtobool
+    for text in EXPECTED_TRUE:
+        assert bool(strtobool(text)) is True
+        assert parse_bool(text) is True
+    for text in EXPECTED_FALSE:
+        assert bool(strtobool(text)) is False
+        assert parse_bool(text) is False
+    # and nothing outside that set is accepted by either
+    for text in ("2", "maybe", "enabled"):
+        with pytest.raises(ValueError):
+            strtobool(text)
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_bool(text)
+
+
+def test_the_strict_form_survives_a_module_reload():
+    """A module-level object() sentinel silently breaks the strict form after a reload.
+
+    The signature default is captured once at definition time while the identity test reads the
+    module global, so a reload rebinds one and not the other -- and parse_bool then treats "no
+    default" as "default given" and returns the sentinel instead of raising. Found because the
+    environment-variable tests in this file reload the module, which made the number-rejection
+    tests pass alone and fail in the suite. Ellipsis is a builtin singleton and cannot drift.
+    """
+    import importlib
+
+    import redis_benchmarks_specification.__common__.env as env_mod
+
+    importlib.reload(env_mod)
+    with pytest.raises(argparse.ArgumentTypeError):
+        env_mod.parse_bool("maybe")
+    # and the binding captured before the reload must behave the same way
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_bool("maybe")
+
+
+@pytest.mark.parametrize(
+    "name,default",
+    [("PROFILE", False), ("BENCHMARK_PR_DIFF_SCOPING", True)],
+)
+def test_the_other_boolean_environment_variables_use_the_same_decoder(name, default):
+    """One decoder for the whole module, not four idioms in one file.
+
+    PROFILE was bool(int(...)), which raises at import time on "false" and aborts every entrypoint.
+    BENCHMARK_PR_DIFF_SCOPING was a hand-rolled copy of parse_bool accepting a different set -- no
+    "t", no "y" -- which is exactly how the spellings drift apart.
+    """
+    import importlib
+    import os
+
+    import redis_benchmarks_specification.__common__.env as env_mod
+
+    attribute = {
+        "PROFILE": "PROFILERS_ENABLED",
+        "BENCHMARK_PR_DIFF_SCOPING": "BENCHMARK_PR_DIFF_SCOPING",
+    }[name]
+    original = os.environ.get(name)
+    try:
+        for raw, expected in (
+            ("0", False),
+            ("false", False),
+            ("off", False),
+            ("1", True),
+            ("t", True),
+        ):
+            os.environ[name] = raw
+            reloaded = importlib.reload(env_mod)
+            assert (
+                getattr(reloaded, attribute) is expected
+            ), f"{name}={raw!r} read as {getattr(reloaded, attribute)!r}"
+        os.environ.pop(name)
+        assert getattr(importlib.reload(env_mod), attribute) is default
+    finally:
+        os.environ.pop(name, None)
+        if original is not None:
+            os.environ[name] = original
         importlib.reload(env_mod)

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -157,12 +157,17 @@ def test_the_cli_no_longer_imports_distutils():
     It resolves only through a setuptools shim. setuptools is an explicit runtime dependency here,
     so this is hygiene -- dropping a dependency on a deprecated shim -- and not the "the CLI cannot
     start" hazard an earlier version of this PR claimed.
+
+    Asserted against sys.modules rather than the module's source text: a source check passes on
+    `importlib.import_module("distutils.util")` and fails on the word appearing in a comment.
     """
-    import inspect
+    import sys
 
-    import redis_benchmarks_specification.__cli__.args as args_mod
+    import redis_benchmarks_specification.__cli__.args  # noqa: F401
 
-    assert "distutils" not in inspect.getsource(args_mod)
+    assert (
+        "distutils" not in sys.modules
+    ), "importing the CLI args module still pulls in distutils"
 
 
 def test_use_git_timestamp_flag_parses_false():
@@ -323,33 +328,47 @@ def test_the_accepted_spellings_are_strtobool_s_plus_whitespace():
 
 
 def _all_parsers():
-    """The parsers that can be built in-process.
+    """Every parser that can be built in this process.
 
-    __spec__/args.py is covered separately, in a subprocess. It IS importable once a sibling has
+    __spec__/args.py is covered separately, in a subprocess: it IS importable once a sibling has
     populated sys.modules -- the cold-interpreter failure of issue #466 is an import-order artifact,
-    not an absolute -- but importing it binds the subpackage over the parent's ModuleSpec for the
-    rest of the process, and Flask reads `.origin` off that to find an app's root path. Doing it here
-    breaks test_app.py whenever the two files run in the same session, in that order.
+    not an absolute -- but importing it binds the subpackage over the parent's ModuleSpec, and Flask
+    reads `.origin` off that to find an app's root path, so doing it here breaks test_app.py when the
+    two files share a session.
+
+    __builder__/builder.py and __api__/api.py build their parsers inline in main() and so cannot be
+    introspected without running them. Those two are covered by the source scan below instead.
     """
     import argparse
 
     from redis_benchmarks_specification.__cli__.args import spec_cli_args
     from redis_benchmarks_specification.__compare__.args import create_compare_arguments
+    from redis_benchmarks_specification.__runner__.args import create_client_runner_args
+    from redis_benchmarks_specification.__self_contained_coordinator__.args import (
+        create_self_contained_coordinator_args,
+    )
+    from redis_benchmarks_specification.__watchdog__.args import spec_watchdog_args
 
     return {
         "compare": create_compare_arguments(argparse.ArgumentParser()),
         "cli": spec_cli_args(argparse.ArgumentParser()),
+        "runner": create_client_runner_args("probe"),
+        "coordinator": create_self_contained_coordinator_args("probe"),
+        "watchdog": spec_watchdog_args(argparse.ArgumentParser()),
     }
 
 
-def test_no_parser_action_converts_with_builtin_bool():
-    """Introspect what argparse will call, not the characters used to name it.
+def test_no_parser_action_reads_the_string_false_as_true():
+    """Probe what argparse will call, rather than comparing it by identity.
 
-    A text scan for "type=bool" is the obvious guard and the wrong one: it misses
-    `builtins.bool`, `eval("bool")`, a functools.partial, an alias, a tab, and -- the one that
-    happens without any intent to evade -- a kwarg that black reformats across lines. Reading
-    action.type off the built parser catches all of them, and cannot pass vacuously depending on
-    the working directory the way a relative path scan did.
+    Forbidding the name `bool` catches one spelling. A one-line helper returning bool(x), a lambda, a
+    callable class, a locally shadowed name and `builtins.bool` all reintroduce the defect and all
+    pass an identity check. What they share is the only thing worth asserting: no converter anywhere
+    may turn the string "false" into True.
+
+    This needs no allowlist to maintain, which matters -- an allowlist of permitted types flagged the
+    legitimate --from-date and --to-date parsers on the first run. Legitimate converters either
+    return a non-True value or reject the input outright, and both are accepted here.
     """
     import functools
 
@@ -357,11 +376,19 @@ def test_no_parser_action_converts_with_builtin_bool():
     for name, parser in _all_parsers().items():
         for action in parser._actions:
             converter = action.type
+            if converter is None:
+                continue
             if isinstance(converter, functools.partial):
                 converter = converter.func
-            if converter is bool:
-                offenders.append(f"{name}:{action.option_strings}")
-    assert not offenders, f"builtin bool used as an argparse converter: {offenders}"
+            try:
+                result = converter("false")
+            except Exception:
+                continue  # rejects the value outright, which is fine
+            if result is True:
+                offenders.append(f"{name}:{action.option_strings} -> {converter!r}")
+    assert (
+        not offenders
+    ), f'converter maps "false" to True, so a falsy value reads as enabled: {offenders}'
 
 
 def test_every_boolean_flag_uses_the_canonical_decoder():
@@ -383,6 +410,10 @@ def test_every_boolean_flag_uses_the_canonical_decoder():
     seen = set()
     for parser in _all_parsers().values():
         for action in parser._actions:
+            if action.nargs == 0:
+                # store_true / store_false consume no value, so no converter is called and none is
+                # needed. Only flags that take a value can feed a string to bool().
+                continue
             for option in action.option_strings:
                 if option in known_boolean_flags:
                     seen.add(option)
@@ -444,7 +475,14 @@ def _env_probe(script, **env):
     import sys
 
     environment = dict(os.environ)
-    environment.pop("DATASINK_PUSH_RTS", None)
+    # Cleared so an "unset" case is genuinely unset regardless of the developer's shell.
+    for name in (
+        "DATASINK_PUSH_RTS",
+        "PROFILE",
+        "BENCHMARK_PR_DIFF_SCOPING",
+        "PUSH_RTS",
+    ):
+        environment.pop(name, None)
     environment.update({key: str(value) for key, value in env.items()})
     result = subprocess.run(
         [sys.executable, "-c", script],
@@ -697,3 +735,162 @@ def test_the_spec_parser_uses_the_canonical_decoder():
         "a.type is env.parse_bool for a in p._actions))"
     )
     assert _env_probe(script) == "True"
+
+
+def test_no_module_in_the_package_passes_builtin_bool_to_add_argument():
+    """A source scan alongside the introspection guard, because neither covers everything.
+
+    Introspection reads the object argparse will call, so it catches builtins.bool, an alias, a
+    partial and a multi-line kwarg -- but only for parsers that can be built here. Two modules build
+    theirs inline in main() (__builder__/builder.py, __api__/api.py) and one needs a subprocess
+    (__spec__), so introspection alone left six of the eight add_argument modules uncovered. An
+    earlier revision of this branch made exactly that trade without noticing.
+
+    Reads the syntax tree rather than the characters, for two reasons: a text scan matched its own
+    explanatory prose in this very branch, and matching `add_argument(type=...)` specifically also
+    catches `builtins.bool` and survives reformatting.
+
+    Anchored to the package's __file__ and asserting it scanned something: a relative path made an
+    earlier version pass vacuously from any directory but the repo root.
+    """
+    import ast
+    import pathlib
+
+    import redis_benchmarks_specification
+
+    package = pathlib.Path(redis_benchmarks_specification.__file__).parent
+    scanned = sorted(package.rglob("*.py"))
+    assert len(scanned) > 20, f"only scanned {len(scanned)} files under {package}"
+
+    def names_builtin_bool(node):
+        if isinstance(node, ast.Name):
+            return node.id == "bool"
+        # builtins.bool, and any other attribute access ending in .bool
+        return isinstance(node, ast.Attribute) and node.attr == "bool"
+
+    offenders = []
+    for path in scanned:
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if getattr(node.func, "attr", None) != "add_argument":
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "type" and names_builtin_bool(keyword.value):
+                    offenders.append(f"{path.relative_to(package)}:{node.lineno}")
+    assert not offenders, f"builtin bool used as an argparse converter at {offenders}"
+
+
+def test_every_add_argument_module_is_covered_by_one_guard_or_the_other():
+    """Neither guard is complete alone, so pin which module each one covers.
+
+    Otherwise a future narrowing of either guard silently drops modules, which is what happened here
+    when the source scan was replaced rather than supplemented.
+    """
+    import pathlib
+
+    import redis_benchmarks_specification
+
+    package = pathlib.Path(redis_benchmarks_specification.__file__).parent
+    with_arguments = {
+        str(path.relative_to(package))
+        for path in package.rglob("*.py")
+        if "add_argument" in path.read_text()
+    }
+    introspected = {
+        "__cli__/args.py",
+        "__compare__/args.py",
+        "__runner__/args.py",
+        "__self_contained_coordinator__/args.py",
+        "__watchdog__/args.py",
+    }
+    subprocess_covered = {"__spec__/args.py"}
+    scan_only = {"__builder__/builder.py", "__api__/api.py"}
+    assert with_arguments == introspected | subprocess_covered | scan_only, (
+        "a module gained or lost add_argument; assign it to a guard: "
+        f"{with_arguments ^ (introspected | subprocess_covered | scan_only)}"
+    )
+
+
+def test_the_sentinel_survives_a_module_reload():
+    """Why the sentinel is Ellipsis and not a module-level object().
+
+    A module-level sentinel is captured in the signature at definition time while the identity test
+    reads the module global, so importlib.reload rebinds one and not the other -- parse_bool then
+    treats "no default" as "default given" and returns the sentinel instead of raising. The
+    environment tests that first exposed this were later replaced by subprocesses, which removed the
+    only mechanism that failed on it; this keeps the property under test on its own terms.
+    """
+    import importlib
+
+    import redis_benchmarks_specification.__common__.env as env_mod
+
+    importlib.reload(env_mod)
+    with pytest.raises(argparse.ArgumentTypeError):
+        env_mod.parse_bool("maybe")
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_bool("maybe")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("2", "True"), ("0", "False"), ("false", "False"), ("maybe", "False")],
+)
+def test_push_rts_no_longer_aborts_on_a_word(raw, expected):
+    """The competing bool(int(...)) decoder in a file this branch already edits.
+
+    PUSH_RTS=false raised ValueError at import of __compare__/args, aborting every compare command
+    -- the same defect fixed for PROFILE. The default preserves the old integer reading so no
+    non-zero value flips to disabled.
+    """
+    script = (
+        "from redis_benchmarks_specification.__compare__.args import PERFORMANCE_RTS_PUSH;"
+        "print(PERFORMANCE_RTS_PUSH)"
+    )
+    assert _env_probe(script, PUSH_RTS=raw) == expected
+
+
+@pytest.mark.parametrize("flag", COMPARE_BOOL_FLAGS)
+def test_the_compare_flags_still_default_to_false(flag):
+    """The declared defaults, which nothing covered.
+
+    Every case above passes an explicit value, so flipping all six declarations to default=True
+    passed the whole suite -- and that would make every default comparison skip unstable rows and
+    print regressions only.
+    """
+    parser = _all_parsers()["compare"]
+    namespace = parser.parse_args([])
+    assert getattr(namespace, flag.lstrip("-").replace("-", "_")) is False
+
+
+@pytest.mark.parametrize(
+    "attribute,expected",
+    [
+        ("DATASINK_RTS_PUSH", "False"),
+        ("PROFILERS_ENABLED", "False"),
+        ("BENCHMARK_PR_DIFF_SCOPING", "True"),
+    ],
+)
+def test_the_environment_defaults_when_nothing_is_set(attribute, expected):
+    """The unset direction, which is what almost every process actually runs with.
+
+    Every environment case above sets a value, so changing a default passed the suite. An unset
+    DATASINK_PUSH_RTS reading True would start pushing to the datasink from a process that had never
+    asked to -- the mirror image of the failure this branch was opened to prevent, and the direction
+    the branch claims to have made unreachable.
+    """
+    script = (
+        f"from redis_benchmarks_specification.__common__.env import {attribute};"
+        f"print({attribute})"
+    )
+    assert _env_probe(script) == expected
+
+
+def test_the_push_rts_default_when_nothing_is_set():
+    """Same, for the constant in __compare__/args.py."""
+    script = (
+        "from redis_benchmarks_specification.__compare__.args import PERFORMANCE_RTS_PUSH;"
+        "print(PERFORMANCE_RTS_PUSH)"
+    )
+    assert _env_probe(script) == "False"

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -94,8 +94,8 @@ def test_an_actual_bool_passes_through(value):
 def test_an_unrecognised_value_returns_the_default(value, default):
     """Returning the default beats guessing, which is what `bool()` already does.
 
-    Includes an undecodable byte string: the previous code called `.decode()` unguarded, so a
-    corrupt stream field raised UnicodeDecodeError from inside the consumer loop.
+    Includes an undecodable byte string, because the stream decode sites this is intended for call
+    `.decode()` unguarded today -- a corrupt field would raise from inside a consumer loop.
     """
     assert parse_bool(value, default=default) is default
 
@@ -154,9 +154,9 @@ def test_the_raised_message_names_every_accepted_spelling(text):
 def test_the_cli_no_longer_imports_distutils():
     """distutils was removed from the standard library in 3.12.
 
-    It resolves today only through a setuptools shim, so `from distutils.util import strtobool` at
-    module scope made the CLI fail at import time in any 3.12 environment without setuptools --
-    which is a hard failure of the entire command, not a degraded flag.
+    It resolves only through a setuptools shim. setuptools is an explicit runtime dependency here,
+    so this is hygiene -- dropping a dependency on a deprecated shim -- and not the "the CLI cannot
+    start" hazard an earlier version of this PR claimed.
     """
     import inspect
 
@@ -296,11 +296,11 @@ def test_numbers_are_rejected(value):
         parse_bool(value)
 
 
-def test_the_accepted_spellings_are_exactly_strtobool_s():
+def test_the_accepted_spellings_are_strtobool_s_plus_whitespace():
     """Pinned against strtobool itself, which this replaces.
 
-    The PR claims the spellings match; this is that claim as a test rather than as prose. Skipped
-    only where distutils is genuinely unavailable, which is the situation being fixed.
+    A superset, not an exact match: surrounding whitespace is tolerated where strtobool raises. Both
+    directions are asserted. Skipped where distutils is genuinely unavailable.
     """
     strtobool = pytest.importorskip("distutils.util").strtobool
     for text in EXPECTED_TRUE:
@@ -315,14 +315,21 @@ def test_the_accepted_spellings_are_exactly_strtobool_s():
             strtobool(text)
         with pytest.raises(argparse.ArgumentTypeError):
             parse_bool(text)
+    # the superset direction: whitespace is tolerated here and rejected there
+    for text in (" true ", "\tfalse\n"):
+        with pytest.raises(ValueError):
+            strtobool(text)
+        assert parse_bool(text) is (text.strip() == "true")
 
 
 def _all_parsers():
-    """Every argparse parser the package builds that can actually be imported.
+    """The parsers that can be built in-process.
 
-    __spec__/args.py is deliberately absent: the package contains a subpackage literally named
-    __spec__, which shadows the attribute CPython's import machinery reads, so importing anything
-    beneath it raises. See test_the_spec_subpackage_cannot_be_imported.
+    __spec__/args.py is covered separately, in a subprocess. It IS importable once a sibling has
+    populated sys.modules -- the cold-interpreter failure of issue #466 is an import-order artifact,
+    not an absolute -- but importing it binds the subpackage over the parent's ModuleSpec for the
+    rest of the process, and Flask reads `.origin` off that to find an app's root path. Doing it here
+    breaks test_app.py whenever the two files run in the same session, in that order.
     """
     import argparse
 
@@ -537,8 +544,8 @@ def test_the_other_boolean_environment_variables_use_the_same_decoder(
     assert _env_probe(script, **{name: raw}) == expected
 
 
-def test_the_spec_subpackage_cannot_be_imported():
-    """Documents why __spec__/args.py is not covered by introspection above.
+def test_the_spec_subpackage_cannot_be_imported_from_a_cold_interpreter():
+    """The shape of issue #466, which is why the console script cannot start.
 
     The package contains a subpackage named __spec__, which shadows the ModuleSpec CPython's import
     machinery puts on the parent package, so importing anything beneath it raises AttributeError.
@@ -549,8 +556,10 @@ def test_the_spec_subpackage_cannot_be_imported():
     submodule_search_locations, 3.12 reports _uninitialized_submodules. So the assertion matches the
     shadowed module rather than either internal name.
 
-    Pre-existing and out of scope here, but asserted so that fixing it fails this test and prompts
-    restoring the coverage that had to be dropped.
+    Order-dependent, not absolute: _all_parsers above imports a sibling first and then loads
+    __spec__/args.py without trouble. Only a cold interpreter -- which is what a console-script
+    entrypoint is -- hits it. Pre-existing and out of scope here; asserted so that fixing it fails
+    this test rather than passing unnoticed.
     """
     import subprocess
     import sys
@@ -560,9 +569,131 @@ def test_the_spec_subpackage_cannot_be_imported():
         capture_output=True,
         text=True,
     )
-    assert result.returncode != 0, (
-        "__spec__ is importable now -- restore it to _all_parsers() and re-enable the "
-        "trigger-unstable-commits cases for it"
-    )
+    assert result.returncode != 0, "issue #466 appears fixed -- drop this test"
     assert "AttributeError" in result.stderr, result.stderr
     assert "__spec__" in result.stderr, result.stderr
+
+
+def test_use_git_timestamp_with_an_empty_value():
+    """The one flag whose empty-value behaviour changed, pinned rather than left implicit.
+
+    It used strtobool, which raised on "", while the other eight read "" as False. Unified to False.
+    Moot in practice: the parsed value is discarded before it reaches the stream (issue #464), so
+    this cannot change what any run does today -- but it is a real difference from the base and
+    belongs under test rather than in a comment.
+    """
+    parser = _all_parsers()["cli"]
+    assert parser.parse_args(["--use-git-timestamp", ""]).use_git_timestamp is False
+    assert parser.parse_args(["--use-git-timestamp", "  "]).use_git_timestamp is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("2", "True"), ("-1", "True"), ("01", "True"), ("0", "False"), ("1", "True")],
+)
+def test_profile_preserves_the_any_non_zero_integer_reading(raw, expected):
+    """PROFILE was bool(int(...)), so every non-zero integer meant enabled.
+
+    Narrowing to the literal "1" would flip PROFILE=2 from on to off and silently stop profiling
+    artifacts being collected -- the same data-losing direction that DATASINK_PUSH_RTS is protected
+    against, so it gets the same policy rather than the opposite one.
+    """
+    script = (
+        "from redis_benchmarks_specification.__common__.env import PROFILERS_ENABLED;"
+        "print(PROFILERS_ENABLED)"
+    )
+    assert _env_probe(script, PROFILE=raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["false", "off", "no", ""])
+def test_profile_no_longer_aborts_the_process_on_a_word(raw):
+    """bool(int("false")) raises ValueError at import, taking down every entrypoint."""
+    script = (
+        "from redis_benchmarks_specification.__common__.env import PROFILERS_ENABLED;"
+        "print(PROFILERS_ENABLED)"
+    )
+    assert _env_probe(script, PROFILE=raw) == "False"
+
+
+@pytest.mark.parametrize("raw", ["maybe", "enabled", "2"])
+def test_pr_diff_scoping_leaves_an_unrecognised_value_disabled(raw):
+    """The safety invariant that was asserted only in a comment.
+
+    A True here skips nothing and runs the full suite on every labelled PR, which is the expensive
+    direction. The old hand-rolled check read anything outside its set as False, and that must not
+    invert -- flipping the default passed the entire suite before this test existed.
+    """
+    script = (
+        "from redis_benchmarks_specification.__common__.env import BENCHMARK_PR_DIFF_SCOPING;"
+        "print(BENCHMARK_PR_DIFF_SCOPING)"
+    )
+    assert _env_probe(script, BENCHMARK_PR_DIFF_SCOPING=raw) == "False"
+
+
+@pytest.mark.parametrize("value", [b"\xff\xfe", bytearray(b"\xff")])
+def test_an_undecodable_value_warns_and_keeps_the_offending_bytes(caplog, value):
+    """Blanking it to None erased the value from the message and from the warning.
+
+    An undecodable stream field then read identically to an absent one, which is the diagnostic the
+    reader most needs. The docstring promised a warning on every fallback; it was suppressed for
+    exactly the two inputs a stream reader can hit.
+    """
+    with caplog.at_level(logging.WARNING):
+        assert parse_bool(value, default=True) is True
+    messages = [
+        r.getMessage()
+        for r in caplog.records
+        if "Unrecognised boolean" in r.getMessage()
+    ]
+    assert messages, "no warning for an undecodable value"
+    assert "None" not in messages[0], f"offending bytes erased: {messages[0]}"
+
+
+def test_an_absent_value_does_not_warn(caplog):
+    """None means nothing was supplied, which is the normal case for an unset variable.
+
+    Warning about it would add two lines of noise to every import of this module and train readers
+    to ignore the warning that matters. Undecodable bytes are a different case -- something was
+    supplied and could not be read -- and those do warn.
+    """
+    with caplog.at_level(logging.WARNING):
+        assert parse_bool(None, default=True) is True
+        assert parse_bool(None, default=False) is False
+    assert not [
+        r for r in caplog.records if "Unrecognised boolean" in r.getMessage()
+    ], "warned about an absent value"
+
+
+@pytest.mark.parametrize(
+    "text,expected", [("false", "False"), ("0", "False"), ("true", "True")]
+)
+def test_the_spec_parser_also_honours_a_false_value(text, expected):
+    """Covers the second file this PR edits, in a subprocess and for two reasons.
+
+    It needs a sibling imported first, because importing __spec__ from a cold interpreter fails
+    (issue #466). And having imported it, the subpackage is bound over the parent's ModuleSpec for
+    the rest of the process, so Flask can no longer find an app's root path -- which breaks
+    test_app.py if this runs in the same session. A subprocess gets the coverage without the
+    side effect.
+    """
+    script = (
+        "import argparse;"
+        "import redis_benchmarks_specification.__common__.env;"
+        "from redis_benchmarks_specification.__spec__.args import spec_cli_args;"
+        "p=spec_cli_args(argparse.ArgumentParser());"
+        f"print(p.parse_args(['--trigger-unstable-commits','{text}']).trigger_unstable_commits)"
+    )
+    assert _env_probe(script) == expected
+
+
+def test_the_spec_parser_uses_the_canonical_decoder():
+    """Same file, the guard rather than the behaviour. Subprocess for the same reason."""
+    script = (
+        "import argparse;"
+        "import redis_benchmarks_specification.__common__.env as env;"
+        "from redis_benchmarks_specification.__spec__.args import spec_cli_args;"
+        "p=spec_cli_args(argparse.ArgumentParser());"
+        "print(all(a.type is not bool for a in p._actions) and any("
+        "a.type is env.parse_bool for a in p._actions))"
+    )
+    assert _env_probe(script) == "True"

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -286,3 +286,29 @@ def test_the_warning_names_the_accepted_spellings(caplog):
     text = " ".join(r.getMessage() for r in caplog.records)
     for spelling in TRUE_STRINGS + tuple(f for f in FALSE_STRINGS if f):
         assert spelling in text, f"warning does not mention {spelling!r}"
+
+
+@pytest.mark.parametrize("raw", ["2", "enabled", "on-please", "sure"])
+def test_an_unrecognised_datasink_setting_cannot_turn_pushing_off(raw):
+    """The fix must never be able to stop results reaching the datasink.
+
+    When DATASINK_RTS_PUSH is False the datasink connection is None and nothing is exported, so a
+    wrong answer in that direction means benchmark results silently stop being recorded. The old
+    bool() read any non-empty string as True; the default here reproduces that, so only recognised
+    falsy spellings change meaning. The fleet's actual setting is not visible from here, which is
+    exactly why this direction is pinned rather than assumed.
+    """
+    import importlib
+    import os
+
+    import redis_benchmarks_specification.__common__.env as env_mod
+
+    original = os.environ.get("DATASINK_PUSH_RTS")
+    try:
+        os.environ["DATASINK_PUSH_RTS"] = raw
+        assert importlib.reload(env_mod).DATASINK_RTS_PUSH is True
+    finally:
+        os.environ.pop("DATASINK_PUSH_RTS", None)
+        if original is not None:
+            os.environ["DATASINK_PUSH_RTS"] = original
+        importlib.reload(env_mod)

--- a/utils/tests/test_parse_bool.py
+++ b/utils/tests/test_parse_bool.py
@@ -1,0 +1,156 @@
+"""Property tests for boolean decoding of values that have been through a string round-trip.
+
+Booleans reach this package as strings: written to the commits and builds streams with `str()`,
+and read from the environment. A bare `bool()` on such a value is wrong in the one direction that
+matters, because every non-empty string is truthy -- so `"False"`, `"0"` and `"no"` all decode to
+`True` and the flag is stuck on. `bool(b"False")` is `True` as well, which matters because stream
+reads are not always decoded first.
+
+Offline; no Redis, no Docker.
+"""
+
+import itertools
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from redis_benchmarks_specification.__common__.env import (
+    FALSE_STRINGS,
+    TRUE_STRINGS,
+    parse_bool,
+    parse_bool_arg,
+)
+
+
+@given(value=st.booleans())
+def test_a_bool_survives_the_str_round_trip(value):
+    """The property the stream needs and `bool()` does not provide.
+
+    `str(False)` is `"False"`, and `bool("False")` is `True`. This is the whole defect.
+    """
+    assert parse_bool(str(value)) is value
+
+
+@given(value=st.booleans())
+def test_a_bool_survives_the_round_trip_as_bytes(value):
+    """Stream reads are not always decoded, so the bytes form must round-trip too."""
+    assert parse_bool(str(value).encode()) is value
+
+
+@pytest.mark.parametrize("text", TRUE_STRINGS)
+def test_true_spellings(text):
+    assert parse_bool(text) is True
+    assert parse_bool(text.upper()) is True
+    assert parse_bool(f"  {text}  ") is True
+
+
+@pytest.mark.parametrize("text", FALSE_STRINGS)
+def test_false_spellings(text):
+    assert parse_bool(text) is False
+    assert parse_bool(text.upper()) is False
+    assert parse_bool(f"  {text}  ") is False
+
+
+def test_true_and_false_spellings_do_not_overlap():
+    """A spelling in both tables would make the tables' order decide the answer."""
+    assert not set(TRUE_STRINGS) & set(FALSE_STRINGS)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_an_actual_bool_passes_through(value):
+    """Call sites are being converted one at a time, so both forms must work during the overlap."""
+    assert parse_bool(value) is value
+
+
+@pytest.mark.parametrize("default", [True, False])
+@pytest.mark.parametrize(
+    "value", ["maybe", "yes-ish", "2", "None", "null", b"\xff\xfe"]
+)
+def test_an_unrecognised_value_returns_the_default(value, default):
+    """Returning the default beats guessing, which is what `bool()` already does.
+
+    Includes an undecodable byte string: the previous code called `.decode()` unguarded, so a
+    corrupt stream field raised UnicodeDecodeError from inside the consumer loop.
+    """
+    assert parse_bool(value, default=default) is default
+
+
+@pytest.mark.parametrize("default", [True, False])
+def test_none_returns_the_default(default):
+    assert parse_bool(None, default=default) is default
+
+
+@given(number=st.integers())
+def test_numbers_follow_python_truthiness(number):
+    """A stream field written from an int should not become a silent default."""
+    assert parse_bool(number) is bool(number)
+
+
+@given(
+    value=st.one_of(
+        st.booleans(),
+        st.sampled_from(TRUE_STRINGS + FALSE_STRINGS),
+        st.integers(min_value=-3, max_value=3),
+        st.none(),
+    )
+)
+def test_parse_bool_always_returns_a_bool(value):
+    """Never a truthy string, never None -- callers use the result in `if` and in f-strings."""
+    assert isinstance(parse_bool(value), bool)
+
+
+# --- the argparse variant -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text", [t for t in TRUE_STRINGS + FALSE_STRINGS if t]  # "" is rejected, see below
+)
+def test_parse_bool_arg_accepts_every_spelling_parse_bool_does(text):
+    """The two must agree, or a flag means one thing on the CLI and another on the stream."""
+    assert parse_bool_arg(text) is parse_bool(text)
+
+
+@pytest.mark.parametrize("text", ["maybe", "", "2", "tru", "flase"])
+def test_parse_bool_arg_rejects_unrecognised_input(text):
+    """On a command line a typo should be reported, not guessed at.
+
+    argparse converts ValueError from a `type=` callable into a usage error, so this is what makes
+    `--use-git-timestamp flase` fail loudly instead of silently meaning False.
+    """
+    with pytest.raises(ValueError):
+        parse_bool_arg(text)
+
+
+def test_the_cli_no_longer_imports_distutils():
+    """distutils was removed from the standard library in 3.12.
+
+    It resolves today only through a setuptools shim, so `from distutils.util import strtobool` at
+    module scope made the CLI fail at import time in any 3.12 environment without setuptools --
+    which is a hard failure of the entire command, not a degraded flag.
+    """
+    import inspect
+
+    import redis_benchmarks_specification.__cli__.args as args_mod
+
+    assert "distutils" not in inspect.getsource(args_mod)
+
+
+def test_use_git_timestamp_flag_parses_false():
+    """The flag this defect was found through, end to end via the real parser."""
+    import argparse
+
+    from redis_benchmarks_specification.__cli__.args import spec_cli_args
+
+    parser = spec_cli_args(argparse.ArgumentParser())
+    assert (
+        parser.parse_args(["--use-git-timestamp", "false"]).use_git_timestamp is False
+    )
+    assert parser.parse_args(["--use-git-timestamp", "true"]).use_git_timestamp is True
+    assert parser.parse_args([]).use_git_timestamp is True
+
+
+def test_every_accepted_spelling_is_lowercase_in_the_tables():
+    """Lookup lowercases its input, so an uppercase table entry would be unreachable."""
+    for text in itertools.chain(TRUE_STRINGS, FALSE_STRINGS):
+        assert text == text.lower(), f"{text!r} can never match"


### PR DESCRIPTION
Rewritten against the current head. The first version overstated the `distutils` justification and misstated its own test count; both are corrected below and the corrections are called out rather than quietly edited.

Booleans in this package travel as strings — through argparse, through the environment, and through the commits/builds streams — and are read back with `bool()`. Every non-empty string is truthy, so `"false"` decodes to `True`. Found by property-testing the round trip `parse(str(v)) == v`, which fails for `False` on every path.

## What this fixes

**Eight argparse flags used `type=bool`.** argparse hands the `type` callable the raw argv string, so `--skip-unstable false`, `--verbose 0` and `--print-regressions-only no` all meant `True`, and a misspelled value was accepted rather than reported. Six are the compare CLI's own flags, all consumed by `compare_command_logic`, so a flag that silently inverts changes which rows a comparison prints.

| value | before | after |
|---|---|---|
| `false` `False` `0` `no` `off` `n` `f` | `True` | `False` |
| `true` `1` `yes` `on` `y` `t` | `True` | `True` |
| `2` `enabled` `tru` | `True` | usage error naming the accepted spellings |
| `""` | `False` | `False` |

Existing invocations are unaffected — every one I can find in this repo, its workflows, and the automation that drives it passes `true`, which worked by accident. `""` deliberately still means `False`: `--verbose "$VERBOSE"` with the variable unset is what produces it, and turning a common accident into a usage error would be a regression.

The remaining two of the eight are `--trigger-unstable-commits`, declared in **`__cli__/args.py` and `__spec__/args.py`** and **consumed nowhere** — so those two conversions are no-ops. Left in place rather than deleted, since removing a declared flag breaks anyone passing it; flagging them so the count isn't mistaken for eight live fixes.

**`DATASINK_PUSH_RTS=0` enabled pushing to the datasink.** Worse than the general case: the value is the default of a `--datasink_push_results_redistimeseries` `store_true` flag, so once it reads `True` there is no flag that can turn it off. The default here deliberately reproduces the old `bool()` reading, so **only recognised falsy spellings change meaning** — `2` and `enabled` stay `True`. When that flag is off the datasink connection is `None` and nothing is exported, so the other direction would turn a misconfiguration into silently missing benchmark data. I could not verify the fleet's actual setting from where I work, so the data-losing direction is made unreachable rather than assumed away.

**Three other boolean idioms in the same file now use the same decoder.** `PROFILE` was `bool(int(...))`, which raises at import time on `PROFILE=false` and aborts every entrypoint — the crash class of #465 applied to a boolean. `BENCHMARK_PR_DIFF_SCOPING` was a hand-rolled copy of the same logic accepting a *different* set (no `t`, no `y`), which is exactly how spellings drift apart; it keeps `default=False` so an unrecognised value still disables scoping rather than enabling it. `VERBOSE` is left alone — its sense is inverted and that is a separate question.

## Correcting the first version of this description

**The `distutils` claim was overstated.** I wrote that the import "survives on an implicit dependency" and that CI is not using the locked version. Both are wrong:

- `setuptools` is an **explicit, version-bounded runtime dependency** (`pyproject.toml:38`, `^69.0.0`), not implicit.
- `tox.yml` does upgrade setuptools unpinned, but that lands in the runner and packaging environments; the **testenv pins `setuptools==69.5.1` on all six legs**, which is inside the declared bound.
- There is no scheduled removal of setuptools' bundled `_distutils` shim.

So this is **hygiene, not a latent outage**: `distutils` was removed from the stdlib in 3.12 and resolves only through that shim, and dropping a dependency on a deprecated shim is worth doing on its own terms. It is not the "the whole CLI fails to start" hazard I originally described.

Relatedly, "accepts exactly the spellings `strtobool` did" is a **superset** — surrounding whitespace is tolerated, which `strtobool` rejects. The suite now pins the tables against `strtobool` itself so the claim is tested rather than asserted.

**The test count was wrong** (it said 80). It is **144**.

## Not in this PR

The stream-field decode sites. Investigating them established something worth recording, because it contradicts the assumption this work started from: the decode bug is **inert** there. Both consumers require `use_git_timestamp is True` *and* `git_timestamp_ms is not None`, and across the three live streams — 22,449 entries, full retention — **zero** entries pair `"False"` with a timestamp. The builder also launders the value, re-emitting `str(...)`, so a single-site fix is a guaranteed no-op.

The real reason `--use-git-timestamp false` does nothing is a plumbing bug filed as **#464**: the value is hardcoded `True` at the call that builds the stream payload, and the one place the parsed argument is written targets a dict that is not the xadd payload. Fixing the decoder alone would make the flag *look* controllable while still doing nothing, which is why it is separate.

Also filed: **#465**, nine unguarded `int(os.getenv(...))` calls at import time. And **#466**, found while building every parser in the package for the introspection guard: the `redis-benchmarks-spec` console script cannot start at all, because the package contains a subpackage named `__spec__` that shadows the `ModuleSpec` CPython's own import machinery reads. That is pre-existing on `main` and invisible to CI because nothing in the suite imports it — which is why `__spec__/args.py` is absent from the introspection guard here, with a test that will fail once it is fixed so the dropped coverage gets restored.

Two things a reader of those sites should know: `restore_build_artifacts` has **never functioned** — no CLI argument, hardcoded default, only ever written `"False"`, and all 23 live entries carrying it have an empty `build_artifacts` list, so the restore it wrongly performs is an empty loop. And `docker_air_gap` is read from the stream but **no writer exists**.

`argparse.BooleanOptionalAction` was considered for the eight flags and rejected: it gives `--flag` / `--no-flag` but rejects the value form, and every entrypoint uses `parse_args`, so `--print-regressions-only true` would become a fatal `unrecognized arguments` error for existing callers. Worth adding additively later so the value form can be deprecated on a normal cycle.

## Tests

**144, offline, no Redis or Docker.** CI executed them on all six matrix legs.

The `type=bool` guard now **introspects the built parsers** (`action.type is not bool`) instead of scanning source text. The scan caught two of nine ways to reintroduce the defect and missed seven, including a kwarg that `black` reformats across lines — no intent to evade required. Verified against `builtins.bool`, a multi-line kwarg and an alias.

`--trigger-unstable-commits` now has behavioural tests in addition to the guard; previously the guard was its only cover, and it is read nowhere, which is exactly where a reintroduced defect goes unnoticed.

The environment tests use subprocesses rather than `importlib.reload`. Reloading rebinds function objects while every module that did a from-import keeps the old ones, so identity assertions became order-dependent — a test passed alone and failed in the suite. It also never reached the from-import copies production ships: `__runner__/args.py` and `__self_contained_coordinator__/args.py` both take `DATASINK_RTS_PUSH` by value as a `store_true` default, and that default is the whole reason the value matters. A subprocess asserts the default those parsers actually ship.

The spelling tables are pinned against literals **and** against `strtobool`, not iterated — deriving the cases from the table under test meant moving `"off"` between tables kept the suite green. The `type=bool` guard is anchored to the package's `__file__` and asserts it scanned something, because a relative path made it pass vacuously from any directory but the repo root.

One test exists because of a bug the review process surfaced in this PR's own helper: a module-level `object()` sentinel does not survive `importlib.reload` — the signature default is captured at definition time while the identity check reads the module global — so after a reload the strict form silently stopped raising. It is now `Ellipsis`, a builtin singleton. That was not hypothetical: it made the number-rejection tests pass alone and fail in the suite.

Each behavioural change was verified by reverting it, with the mutation asserted to have landed in the file first.

## Version

Bumped to `0.3.30`. This changes CLI and environment semantics, and #459 bumped in-PR, so that is the convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI and environment boolean semantics for datasink push, profiling, and compare output filters; defaults are tuned to avoid silently turning off data export, but mis-set env vars now behave differently for recognized falsy spellings.
> 
> **Overview**
> Fixes boolean handling where string values like `"false"` and `"0"` were treated as **True** because `type=bool` and `bool()` treat any non-empty string as truthy.
> 
> Adds shared **`parse_bool`** in `env.py` (replacing `distutils.strtobool` on the CLI) with strict argparse errors for typos, optional defaults and warnings for env/stream values, and support for `str`/`bytes` round-trips.
> 
> **CLI:** Eight flags across `__cli__`, `__compare__`, and `__spec__` now use `type=parse_bool` (including compare filters like `--skip-unstable` and `--use-git-timestamp`).
> 
> **Environment:** `DATASINK_PUSH_RTS`, `PROFILE` / `PROFILERS_ENABLED`, `BENCHMARK_PR_DIFF_SCOPING`, and compare `PUSH_RTS` / `PERFORMANCE_RTS_PUSH` decode through `parse_bool`, preserving prior behavior for ambiguous values where disabling would silently drop benchmark data or profiling.
> 
> Adds **`utils/tests/test_parse_bool.py`** (property tests, parser introspection, AST guard against `type=bool`, subprocess env probes). Version **0.3.31**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49514ce14236463849786b6ec2dd37a89fa2b4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->