### PR TITLE
fix(test-suites): correct preload key-maximum in 7 hash read specs

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hgetall-50-fields-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hgetall-50-fields-100B-values.yml
@@ -23,7 +23,7 @@ dbconfig:
       __data__ field:39 __data__ field:40 __data__ field:41 __data__ field:42 __data__
       field:43 __data__ field:44 __data__ field:45 __data__ field:46 __data__ field:47
       __data__ field:48 __data__ field:49 __data__ field:50 __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 1000000 -n 500 -c 50 -t 4 --hide-histogram'
+      --key-minimum=1 --key-maximum 100000 -n 500 -c 50 -t 4 --hide-histogram'
   resources:
     requests:
       memory: 2g

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hexists.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hexists.yml
@@ -13,7 +13,7 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '"--data-size" "100" --command "HSET __key__ field1 __data__ field2
       __data__ field3 __data__ field4 __data__ field5 __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
+      --key-minimum=1 --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
       50'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hget-hgetall-hkeys-hvals-with-100B-values-template.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hget-hgetall-hkeys-hvals-with-100B-values-template.yml
@@ -13,7 +13,7 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "100" --command "HSET __key__ field1 __data__ field2 __data__ field3 __data__ field4 __data__
-      field5 __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram
+      field5 __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram
       --pipeline 50'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hget-hgetall-hkeys-hvals-with-100B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hget-hgetall-hkeys-hvals-with-100B-values.yml
@@ -14,7 +14,7 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '"--data-size" "100" --command "HSET __key__ field1 __data__ field2
       __data__ field3 __data__ field4 __data__ field5 __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
+      --key-minimum=1 --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
       50'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hgetall-50-fields-10B-values-template.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hgetall-50-fields-10B-values-template.yml
@@ -21,7 +21,7 @@ dbconfig:
       __data__ field:32 __data__ field:33 __data__ field:34 __data__ field:35 __data__ field:36 __data__ field:37 __data__
       field:38 __data__ field:39 __data__ field:40 __data__ field:41 __data__ field:42 __data__ field:43 __data__ field:44
       __data__ field:45 __data__ field:46 __data__ field:47 __data__ field:48 __data__ field:49 __data__ field:50 __data__"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50'
+      --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50'
   resources:
     requests:
       memory: 2g

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hgetall-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hgetall-50-fields-10B-values.yml
@@ -25,7 +25,7 @@ dbconfig:
       __data__ field:39 __data__ field:40 __data__ field:41 __data__ field:42 __data__
       field:43 __data__ field:44 __data__ field:45 __data__ field:46 __data__ field:47
       __data__ field:48 __data__ field:49 __data__ field:50 __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
+      --key-minimum=1 --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
       50'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hmget-5-fields-with-100B-values-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hmget-5-fields-with-100B-values-pipeline-10.yml
@@ -14,7 +14,7 @@ dbconfig:
     tool: memtier_benchmark
     arguments: '"--data-size" "100" --command "HSET __key__ field1 __data__ field2
       __data__ field3 __data__ field4 __data__ field5 __data__" --command-key-pattern="P"
-      --key-minimum=1 --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
+      --key-minimum=1 --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline
       50'
   resources:
     requests:


### PR DESCRIPTION
The preload_tool --key-maximum was 10x larger than the measured phase's --key-maximum, so ~90% of the measured commands hit keys that were never written and returned an empty reply.

With --command-key-pattern=P, memtier splits [key-minimum, key-maximum] into one contiguous block per client and each client writes only the first -n keys of its own block. Because the preload range was 10x too wide, each block was 10x too large and -n covered just its first 10%:

  100Kkeys-hash-hgetall-50-fields-100B-values
    preload  --key-maximum 1000000, 200 clients -> block 5000, -n 500 = 10%
    measured --key-maximum 100000 -> 20 blocks x 500 = 10k of 100k keys exist
  1Mkeys-hash-hgetall-50-fields-10B-values
  1Mkeys-hash-hget-hgetall-hkeys-hvals-with-100B-values
    preload  --key-maximum 10000000, 200 clients -> block 50000, -n 5000 = 10%
    measured --key-maximum 1000000 -> 20 blocks x 5000 = 100k of 1M keys exist

Predicted 90.0% miss rate matched the measured 90.0/90.1% on all three, and probing confirmed it: memtier-1..500 existed while memtier-501, memtier-50000 and memtier-99999 did not. The keyspacelen check still passed because the remaining 90% of the written keys landed above the measured range.

Setting the preload --key-maximum equal to the measured one makes the block size exactly match the existing -n, so the whole tested range is written once: this is the same convention the other 200-client preloads in this folder use (e.g. 1Mkeys-hash-hincrby: key-maximum 1000000, -n 5000, -c 50 -t 4).

-n is left untouched, so the preload issues the same number of writes as before and its runtime is unchanged. Verified on redis 8.8.1: misses go 90.0% -> 0.00%, dbsize is fully dense over the tested range, and throughput drops accordingly (100Kkeys-hgetall 437,985 -> 230,758 ops/sec) now that every command does real hash serialization instead of returning an empty reply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark validity and baseline throughput/latency for affected hash suites; no production code, but CI performance comparisons and historical baselines for these tests will shift.
> 
> **Overview**
> Fixes **incorrect hash read benchmarks** where preload used a `--key-maximum` **10× wider** than the measured `clientconfig` range. With `--command-key-pattern=P`, each client only writes the first `-n` keys in its partition, so most measured commands hit **missing keys** and returned empty replies (~90% miss rate) while `keyspacelen` checks could still pass.
> 
> **Preload `--key-maximum` is reduced** to match the measured phase (e.g. `1000000` → `100000` for the 100K suite; `10000000` → `1000000` for 1M suites) across seven memtier YAML specs, including `hgetall`, `hget`/`hkeys`/`hvals`, `hexists`, `hmget`, and template variants. **`-n` and other preload args are unchanged**, so write volume and preload runtime stay the same; benchmarks now exercise real hash reads and reported throughput drops accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0bd13c622fdeefaa0bc479247ab17dd97ec35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->