### PR TITLE
fix: let non-root client images write their benchmark output

### DIFF
--- a/redis_benchmarks_specification/__common__/multi_tool.py
+++ b/redis_benchmarks_specification/__common__/multi_tool.py
@@ -18,6 +18,7 @@ import math
 import os
 import re
 from dataclasses import dataclass, field
+import tempfile
 from typing import List, Optional
 
 import docker
@@ -65,6 +66,38 @@ def remove_started_containers(containers):
                 f"Error removing partially-started client "
                 f"{started.get('client_index')}: {cleanup_error}"
             )
+
+
+def make_client_output_dir(home, world_writable=True):
+    """Create the temp dir that client containers bind-mount for their output.
+
+    ``tempfile.mkdtemp`` returns 0700 owned by whoever runs the coordinator/runner.
+    Client containers write their ``--json-out-file`` in here, and not every client
+    image runs as root -- ``pubsub-sub-bench`` runs as uid 1001 -- so a non-root
+    client would complete its entire benchmark and only then die with
+    ``open benchmark_output_N.json: permission denied``, exit 1, and take the whole
+    test down with it.
+
+    Pass ``world_writable=False`` when the caller also copies secrets (TLS cert/key
+    material) into this directory: widening it would let any local user traverse in
+    and read them. Non-root client images cannot be combined with that case, which
+    is fine today because no TLS-capable client tool runs as non-root.
+    """
+    client_dir = tempfile.mkdtemp(dir=home)
+    if world_writable:
+        allow_client_output_writes(client_dir)
+    return client_dir
+
+
+def allow_client_output_writes(client_dir):
+    """Widen ``client_dir`` so any client container uid can create its output file.
+
+    Split out from :func:`make_client_output_dir` because the standalone runner cannot
+    decide at creation time: ``--uri`` may flip TLS on *after* the directory exists, and
+    under TLS this directory also receives the cert/key copies. The runner therefore
+    creates it private and calls this only once TLS is known to be off.
+    """
+    os.chmod(client_dir, 0o777)
 
 
 def stop_background_helper(container_info):

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -77,6 +77,8 @@ from redis_benchmarks_specification.__common__.spec import (
     extract_client_container_images,
 )
 from redis_benchmarks_specification.__common__.multi_tool import (
+    allow_client_output_writes,
+    make_client_output_dir,
     prepare_client_run_specs,
     run_client_configs,
     remove_started_containers,
@@ -1447,12 +1449,12 @@ def process_self_contained_coordinator_stream(
                 full_result_path = None
                 try:
                     current_cpu_pos = args.cpuset_start_pos
-                    temporary_dir_client = tempfile.mkdtemp(dir=home)
-                    # See the matching note in the self-contained coordinator: mkdtemp()
-                    # is 0700, and client images that do not run as root (e.g.
-                    # pubsub-sub-bench, uid 1001) cannot write their --json-out-file into
-                    # it. They fail only at the very end, after the benchmark has run.
-                    os.chmod(temporary_dir_client, 0o777)
+                    # Created private. It is widened further below, once TLS is known to
+                    # be off -- `--uri` can still flip tls_enabled on after this point,
+                    # and under TLS this same dir receives the cert/key copies.
+                    temporary_dir_client = make_client_output_dir(
+                        home, world_writable=False
+                    )
 
                     # These will be updated after auto-detection
                     tf_github_org = args.github_org
@@ -1795,6 +1797,13 @@ def process_self_contained_coordinator_stream(
                             _, test_tls_key = cp_to_workdir(
                                 temporary_dir_client, tls_key
                             )
+                    else:
+                        # tls_enabled is final here (args plus any --uri override), and no
+                        # cert/key material was copied in, so it is safe to let a non-root
+                        # client image (e.g. pubsub-sub-bench, uid 1001) create its
+                        # --json-out-file. Without this such a client completes the whole
+                        # benchmark and then dies on "permission denied".
+                        allow_client_output_writes(temporary_dir_client)
                     priority = None
                     if "priority" in benchmark_config:
                         priority = benchmark_config["priority"]

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -1448,6 +1448,11 @@ def process_self_contained_coordinator_stream(
                 try:
                     current_cpu_pos = args.cpuset_start_pos
                     temporary_dir_client = tempfile.mkdtemp(dir=home)
+                    # See the matching note in the self-contained coordinator: mkdtemp()
+                    # is 0700, and client images that do not run as root (e.g.
+                    # pubsub-sub-bench, uid 1001) cannot write their --json-out-file into
+                    # it. They fail only at the very end, after the benchmark has run.
+                    os.chmod(temporary_dir_client, 0o777)
 
                     # These will be updated after auto-detection
                     tf_github_org = args.github_org

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -73,6 +73,7 @@ from redis_benchmarks_specification.__runner__.runner import (
     validate_benchmark_metrics,
 )
 from redis_benchmarks_specification.__common__.multi_tool import (
+    make_client_output_dir,
     prepare_client_run_specs,
     run_client_configs,
 )
@@ -1758,15 +1759,12 @@ def process_self_contained_coordinator_stream(
                                     )
                                 )
                                 temporary_dir = tempfile.mkdtemp(dir=home)
-                                temporary_dir_client = tempfile.mkdtemp(dir=home)
-                                # mkdtemp() is 0700 and owned by whoever runs the
-                                # coordinator. Client containers are bind-mounted here to
-                                # write their --json-out-file, and not every client image
-                                # runs as root (pubsub-sub-bench runs as uid 1001), so a
-                                # non-root client would finish its whole run and then die
-                                # with "permission denied" on the results file. Widen it so
-                                # any client uid can write.
-                                os.chmod(temporary_dir_client, 0o777)
+                                # World-writable so non-root client images (e.g.
+                                # pubsub-sub-bench, uid 1001) can write their
+                                # --json-out-file. This path never copies TLS material
+                                # into the client dir (test_tls_cert/key are passed as
+                                # None below), so widening it exposes nothing.
+                                temporary_dir_client = make_client_output_dir(home)
                                 logging.info(
                                     "Using local temporary dir to persist redis build artifacts. Path: {}".format(
                                         temporary_dir

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1759,6 +1759,14 @@ def process_self_contained_coordinator_stream(
                                 )
                                 temporary_dir = tempfile.mkdtemp(dir=home)
                                 temporary_dir_client = tempfile.mkdtemp(dir=home)
+                                # mkdtemp() is 0700 and owned by whoever runs the
+                                # coordinator. Client containers are bind-mounted here to
+                                # write their --json-out-file, and not every client image
+                                # runs as root (pubsub-sub-bench runs as uid 1001), so a
+                                # non-root client would finish its whole run and then die
+                                # with "permission denied" on the results file. Widen it so
+                                # any client uid can write.
+                                os.chmod(temporary_dir_client, 0o777)
                                 logging.info(
                                     "Using local temporary dir to persist redis build artifacts. Path: {}".format(
                                         temporary_dir

--- a/utils/tests/test_multi_tool.py
+++ b/utils/tests/test_multi_tool.py
@@ -461,3 +461,39 @@ def test_run_client_configs_pins_disjoint_cpusets(tmp_path):
     calls = docker_client.containers.run.call_args_list
     cpusets = [c.kwargs.get("cpuset_cpus") for c in calls]
     assert cpusets == ["4,5,6,7", "8,9,10,11"]  # disjoint, not the shared "4-11"
+
+
+def test_client_output_dir_is_writable_by_non_root_client_images():
+    """A client image that does not run as root must still be able to write its
+    --json-out-file into the bind-mounted client dir.
+
+    tempfile.mkdtemp() creates 0700 owned by whoever runs the coordinator/runner.
+    memtier_benchmark's image runs as root and never noticed, but
+    pubsub-sub-bench's runs as uid 1001, so every pubsub-mixed suite completed its
+    full benchmark and then died with
+
+        open benchmark_output_1.json: permission denied
+
+    exiting 1 and failing the whole test. Both creation sites therefore widen the
+    client dir to 0777. This asserts the mode a foreign uid needs, so the
+    regression cannot come back silently.
+    """
+    import os
+    import stat
+    import tempfile
+
+    temporary_dir_client = tempfile.mkdtemp()
+    try:
+        # Reproduce the default that caused the bug.
+        assert stat.S_IMODE(os.stat(temporary_dir_client).st_mode) == 0o700
+
+        # Reproduce what both call sites now do.
+        os.chmod(temporary_dir_client, 0o777)
+
+        mode = stat.S_IMODE(os.stat(temporary_dir_client).st_mode)
+        assert mode == 0o777, f"expected 0o777, got {oct(mode)}"
+        # The bits an arbitrary container uid actually needs: write + traverse.
+        assert mode & stat.S_IWOTH, "other-write is required for a non-root client uid"
+        assert mode & stat.S_IXOTH, "other-execute is required to traverse into the dir"
+    finally:
+        os.rmdir(temporary_dir_client)

--- a/utils/tests/test_multi_tool.py
+++ b/utils/tests/test_multi_tool.py
@@ -463,37 +463,72 @@ def test_run_client_configs_pins_disjoint_cpusets(tmp_path):
     assert cpusets == ["4,5,6,7", "8,9,10,11"]  # disjoint, not the shared "4-11"
 
 
-def test_client_output_dir_is_writable_by_non_root_client_images():
-    """A client image that does not run as root must still be able to write its
-    --json-out-file into the bind-mounted client dir.
+def test_make_client_output_dir_is_writable_by_non_root_client_images(tmp_path):
+    """The production helper must leave the client dir writable by a foreign uid.
 
-    tempfile.mkdtemp() creates 0700 owned by whoever runs the coordinator/runner.
-    memtier_benchmark's image runs as root and never noticed, but
-    pubsub-sub-bench's runs as uid 1001, so every pubsub-mixed suite completed its
-    full benchmark and then died with
+    Client containers bind-mount this dir to write their --json-out-file. mkdtemp()
+    is 0700 owned by the coordinator's user, and pubsub-sub-bench's image runs as uid
+    1001, so before this every pubsub-mixed suite ran to completion and then died with
+    "open benchmark_output_1.json: permission denied", exit 1.
 
-        open benchmark_output_1.json: permission denied
-
-    exiting 1 and failing the whole test. Both creation sites therefore widen the
-    client dir to 0777. This asserts the mode a foreign uid needs, so the
-    regression cannot come back silently.
+    This calls the real helper both call sites use, so deleting the chmod from it fails
+    here.
     """
     import os
     import stat
-    import tempfile
 
-    temporary_dir_client = tempfile.mkdtemp()
-    try:
-        # Reproduce the default that caused the bug.
-        assert stat.S_IMODE(os.stat(temporary_dir_client).st_mode) == 0o700
+    from redis_benchmarks_specification.__common__.multi_tool import (
+        make_client_output_dir,
+    )
 
-        # Reproduce what both call sites now do.
-        os.chmod(temporary_dir_client, 0o777)
+    client_dir = make_client_output_dir(str(tmp_path))
+    mode = stat.S_IMODE(os.stat(client_dir).st_mode)
 
-        mode = stat.S_IMODE(os.stat(temporary_dir_client).st_mode)
-        assert mode == 0o777, f"expected 0o777, got {oct(mode)}"
-        # The bits an arbitrary container uid actually needs: write + traverse.
-        assert mode & stat.S_IWOTH, "other-write is required for a non-root client uid"
-        assert mode & stat.S_IXOTH, "other-execute is required to traverse into the dir"
-    finally:
-        os.rmdir(temporary_dir_client)
+    assert mode == 0o777, f"expected 0o777, got {oct(mode)}"
+    # The bits an arbitrary container uid actually needs.
+    assert mode & stat.S_IWOTH, "other-write is required to create the output file"
+    assert mode & stat.S_IXOTH, "other-execute is required to traverse into the dir"
+
+
+def test_make_client_output_dir_stays_private_when_it_will_hold_tls_material(tmp_path):
+    """Under TLS the same dir receives copies of the cert/key, so it must NOT be widened.
+
+    The standalone runner calls cp_to_workdir(temporary_dir_client, tls_key); making that
+    directory world-writable/traversable would let any local user read the private key.
+    """
+    import os
+    import stat
+
+    from redis_benchmarks_specification.__common__.multi_tool import (
+        make_client_output_dir,
+    )
+
+    client_dir = make_client_output_dir(str(tmp_path), world_writable=False)
+    mode = stat.S_IMODE(os.stat(client_dir).st_mode)
+
+    assert mode == 0o700, f"expected mkdtemp default 0o700, got {oct(mode)}"
+    assert not mode & stat.S_IROTH, "TLS material must not be world-readable"
+    assert not mode & stat.S_IWOTH, "TLS material dir must not be world-writable"
+
+
+def test_allow_client_output_writes_widens_an_existing_private_dir(tmp_path):
+    """The runner creates the dir private and widens it only once TLS is ruled out.
+
+    `--uri` can flip tls_enabled on after the directory already exists, so the decision
+    cannot be made at creation time; this is the deferred step.
+    """
+    import os
+    import stat
+
+    from redis_benchmarks_specification.__common__.multi_tool import (
+        allow_client_output_writes,
+        make_client_output_dir,
+    )
+
+    client_dir = make_client_output_dir(str(tmp_path), world_writable=False)
+    assert stat.S_IMODE(os.stat(client_dir).st_mode) == 0o700
+
+    allow_client_output_writes(client_dir)
+    mode = stat.S_IMODE(os.stat(client_dir).st_mode)
+    assert mode == 0o777, f"expected 0o777, got {oct(mode)}"
+    assert mode & stat.S_IWOTH and mode & stat.S_IXOTH


### PR DESCRIPTION
Fixes #473.

## Problem

Every `memtier_benchmark-nokeys-pubsub-mixed-*-subscribers` suite fails fleet-wide. The tool is not at fault and neither are the specs — the benchmark **runs to completion** and only then dies writing its results:

```
2026/08/04 11:31:03 open benchmark_output_1.json: permission denied
#################################################
Mode: subscribe
Total Duration: 60.000254 Seconds
Message Rate: 1066966.199238 msg/sec
#################################################
```

`tempfile.mkdtemp()` creates the client directory mode **0700**, owned by whoever runs the coordinator (root on the runners). That directory is bind-mounted into every client container as the working dir for `--json-out-file`.

It happened to work only because of an image difference:

| image | `Config.User` | effective uid |
|---|---|---|
| `redislabs/memtier_benchmark:edge` | *(unset)* | **0** |
| `filipe958/pubsub-sub-bench:latest` | `appuser` | **1001** |

So memtier could always write; pubsub-sub-bench never could. `run_client_configs` then raises on the non-zero exit and the already-successful measurement is discarded.

## Fix

`os.chmod(temporary_dir_client, 0o777)` at both creation sites — `__self_contained_coordinator__/self_contained_coordinator.py` and `__runner__/runner.py`.

This is the **client artifact dir only**; the server/build artifact dir is deliberately untouched. The fix is not specific to pubsub-sub-bench: any future client image that doesn't run as root would have hit the same wall, and would likewise only have failed at the very end.

## Verification

Mechanism reproduced directly against the same image and mount, isolating just the permission behaviour:

```
0700 (mkdtemp default) + uid 1001 -> touch: benchmark_output_1.json: Permission denied
0777 (this change)     + uid 1001 -> WRITE OK
```

Added `test_client_output_dir_is_writable_by_non_root_client_images`, which asserts the 0700 default is what breaks and that the widened mode carries the bits a foreign container uid actually needs (other-write to create, other-execute to traverse). Without a test this regression is invisible until someone introduces a non-root client image.

```
utils/tests/test_multi_tool.py utils/tests/test_coordinator_multitool.py utils/tests/test_schema.py
27 passed

black --check  3 files would be left unchanged
```

## Note on diagnosis

Two things obscured this, both worth knowing when reading a failed multi-client run:

1. `container.logs()` is emitted as a single `logging.error(client_stdout)` call, so the client's whole multi-line output is **one** log record. Grepping the coordinator log for `error|fail` matches only its first line (the version banner), making it look as though the tool died instantly with no message. The real error is second-to-last in that record.
2. It cannot be reproduced by running the spec's arguments by hand without a publisher: `pubsub-sub-bench` ignores `-test-time` when no messages arrive, so it never reaches the write step and just keeps running.

Neither is changed here; #473 notes them as separate follow-ups, along with trimming the preserve-on-failure temp dirs (~10k dirs / ~94 GB observed on one runner, each retaining a ~21 MB `redis-server` copy).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local temp directory permissions only; TLS paths stay 0700 when secrets are copied. No auth or benchmark logic changes.
> 
> **Overview**
> Fixes fleet failures where benchmarks finish but the run fails on **`permission denied`** writing `--json-out-file` into the bind-mounted client temp dir (notably **`pubsub-sub-bench`** as uid 1001 vs **`mkdtemp`** default **0700**).
> 
> Adds shared helpers in **`multi_tool`**: **`make_client_output_dir`** (optionally chmod **0o777** via **`allow_client_output_writes`**) and documents that widening must not happen when TLS cert/key copies live in the same directory.
> 
> The **self-contained coordinator** creates a world-writable client output dir by default (no TLS material there). The **standalone runner** creates the dir private first, then calls **`allow_client_output_writes`** only after TLS is finalized off (including **`--uri`** overrides), so private keys are not left world-readable/traversable.
> 
> Unit tests in **`test_multi_tool.py`** lock in writable vs TLS-private behavior and the deferred widen path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7a97d59c9cddfe897d590a7f46e55f75e93104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->