### PR TITLE
fix(auth-reconnect spec): stop overriding the harness-injected credential

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.3.31"
+version = "0.3.32"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "Readme.md"

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-auth-reconnect-10B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-auth-reconnect-10B.yml
@@ -29,7 +29,6 @@ tested-commands:
 - get
 tested-groups:
 - string
-- connection
 redis-topologies:
 - oss-standalone
 build-variants:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-auth-reconnect-10B.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-auth-reconnect-10B.yml
@@ -1,26 +1,35 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-string-auth-reconnect-10B
-description: Measures throughput under rapid connection churn with AUTH authentication on every connection. Each memtier client reconnects frequently (-c 1 --reconnect-interval 1), forcing AUTH + GET on each connection cycle. Validates the overhead of argument redaction on the AUTH hot path (defer-argv-redaction optimization target).
+description: Measures Ops/sec under rapid connection churn with AUTH on every connection.
+  Each memtier client reconnects after every request (-c 1 -t 10 --reconnect-interval 1),
+  so each cycle pays TCP connect + AUTH + GET. Values are 10 B strings (EMBSTR encoding);
+  the GET is incidental — the metric of interest is Ops/sec as a proxy for per-connection
+  AUTH + handshake cost (e.g. argument redaction on the AUTH path). The harness always
+  starts the server under test with its own --requirepass and injects the matching
+  --authenticate into every client, so AUTH is exercised without the spec setting any
+  password of its own. Note this holds on the coordinator path; driven by the standalone
+  runner against a target that has no password, no AUTH is sent and the workload degrades
+  to reconnect + GET.
 dbconfig:
   configuration-parameters:
     save: '""'
-    requirepass: '"benchmarkpass"'
   check:
     keyspacelen: 1000000
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50 -a benchmarkpass'
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram" "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
   resources:
     requests:
       memory: 1g
   dataset_name: 1Mkeys-string-10B-size
-  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes. Server has requirepass set to exercise AUTH on every connection.
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes (EMBSTR). The harness-injected requirepass on the server under test is what makes every reconnect pay an AUTH.
 tested-commands:
 - auth
 - get
 tested-groups:
 - string
+- connection
 redis-topologies:
 - oss-standalone
 build-variants:
@@ -30,7 +39,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '"--data-size" "10" --distinct-client-seed --ratio 0:1 --key-pattern R:R -c 1 -t 10 --hide-histogram --test-time 120 --key-minimum 1 --key-maximum 1000000 -a benchmarkpass --reconnect-interval 1'
+  arguments: '"--data-size" "10" --distinct-client-seed --ratio 0:1 --key-pattern R:R -c 1 -t 10 --hide-histogram --test-time 120 --key-minimum 1 --key-maximum 1000000 --reconnect-interval 1'
   resources:
     requests:
       cpus: '10'


### PR DESCRIPTION
## Problem

`memtier_benchmark-1Mkeys-string-auth-reconnect-10B` has **never produced a single datapoint on any platform** since it was added. I confirmed the TimeSeries key does not exist for either `x86-aws-m7i.metal-24xl` or `arm-aws-m8g.metal-24xl`.

Two spec-level settings caused it:

```yaml
dbconfig.configuration-parameters.requirepass: '"benchmarkpass"'
-a benchmarkpass    # in both preload_tool and clientconfig arguments
```

- The coordinator always starts the server under test with **its own** `--requirepass`, and `requirepass` is in the builder's `added_params` list — so the spec's value was silently dropped and never reached the server.
- The coordinator then injects the matching `--authenticate` into every memtier invocation and appends the spec's `arguments` **after** it. So the trailing `-a benchmarkpass` won as the last occurrence, authenticating with a password the server never had.

Net effect: `error: authentication failed [-WRONGPASS invalid username-password pair or user is disabled.]` repeated for the entire run. memtier sat at **0 ops/sec and never exited** — I observed a container up 13 minutes still printing `[RUN #1 0%, N secs] 0 ops`. Because this spec sorts first in a scoped selection, it also **blocked every remaining test in the same run**.

This is the only spec of 448 that sets `requirepass` or passes `-a`.

## Fix

Remove both. Since the coordinator *always* sets a requirepass, every connection still pays an AUTH, so the spec's stated objective survives without it.

Verified locally after the fix:

| phase | result |
|---|---|
| preload | 623,680 ops/sec, `DBSIZE` **1000000** == `check.keyspacelen` |
| client  | **15,214 ops/sec**, 0 misses, clean exit |

Also in this PR:

- Describe the underlying encoding (10 B values are EMBSTR) and the metric of interest, and note that the AUTH coverage holds on the coordinator path — driven by the standalone runner against a target with no password, no AUTH is sent.
- Add `connection` to `tested-groups`, since `AUTH` belongs to that group while `GET` is `string`.
- Bump the version, so coordinators running a pinned release actually pick the fix up. Without the bump a merge alone would leave the spec broken on the fleet.

## Notes

- `--key-maximum 1000000` is deliberately left as-is. I briefly changed it to `1000001` on the assumption that `-n allkeys` yields `(max - min)` requests, measured `DBSIZE 1000001` against `keyspacelen: 1000000`, and reverted. With the `--key-pattern P:P` preload form the range is max-**inclusive**, so `1000000` is correct and produces exactly 1,000,000 keys.
- `--reconnect-interval 1` is retained: deterministic connection churn is the subject of this spec, not an incidental flag.
- `utils/tests/test_schema.py` and `utils/tests/test_runner.py`: 37 passed. The one failure (`test_run_client_runner_logic`) is pre-existing on a clean `main` — it needs a local Redis on the default port and is unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-spec and packaging version only; no runtime code paths or security logic changed.
> 
> **Overview**
> **Fixes a broken benchmark spec** that never produced metrics because spec-level `requirepass` and memtier `-a benchmarkpass` fought the coordinator’s own password injection (wrong password → endless 0 ops/sec runs).
> 
> Removes `dbconfig.configuration-parameters.requirepass` and `-a benchmarkpass` from preload and client memtier args so the server and clients use the harness-injected credential pair. **AUTH-on-reconnect behavior is unchanged** on the coordinator path.
> 
> Expands the spec and dataset descriptions (EMBSTR 10 B values, Ops/sec as the metric, coordinator vs standalone runner behavior).
> 
> Bumps package version **0.3.31 → 0.3.32** so pinned coordinators pick up the fixed YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb2c7d1424b00284bb3913516c84b0172d60b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->