### PR TITLE
fix: raise client thread budget where memtier itself was the bottleneck

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-10-elements-smembers-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-10-elements-smembers-pipeline-10.yml
@@ -29,10 +29,10 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --pipeline 10 --command="SMEMBERS set:10"  --hide-histogram --test-time
+  arguments: -c 25 -t 8 --pipeline 10 --command="SMEMBERS set:10"  --hide-histogram --test-time
     180
   resources:
     requests:
-      cpus: '4'
+      cpus: '8'
       memory: 2g
 priority: 23

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features-template.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features-template.yml
@@ -79,7 +79,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: '--data-size-range=8-24 --random-data --key-prefix "feature_store:user_features:entity:" --distinct-client-seed --pipeline=1 --print-percentiles=50,99 --test-time=120 -c 50 -t 4 --key-minimum=1
+  arguments: '--data-size-range=8-24 --random-data --key-prefix "feature_store:user_features:entity:" --distinct-client-seed --pipeline=1 --print-percentiles=50,99 --test-time=120 -c 25 -t 8 --key-minimum=1
     --key-maximum=10000000 --command=''HGETALL __key__'' --command-key-pattern=Z --command-ratio=19 --command=''HSET __key__ feature_1 __data__ feature_2 __data__ feature_3 __data__ feature_4 __data__ feature_5
     __data__ feature_6 __data__ feature_7 __data__ feature_8 __data__ feature_9 __data__ feature_10 __data__ feature_11 __data__ feature_12 __data__ feature_13 __data__ feature_14 __data__ feature_15 __data__
     feature_16 __data__ feature_17 __data__ feature_18 __data__ feature_19 __data__ feature_20 __data__ feature_21 __data__ feature_22 __data__ feature_23 __data__ feature_24 __data__ feature_25 __data__
@@ -90,6 +90,6 @@ clientconfig:
     '
   resources:
     requests:
-      cpus: '4'
+      cpus: '8'
       memory: 2g
 priority: 38

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features.yml
@@ -130,8 +130,8 @@ clientconfig:
     --pipeline=1
     --print-percentiles=50,99
     --test-time=120
-    -c 50
-    -t 4
+    -c 25
+    -t 8
     --key-minimum=1
     --key-maximum=10000000
     --command='HGETALL __key__'
@@ -143,7 +143,7 @@ clientconfig:
     --hide-histogram
   resources:
     requests:
-      cpus: '4'
+      cpus: '8'
       memory: 2g
 
 priority: 38

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-1M-entities-300-features.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-1M-entities-300-features.yml
@@ -139,8 +139,8 @@ clientconfig:
     --pipeline=1
     --print-percentiles=50,99
     --test-time=120
-    -c 50
-    -t 4
+    -c 25
+    -t 8
     --key-minimum=1
     --key-maximum=1000000
     --command='HGETALL __key__'
@@ -152,7 +152,7 @@ clientconfig:
     --hide-histogram
   resources:
     requests:
-      cpus: '4'
+      cpus: '8'
       memory: 2g
 
 priority: 38

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-session-caching-hash-100k-sessions.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-session-caching-hash-100k-sessions.yml
@@ -55,6 +55,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: >
+    -c 25 -t 8
     --key-prefix ""
     --key-minimum 1
     --key-maximum 100000
@@ -72,7 +73,7 @@ clientconfig:
     --hide-histogram
   resources:
     requests:
-      cpus: '4'
+      cpus: '8'
       memory: 2g
 
 priority: 150


### PR DESCRIPTION
Fixes #485, #486, #487.

## Problem

Three suites were measured genuinely load-generator bound on real hardware (server co-located, but on separate cores from the client):

| Suite | memtier CPU (of its thread budget) | server idle |
|---|---|---|
| `session-caching-hash-100k-sessions` | 91% | ~30% |
| `feature-store-hash-10M-entities-50-features` | 91% | ~33% |
| `1key-set-10-elements-smembers-pipeline-10` | 81% | ~37% |

In each case the reported ops/sec was partly a property of memtier's own capacity rather than the server under test.

## Fix

Applies the pattern already proven in #483: spread the same total connection count over more client threads (`-c 50 -t 4` → `-c 25 -t 8`, or add it explicitly where a suite relied on memtier's defaults), with `resources.requests.cpus` matched to `-t` so the extra threads aren't self-throttled by their own cpuset.

Also fixes `feature-store-hash-1M-entities-300-features` — #486's "worth reviewing at the same time" note (same `-t 4`, heavier per-op cost than the 50-features sibling).

## What was measured and deliberately left alone

Two suites in the same families were checked and are **not** changed here, because measurement didn't support it:
- `session-caching-hash-100k-sessions-pipeline-16` — 40-48% of its client thread budget. Deeper pipelining already gives it enough headroom, confirming the hypothesis in #485's own text.
- `playbook-realtime-analytics-membership` and its `-pipeline-10` variant — 29-33%. Comfortable, no fix needed.

## On #487 specifically

That issue's own text flags it as the weaker case (no in-family precedent, 81% vs. the other two suites' 91%). Local measurement on a smaller box didn't fully reproduce the reported 81% (came in around 40-51% depending on network path), but the suite was consistently the highest-loaded of the three checked in that family, its `--pipeline 10` design is directionally throughput-saturating per this repo's own memtier design guide, and the fix is the same low-risk pattern already proven elsewhere — so it's included, with medium confidence, matching the issue's own "reported for completeness, let maintainers decide" framing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only benchmark client tuning; no Redis or application runtime changes, though published ops/sec may shift for these suites.
> 
> **Overview**
> Updates **five memtier benchmark suites** so the client is less likely to cap reported throughput before Redis does. **Client args** move from **`-c 50 -t 4`** (or implicit defaults on the SMEMBERS pipeline case) to **`-c 25 -t 8`**, keeping the same total connection count while spreading work across more threads. **Client CPU requests** rise from **`4` to `8`** so those threads are not throttled by the pod cpuset.
> 
> Affected specs: **session-caching 100k sessions**, **feature-store** (10M/50-features main + template, and 1M/300-features), and **1-key SMEMBERS pipeline-10**. Workloads, datasets, and command mixes are unchanged—only load-generator sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3cea1b6d22b4312cf1b78a516a0c41c5312478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->