### PR TITLE
fix(env): a malformed integer setting no longer aborts every entrypoint at import

### DIFF
--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -76,26 +76,46 @@ STREAM_GH_NEW_BUILD_RUNNERS_CG = os.getenv(
 # host used to store the streams of events
 GH_TOKEN = os.getenv("GH_TOKEN", None)
 GH_REDIS_SERVER_HOST = os.getenv("GH_REDIS_SERVER_HOST", "localhost")
-GH_REDIS_SERVER_PORT = int(os.getenv("GH_REDIS_SERVER_PORT", "6379"))
-GH_REDIS_SERVER_AUTH = os.getenv("GH_REDIS_SERVER_AUTH", None)
-GH_REDIS_SERVER_USER = os.getenv("GH_REDIS_SERVER_USER", None)
-
-# DB used to authenticate ( read-only/non-dangerous access only )
-REDIS_AUTH_SERVER_HOST = os.getenv("REDIS_AUTH_SERVER_HOST", "localhost")
-REDIS_AUTH_SERVER_PORT = int(os.getenv("REDIS_AUTH_SERVER_PORT", "6379"))
-REDIS_HEALTH_CHECK_INTERVAL = int(os.getenv("REDIS_HEALTH_CHECK_INTERVAL", "15"))
-REDIS_SOCKET_TIMEOUT = int(os.getenv("REDIS_SOCKET_TIMEOUT", "300"))
-REDIS_BINS_EXPIRE_SECS = int(
-    os.getenv("REDIS_BINS_EXPIRE_SECS", "{}".format(24 * 7 * 60 * 60))
-)
-
-_TRUE_STRINGS = ("1", "true", "t", "yes", "y", "on")
-_FALSE_STRINGS = ("0", "false", "f", "no", "n", "off")
 
 
-def accepted_bool_spellings():
-    """The spellings parse_bool accepts, for error and warning messages."""
-    return _TRUE_STRINGS + _FALSE_STRINGS
+def parse_int(value, default, name=None):
+    """Decode an integer that arrived as a string, without aborting the process.
+
+    Every one of these is read at import time, so a bare ``int()`` on a malformed value raises
+    before any entrypoint has a chance to run -- the coordinator, the builder, the runner and the
+    CLI all fail to start, with a traceback pointing at an import statement rather than at the
+    variable that was wrong. A supervisor reads that as a crash loop.
+
+    Falls back to ``default`` and warns instead, naming the variable, which is what the one
+    already-guarded site in this module does. Deliberately no accept-anything coercion: a value
+    that is not an integer is a misconfiguration, and the warning is the point.
+
+    Note ``int()`` is more permissive than operators expect and that is preserved here, since
+    tightening it would reject values that work today: ``"1_000"`` is 1000 and Arabic-Indic
+    ``"\u0663"`` is 3.
+    """
+    if isinstance(value, bool):
+        # bool is an int subclass; almost certainly not what a caller meant here.
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode()
+        except UnicodeDecodeError:
+            value = repr(value)
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        logging.getLogger(__name__).warning(
+            "%s is %r, which is not an integer; using %r instead.",
+            name or "value",
+            value,
+            default,
+        )
+        return default
 
 
 def parse_bool(value, default=...):
@@ -182,6 +202,36 @@ def parse_bool(value, default=...):
     return default
 
 
+GH_REDIS_SERVER_PORT = parse_int(
+    os.getenv("GH_REDIS_SERVER_PORT"), 6379, "GH_REDIS_SERVER_PORT"
+)
+GH_REDIS_SERVER_AUTH = os.getenv("GH_REDIS_SERVER_AUTH", None)
+GH_REDIS_SERVER_USER = os.getenv("GH_REDIS_SERVER_USER", None)
+
+# DB used to authenticate ( read-only/non-dangerous access only )
+REDIS_AUTH_SERVER_HOST = os.getenv("REDIS_AUTH_SERVER_HOST", "localhost")
+REDIS_AUTH_SERVER_PORT = parse_int(
+    os.getenv("REDIS_AUTH_SERVER_PORT"), 6379, "REDIS_AUTH_SERVER_PORT"
+)
+REDIS_HEALTH_CHECK_INTERVAL = parse_int(
+    os.getenv("REDIS_HEALTH_CHECK_INTERVAL"), 15, "REDIS_HEALTH_CHECK_INTERVAL"
+)
+REDIS_SOCKET_TIMEOUT = parse_int(
+    os.getenv("REDIS_SOCKET_TIMEOUT"), 300, "REDIS_SOCKET_TIMEOUT"
+)
+REDIS_BINS_EXPIRE_SECS = parse_int(
+    os.getenv("REDIS_BINS_EXPIRE_SECS"), 24 * 7 * 60 * 60, "REDIS_BINS_EXPIRE_SECS"
+)
+
+_TRUE_STRINGS = ("1", "true", "t", "yes", "y", "on")
+_FALSE_STRINGS = ("0", "false", "f", "no", "n", "off")
+
+
+def accepted_bool_spellings():
+    """The spellings parse_bool accepts, for error and warning messages."""
+    return _TRUE_STRINGS + _FALSE_STRINGS
+
+
 # environment variables
 PULL_REQUEST_TRIGGER_LABEL = os.getenv(
     "PULL_REQUEST_TRIGGER_LABEL", "action:run-benchmark"
@@ -201,7 +251,7 @@ DATASINK_RTS_PUSH = parse_bool(
 DATASINK_RTS_AUTH = os.getenv("DATASINK_RTS_AUTH", None)
 DATASINK_RTS_USER = os.getenv("DATASINK_RTS_USER", None)
 DATASINK_RTS_HOST = os.getenv("DATASINK_RTS_HOST", "localhost")
-DATASINK_RTS_PORT = int(os.getenv("DATASINK_RTS_PORT", "6379"))
+DATASINK_RTS_PORT = parse_int(os.getenv("DATASINK_RTS_PORT"), 6379, "DATASINK_RTS_PORT")
 ALLOWED_PROFILERS = "perf:record,vtune"
 PROFILERS_DEFAULT = "perf:record"
 PROFILE_FREQ_DEFAULT = "99"
@@ -225,7 +275,7 @@ def _profile_was_enabled(raw):
 
 PROFILERS_ENABLED = parse_bool(_PROFILE_RAW, default=_profile_was_enabled(_PROFILE_RAW))
 PROFILERS = os.getenv("PROFILERS", PROFILERS_DEFAULT)
-MAX_PROFILERS_PER_TYPE = int(os.getenv("MAX_PROFILERS", 1))
+MAX_PROFILERS_PER_TYPE = parse_int(os.getenv("MAX_PROFILERS"), 1, "MAX_PROFILERS")
 PROFILE_FREQ = os.getenv("PROFILE_FREQ", PROFILE_FREQ_DEFAULT)
 S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "redis.benchmarks.spec")
 # logging related
@@ -255,13 +305,15 @@ BENCHMARK_PR_DIFF_SCOPING = parse_bool(
 )
 # PRs changing more than this many files are treated as inherently broad -> full suite
 # (also bounds the synchronous GitHub pagination done inside the webhook request).
-try:
-    BENCHMARK_PR_MAX_FILES = int(os.getenv("BENCHMARK_PR_MAX_FILES", "100"))
-    if BENCHMARK_PR_MAX_FILES <= 0:
-        raise ValueError("must be > 0")
-except ValueError:
-    logging.warning(
-        "invalid BENCHMARK_PR_MAX_FILES (must be a positive int); using 100"
+BENCHMARK_PR_MAX_FILES = parse_int(
+    os.getenv("BENCHMARK_PR_MAX_FILES"), 100, "BENCHMARK_PR_MAX_FILES"
+)
+if BENCHMARK_PR_MAX_FILES <= 0:
+    # Bounds the synchronous GitHub pagination inside the webhook request, so a non-positive value
+    # would make every labelled PR fall back to a full suite silently.
+    logging.getLogger(__name__).warning(
+        "BENCHMARK_PR_MAX_FILES is %r, which is not positive; using 100 instead.",
+        BENCHMARK_PR_MAX_FILES,
     )
     BENCHMARK_PR_MAX_FILES = 100
 # Diff-scoping needs to read PR files from the GitHub API. Without a token it runs

--- a/utils/tests/test_parse_int.py
+++ b/utils/tests/test_parse_int.py
@@ -1,0 +1,207 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+"""Property tests for integer settings that arrive as strings.
+
+Every one of these is read at import time, so a bare ``int()`` on a malformed value raises before
+any entrypoint runs -- the coordinator, the builder, the runner and the CLI all fail to start, with a
+traceback pointing at an import statement rather than at the variable that was wrong. Under a
+supervisor that reads as a crash loop with no indication of the cause.
+
+Offline; no Redis, no Docker.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from redis_benchmarks_specification.__common__.env import parse_int
+
+# Every integer setting read at import time, with the default each falls back to.
+INT_SETTINGS = {
+    "GH_REDIS_SERVER_PORT": ("GH_REDIS_SERVER_PORT", 6379),
+    "REDIS_AUTH_SERVER_PORT": ("REDIS_AUTH_SERVER_PORT", 6379),
+    "REDIS_HEALTH_CHECK_INTERVAL": ("REDIS_HEALTH_CHECK_INTERVAL", 15),
+    "REDIS_SOCKET_TIMEOUT": ("REDIS_SOCKET_TIMEOUT", 300),
+    "DATASINK_RTS_PORT": ("DATASINK_RTS_PORT", 6379),
+    "MAX_PROFILERS": ("MAX_PROFILERS_PER_TYPE", 1),
+    "REDIS_BINS_EXPIRE_SECS": ("REDIS_BINS_EXPIRE_SECS", 24 * 7 * 60 * 60),
+    "BENCHMARK_PR_MAX_FILES": ("BENCHMARK_PR_MAX_FILES", 100),
+}
+
+# Values an operator or a templating system realistically produces, including empty.
+HOSTILE = [
+    "",
+    " ",
+    "\t",
+    "abc",
+    "1.5",
+    "0x10",
+    "-",
+    "+",
+    "1e3",
+    "None",
+    "null",
+    "6379 ",
+]
+
+
+def _import_env(**environment):
+    """Import the env module in a subprocess and return (returncode, stdout).
+
+    A subprocess because the constants are computed at import time: reloading rebinds them in one
+    module while every from-import copy keeps the old value, so a reload cannot show what a fresh
+    process would actually see.
+    """
+    keys = list(INT_SETTINGS)
+    clean = {k: v for k, v in os.environ.items() if k not in keys}
+    clean.update({k: str(v) for k, v in environment.items()})
+    script = (
+        "import redis_benchmarks_specification.__common__.env as e;"
+        "print(repr({name: getattr(e, attr) for name, (attr, _) in "
+        + repr({k: v for k, v in INT_SETTINGS.items()})
+        + ".items()}))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=clean
+    )
+    return result.returncode, result.stdout.strip(), result.stderr
+
+
+@pytest.mark.parametrize("name", sorted(INT_SETTINGS))
+@pytest.mark.parametrize("value", HOSTILE)
+def test_no_integer_setting_can_abort_the_import(name, value):
+    """The property that matters: a bad value must not stop the process from starting.
+
+    Before this, six of the seven raised ValueError from module scope on any non-numeric value.
+    """
+    code, _, stderr = _import_env(**{name: value})
+    assert code == 0, f"{name}={value!r} aborted the import:\n{stderr[-400:]}"
+
+
+@pytest.mark.parametrize(
+    "name,expected", [(n, d) for n, (_, d) in INT_SETTINGS.items()]
+)
+@pytest.mark.parametrize("value", ["abc", "", "1.5", "None"])
+def test_a_malformed_value_falls_back_to_the_documented_default(name, expected, value):
+    """And the fallback must be the documented default, not zero or None."""
+    code, out, _ = _import_env(**{name: value})
+    assert code == 0
+    assert eval(out)[name] == expected
+
+
+@pytest.mark.parametrize("name", sorted(INT_SETTINGS))
+def test_a_valid_value_is_honoured(name):
+    """The fallback must not swallow good input."""
+    code, out, _ = _import_env(**{name: 4242})
+    assert code == 0
+    assert eval(out)[name] == 4242
+
+
+def test_a_non_positive_max_files_falls_back_rather_than_disabling_scoping():
+    """It bounds the synchronous GitHub pagination inside the webhook request.
+
+    A non-positive value would make every labelled PR quietly fall back to a full suite, which is
+    expensive and invisible.
+    """
+    for value in ("0", "-1", "-100"):
+        code, out, _ = _import_env(BENCHMARK_PR_MAX_FILES=value)
+        assert code == 0
+        assert eval(out)["BENCHMARK_PR_MAX_FILES"] == 100
+
+
+# --- the helper itself ------------------------------------------------------------------------
+
+
+@given(value=st.integers())
+def test_an_integer_survives_the_str_round_trip(value):
+    """The property the callers need: parse(str(v)) == v."""
+    assert parse_int(str(value), default=-1) == value
+
+
+@given(value=st.integers())
+def test_an_actual_int_passes_through(value):
+    assert parse_int(value, default=-1) == value
+
+
+@pytest.mark.parametrize("value", HOSTILE + [None, [], {}, object()])
+def test_anything_unparseable_yields_the_default(value):
+    if isinstance(value, str) and value.strip().lstrip("+-").isdigit():
+        pytest.skip("parseable")
+    assert parse_int(value, default=99) == 99
+
+
+@pytest.mark.parametrize(
+    "value,expected", [(b"12", 12), (bytearray(b"7"), 7), (b"\xff", 99)]
+)
+def test_bytes_are_decoded_and_undecodable_bytes_fall_back(value, expected):
+    """Stream and environment reads are not always decoded first."""
+    assert parse_int(value, default=99) == expected
+
+
+@pytest.mark.parametrize("value,expected", [("1_000", 1000), ("٣", 3), (" 42 ", 42)])
+def test_the_permissiveness_of_int_is_preserved(value, expected):
+    """int() accepts underscores and Unicode digits, and that is deliberately not tightened.
+
+    Pinned because it is surprising, and because narrowing it would reject values that work today.
+    """
+    assert parse_int(value, default=-1) == expected
+
+
+def test_a_fallback_names_the_variable(caplog):
+    """A warning that does not say which variable was wrong sends the reader to the source."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        parse_int("abc", default=5, name="SOME_SETTING")
+    assert any("SOME_SETTING" in r.getMessage() for r in caplog.records)
+
+
+def test_a_valid_value_does_not_warn(caplog):
+    """Otherwise every normal start logs noise and the real warnings stop being read."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        parse_int("7", default=5, name="SOME_SETTING")
+    assert not [r for r in caplog.records if "SOME_SETTING" in r.getMessage()]
+
+
+def test_no_module_reads_an_integer_setting_with_a_bare_int_cast():
+    """Guards the whole package, since the mistake is invisible at the call site.
+
+    Read from the syntax tree rather than the text: matching `int(os.getenv(...))` as a call node
+    survives reformatting and cannot be fooled by the pattern appearing in a comment.
+    """
+    import ast
+    import pathlib
+
+    import redis_benchmarks_specification
+
+    package = pathlib.Path(redis_benchmarks_specification.__file__).parent
+    scanned = sorted(package.rglob("*.py"))
+    assert len(scanned) > 20, f"only scanned {len(scanned)} files"
+
+    offenders = []
+    for path in scanned:
+        for node in ast.walk(ast.parse(path.read_text())):
+            if (
+                not isinstance(node, ast.Call)
+                or getattr(node.func, "id", None) != "int"
+            ):
+                continue
+            for argument in node.args:
+                if (
+                    isinstance(argument, ast.Call)
+                    and getattr(argument.func, "attr", None) == "getenv"
+                ):
+                    offenders.append(f"{path.relative_to(package)}:{node.lineno}")
+    assert not offenders, (
+        "int(os.getenv(...)) aborts the import on a malformed value; use parse_int: "
+        f"{offenders}"
+    )


### PR DESCRIPTION
Closes #465.

Eight integer settings were read with a bare `int(os.getenv(...))` at module scope. I fuzzed each with values an operator or a templating system realistically produces. **Seven of the eight aborted the import on nine of eleven inputs:**

```
""  " "  "abc"  "1.5"  "0x10"  "-"  "+"  "1e3"  "None"
```

Because this is module scope, the consequence is not a bad setting — it is that **nothing starts**. The coordinator, the builder, the runner and the CLI all fail at import, with a traceback pointing at an `import` statement rather than at the variable that was wrong. Under a supervisor that reads as a crash loop with no indication of the cause.

The eighth, `BENCHMARK_PR_MAX_FILES`, already had a `try/except` and survived everything — so the pattern to follow was established a few lines away.

## The fix

`parse_int` falls back to the documented default and warns, naming the variable. `BENCHMARK_PR_MAX_FILES` keeps its positive-value check, which matters on its own: a non-positive value makes every labelled PR fall back to a full suite, which is expensive and invisible.

**`int()`'s permissiveness is preserved and pinned rather than tightened.** `"1_000"` is 1000 and Arabic-Indic `"٣"` is 3, because Python accepts underscores and Unicode digits. Both are surprising enough to be worth a test, and narrowing them would reject values that work today.

## One site was found by the guard, not by me

`REDIS_BINS_EXPIRE_SECS` spans two lines, so the single-line grep I used to enumerate the sites never saw it. The package-wide guard reads the syntax tree rather than the text, which is why it caught what I missed — and it is the reason the guard is worth having beyond this changeset.

## Tests

163, offline, no Redis or Docker.

The settings are exercised **in a subprocess**, because these constants are computed at import time: reloading the module rebinds them there while every from-import copy keeps the old value, so a reload cannot show what a fresh process would actually see.

Properties: no integer setting can abort the import; a malformed value falls back to the *documented* default rather than to zero or `None`; a valid value is still honoured; the round trip `parse(str(v)) == v` holds over generated integers; bytes are decoded and undecodable bytes fall back; a fallback names the variable and a valid value does not warn.

Each fix verified by reverting it: restoring one bare `int()` fails 16 tests, making `parse_int` raise fails 136, dropping the non-positive guard fails 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-hardening only: misconfigured env vars degrade to defaults with warnings rather than changing happy-path behavior for valid settings.
> 
> **Overview**
> Adds **`parse_int`** so import-time integer settings no longer use bare **`int(os.getenv(...))`**, which could **`ValueError`** and prevent coordinator, builder, runner, and CLI from starting.
> 
> **Eight settings** (Redis ports/timeouts, datasink port, max profilers, bin TTL, PR max files) now **warn with the variable name** and fall back to documented defaults on bad input. **`BENCHMARK_PR_MAX_FILES`** still **rejects non-positive values** and resets to 100 so labelled PRs do not silently run the full suite.
> 
> New **`utils/tests/test_parse_int.py`** covers subprocess import behavior, **`parse_int`** edge cases (bytes, Unicode digits, underscores), and an **AST guard** that forbids **`int(os.getenv(...))`** anywhere in the package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c5e16a70e3105ea409f50ff4dfb13169df66be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->