### PR TITLE
fix(pubsub): 50K-subscribers suite actually creates 50K subscriptions

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-mixed-100-channels-128B-100-publishers-50K-subscribers-5k-conns.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-mixed-100-channels-128B-100-publishers-50K-subscribers-5k-conns.yml
@@ -32,7 +32,8 @@ clientconfigs:
 - run_image: filipe958/pubsub-sub-bench:latest
   tool: pubsub-sub-bench
   arguments: -clients 5000 -channel-minimum 1 -channel-maximum 100 -subscriber-prefix
-    "channel-" -mode subscribe -test-time 120 -subscribers-per-channel 10
+    "channel-" -mode subscribe -test-time 120 -min-number-channels-per-subscriber 10
+    -max-number-channels-per-subscriber 10
   resources:
     requests:
       cpus: '4'


### PR DESCRIPTION
Fixes #499.

`memtier_benchmark-nokeys-pubsub-mixed-...-50K-subscribers-5k-conns.yml` created **5000** subscriptions, not 50K — the same workload as its `-5000-subscribers` sibling.

### Why

`-subscribers-per-channel` does not drive subscription creation in `pubsub-sub-bench`. Verified at `v0.7.3` (`7ebaa44f`), it appears in exactly three places — the flag definition, a reporting multiplication (`total_subscriptions := total_channels * *subscribers_per_channel`), and the JSON output field. Nothing else reads it.

Actual subscriptions come from the dense-placement loop: `-clients` connections, each subscribing to `n_channels_this_conn` channels, where that count is set by `-min-number-channels-per-subscriber` / `-max-number-channels-per-subscriber` — **both default 1**, and neither was passed.

| | before | after |
|---|--:|--:|
| actual subscriptions | 5,000 | **~47,800-50,000** (see Empirical validation) |
| reported `TotalSubscriptions` | 1,000 | 5,000 (still computed from the now-unused inert flag's default of 1 -- tracked in pubsub-sub-bench#43, not fixed here) |

### Empirical validation
Reproduced locally against a real `redis-server` + `filipe958/pubsub-sub-bench:latest` (the
image this suite pins), at a scaled-down `-clients 10 -min/max-number-channels-per-subscriber
10` (10x smaller than the real 5000-client suite, same flags) and checked actual subscriber
counts via `PUBSUB CHANNELS` + `PUBSUB NUMSUB`:
- **Before** (`-subscribers-per-channel 10`, no min/max flags): 10 total subscriptions (1 per
  client) -- confirms the flag is inert, exactly as the source-code analysis above predicts.
- **After** (`-min/max-number-channels-per-subscriber 10`): ~95-100 total subscriptions (~10 per
  client) -- confirms the fix produces the intended ~10x fan-out.
- Note: channel selection draws with replacement from the channel pool, so the real count is
  slightly below the arithmetic 50,000 (birthday-paradox effect, confirmed independently by
  the correctness review below at ~47,800 expected) -- still a genuine ~9.5x increase that
  fixes the plateau bug, not the exact round number in the suite's name.

### Why it matters beyond the label

The four pubsub-mixed suites read as a subscriber-count sweep — 100 → 1000 → 5000 → 50K — but the top two points were the same workload. Fan-out scaling therefore appears to plateau, which looks like a property of the *server* rather than of the benchmark not scaling. That is a believable-looking wrong answer, which is the kind worth fixing.

### The other half

`TotalSubscriptions` is computed from the inert flag rather than from subscriptions actually created, so the tool cannot detect this class of mismatch and in fact reports a number that corroborates the mistaken assumption. Filed separately as redis-performance/pubsub-sub-bench#43.

This change is correct against the current released tool, and remains correct if `-subscribers-per-channel` is later made to work as its help text says (the explicit flags simply take precedence).

### Note for reviewers

This is a genuine ~10x increase in subscriber-side work for that suite — it has never actually run at this fan-out. The client entry's `resources.requests` are left unchanged here to keep the diff minimal, but may be worth revisiting once you see real numbers.
