### PR TITLE
Add explicit TCP keepalive tuning for long-blocking stream reads

### DIFF
--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -37,6 +37,7 @@ from redis_benchmarks_specification.__common__.env import (
     REDIS_HEALTH_CHECK_INTERVAL,
     REDIS_SOCKET_TIMEOUT,
     REDIS_BINS_EXPIRE_SECS,
+    redis_long_blocking_read_keepalive_options,
 )
 from redis_benchmarks_specification.__common__.github import (
     check_github_available_and_actionable,
@@ -220,6 +221,7 @@ def main():
             health_check_interval=REDIS_HEALTH_CHECK_INTERVAL,
             socket_connect_timeout=REDIS_SOCKET_TIMEOUT,
             socket_keepalive=True,
+            socket_keepalive_options=redis_long_blocking_read_keepalive_options(),
         )
         conn.ping()
     except redis.exceptions.ConnectionError as e:

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -241,7 +241,8 @@ def redis_long_blocking_read_keepalive_options():
     import socket
 
     if not all(
-        hasattr(socket, attr) for attr in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
+        hasattr(socket, attr)
+        for attr in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
     ):
         return {}
     return {

--- a/redis_benchmarks_specification/__common__/env.py
+++ b/redis_benchmarks_specification/__common__/env.py
@@ -223,6 +223,34 @@ REDIS_BINS_EXPIRE_SECS = parse_int(
     os.getenv("REDIS_BINS_EXPIRE_SECS"), 24 * 7 * 60 * 60, "REDIS_BINS_EXPIRE_SECS"
 )
 
+
+def redis_long_blocking_read_keepalive_options():
+    """TCP keepalive tuning for redis connections that issue a long/indefinitely
+    blocking read (e.g. XREADGROUP ... BLOCK 0). `socket_keepalive=True` alone
+    only enables the OS's default keepalive timers -- on Linux that means no
+    probe is sent for 2 hours (`net.ipv4.tcp_keepalive_time`), which is far
+    longer than many cloud NAT/security-group/LB idle-connection reap windows
+    (commonly single-digit minutes). Without an earlier probe, the connection
+    can be silently killed by an intermediate hop while genuinely idle inside
+    the blocking wait, surfacing as `ConnectionError: Connection closed by
+    server` on the *next* read attempt with no warning beforehand. Returns {}
+    on platforms without the Linux-specific TCP_KEEPIDLE/KEEPINTVL/KEEPCNT
+    socket options (e.g. local dev on macOS) -- redis-py accepts an empty
+    dict, so callers can pass this straight through unconditionally.
+    """
+    import socket
+
+    if not all(
+        hasattr(socket, attr) for attr in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
+    ):
+        return {}
+    return {
+        socket.TCP_KEEPIDLE: 30,  # start probing after 30s idle
+        socket.TCP_KEEPINTVL: 10,  # then every 10s
+        socket.TCP_KEEPCNT: 6,  # give up (and let redis-py surface the error) after 6 misses
+    }
+
+
 _TRUE_STRINGS = ("1", "true", "t", "yes", "y", "on")
 _FALSE_STRINGS = ("0", "false", "f", "no", "n", "off")
 

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -37,6 +37,7 @@ from redis_benchmarks_specification.__common__.env import (
     REDIS_HEALTH_CHECK_INTERVAL,
     REDIS_SOCKET_TIMEOUT,
     REDIS_BINS_EXPIRE_SECS,
+    redis_long_blocking_read_keepalive_options,
 )
 from redis_benchmarks_specification.__common__.github import (
     check_github_available_and_actionable,
@@ -746,6 +747,7 @@ def main():
             health_check_interval=REDIS_HEALTH_CHECK_INTERVAL,
             socket_connect_timeout=REDIS_SOCKET_TIMEOUT,
             socket_keepalive=True,
+            socket_keepalive_options=redis_long_blocking_read_keepalive_options(),
         )
         gh_event_conn.ping()
     except redis.exceptions.ConnectionError as e:

--- a/utils/tests/test_redis_keepalive_options.py
+++ b/utils/tests/test_redis_keepalive_options.py
@@ -1,0 +1,38 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+"""Pure unit test (no docker / no network) for the TCP keepalive tuning applied to
+long/indefinitely-blocking redis connections (e.g. XREADGROUP ... BLOCK 0). Without
+explicit socket_keepalive_options, `socket_keepalive=True` alone only enables the OS
+default keepalive timers (2h on Linux before the first probe) -- far longer than many
+cloud NAT/security-group/LB idle-connection reap windows, which lets an intermediate
+hop silently kill a genuinely-idle blocking-read connection.
+"""
+import socket
+
+from redis_benchmarks_specification.__common__.env import (
+    redis_long_blocking_read_keepalive_options,
+)
+
+
+def test_keepalive_options_present_on_linux():
+    opts = redis_long_blocking_read_keepalive_options()
+    if not all(
+        hasattr(socket, attr) for attr in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
+    ):
+        assert opts == {}
+        return
+    assert opts[socket.TCP_KEEPIDLE] > 0
+    assert opts[socket.TCP_KEEPINTVL] > 0
+    assert opts[socket.TCP_KEEPCNT] > 0
+    # idle-before-first-probe must be well under typical cloud idle-reap windows
+    # (AWS NAT gateway default ~350s) so probes refresh any middlebox connection
+    # tracking state before it expires.
+    assert opts[socket.TCP_KEEPIDLE] < 120
+
+
+def test_keepalive_options_returns_dict_type():
+    # redis-py's socket_keepalive_options must be a plain dict (or {}), never None.
+    assert isinstance(redis_long_blocking_read_keepalive_options(), dict)

--- a/utils/tests/test_redis_keepalive_options.py
+++ b/utils/tests/test_redis_keepalive_options.py
@@ -10,17 +10,24 @@ default keepalive timers (2h on Linux before the first probe) -- far longer than
 cloud NAT/security-group/LB idle-connection reap windows, which lets an intermediate
 hop silently kill a genuinely-idle blocking-read connection.
 """
+import ast
+import inspect
 import socket
 
 from redis_benchmarks_specification.__common__.env import (
     redis_long_blocking_read_keepalive_options,
+)
+from redis_benchmarks_specification.__builder__ import builder as builder_module
+from redis_benchmarks_specification.__self_contained_coordinator__ import (
+    self_contained_coordinator as coordinator_module,
 )
 
 
 def test_keepalive_options_present_on_linux():
     opts = redis_long_blocking_read_keepalive_options()
     if not all(
-        hasattr(socket, attr) for attr in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
+        hasattr(socket, attr)
+        for attr in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
     ):
         assert opts == {}
         return
@@ -36,3 +43,41 @@ def test_keepalive_options_present_on_linux():
 def test_keepalive_options_returns_dict_type():
     # redis-py's socket_keepalive_options must be a plain dict (or {}), never None.
     assert isinstance(redis_long_blocking_read_keepalive_options(), dict)
+
+
+def _redis_strictredis_kwargs_in(func):
+    """Parse `func`'s source and return the keyword-argument names passed to every
+    top-level `redis.StrictRedis(...)` call inside it -- an execution-free regression
+    guard. `main()` itself isn't practically unit-testable (argparse, an infinite
+    consumer loop, Docker), so this catches "the kwarg got dropped from the call
+    site" at the source level instead of only in production."""
+    tree = ast.parse(inspect.getsource(func))
+    return [
+        {kw.arg for kw in node.keywords if kw.arg is not None}
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "StrictRedis"
+    ]
+
+
+def test_builder_main_wires_keepalive_options_into_blocking_connection():
+    calls = _redis_strictredis_kwargs_in(builder_module.main)
+    assert calls, "no redis.StrictRedis(...) call found in builder.main()"
+    assert any("socket_keepalive_options" in kwargs for kwargs in calls), (
+        "builder.main()'s event-stream connection must pass "
+        "socket_keepalive_options=redis_long_blocking_read_keepalive_options() -- "
+        "without it, a genuinely idle BLOCK 0 read can be silently killed by an "
+        "intermediate NAT/LB hop"
+    )
+
+
+def test_coordinator_main_wires_keepalive_options_into_blocking_connection():
+    calls = _redis_strictredis_kwargs_in(coordinator_module.main)
+    assert (
+        calls
+    ), "no redis.StrictRedis(...) call found in self_contained_coordinator.main()"
+    assert any("socket_keepalive_options" in kwargs for kwargs in calls), (
+        "self_contained_coordinator.main()'s benchmark-stream connection must pass "
+        "socket_keepalive_options=redis_long_blocking_read_keepalive_options()"
+    )

--- a/utils/tests/test_redis_keepalive_options.py
+++ b/utils/tests/test_redis_keepalive_options.py
@@ -45,6 +45,28 @@ def test_keepalive_options_returns_dict_type():
     assert isinstance(redis_long_blocking_read_keepalive_options(), dict)
 
 
+def test_keepalive_options_empty_on_platforms_missing_the_socket_constants():
+    """The Linux-only fallback branch (e.g. macOS local dev) isn't reachable on this
+    CI's Linux runners without forcing it -- delete one of the three required attrs
+    from a throwaway `socket`-like object via monkeypatch and confirm {} comes back
+    rather than a KeyError/AttributeError from a partially-built options dict."""
+    import types
+
+    import redis_benchmarks_specification.__common__.env as env_module
+
+    fake_socket = types.SimpleNamespace(TCP_KEEPIDLE=1, TCP_KEEPINTVL=2)
+    # TCP_KEEPCNT deliberately absent, mirroring a non-Linux platform.
+
+    import sys
+
+    real_socket = sys.modules["socket"]
+    sys.modules["socket"] = fake_socket
+    try:
+        assert env_module.redis_long_blocking_read_keepalive_options() == {}
+    finally:
+        sys.modules["socket"] = real_socket
+
+
 def _redis_strictredis_kwargs_by_target_in(func):
     """Parse `func`'s source and return {assigned-variable-name: kwarg-names} for every
     top-level `<var> = redis.StrictRedis(...)` assignment inside it -- an execution-free

--- a/utils/tests/test_redis_keepalive_options.py
+++ b/utils/tests/test_redis_keepalive_options.py
@@ -13,7 +13,10 @@ hop silently kill a genuinely-idle blocking-read connection.
 import ast
 import inspect
 import socket
+import sys
+import types
 
+import redis_benchmarks_specification.__common__.env as env_module
 from redis_benchmarks_specification.__common__.env import (
     redis_long_blocking_read_keepalive_options,
 )
@@ -45,26 +48,32 @@ def test_keepalive_options_returns_dict_type():
     assert isinstance(redis_long_blocking_read_keepalive_options(), dict)
 
 
-def test_keepalive_options_empty_on_platforms_missing_the_socket_constants():
+def test_keepalive_options_empty_on_platforms_missing_the_socket_constants(
+    monkeypatch,
+):
     """The Linux-only fallback branch (e.g. macOS local dev) isn't reachable on this
     CI's Linux runners without forcing it -- delete one of the three required attrs
-    from a throwaway `socket`-like object via monkeypatch and confirm {} comes back
-    rather than a KeyError/AttributeError from a partially-built options dict."""
-    import types
-
-    import redis_benchmarks_specification.__common__.env as env_module
-
+    from a throwaway `socket`-like object and confirm {} comes back rather than a
+    KeyError/AttributeError from a partially-built options dict."""
     fake_socket = types.SimpleNamespace(TCP_KEEPIDLE=1, TCP_KEEPINTVL=2)
     # TCP_KEEPCNT deliberately absent, mirroring a non-Linux platform.
+    monkeypatch.setitem(sys.modules, "socket", fake_socket)
+    assert env_module.redis_long_blocking_read_keepalive_options() == {}
 
-    import sys
 
-    real_socket = sys.modules["socket"]
-    sys.modules["socket"] = fake_socket
-    try:
-        assert env_module.redis_long_blocking_read_keepalive_options() == {}
-    finally:
-        sys.modules["socket"] = real_socket
+def test_keepalive_options_populated_when_all_socket_constants_present(monkeypatch):
+    """The populated-dict branch is otherwise only exercised incidentally (this CI's
+    runners happen to be Linux) -- force it explicitly, mirroring the test above, so
+    it's deterministic regardless of the host OS running the suite."""
+    fake_socket = types.SimpleNamespace(
+        TCP_KEEPIDLE="idle", TCP_KEEPINTVL="intvl", TCP_KEEPCNT="cnt"
+    )
+    monkeypatch.setitem(sys.modules, "socket", fake_socket)
+    assert env_module.redis_long_blocking_read_keepalive_options() == {
+        "idle": 30,
+        "intvl": 10,
+        "cnt": 6,
+    }
 
 
 def _redis_strictredis_kwargs_by_target_in(func):

--- a/utils/tests/test_redis_keepalive_options.py
+++ b/utils/tests/test_redis_keepalive_options.py
@@ -45,39 +45,61 @@ def test_keepalive_options_returns_dict_type():
     assert isinstance(redis_long_blocking_read_keepalive_options(), dict)
 
 
-def _redis_strictredis_kwargs_in(func):
-    """Parse `func`'s source and return the keyword-argument names passed to every
-    top-level `redis.StrictRedis(...)` call inside it -- an execution-free regression
-    guard. `main()` itself isn't practically unit-testable (argparse, an infinite
-    consumer loop, Docker), so this catches "the kwarg got dropped from the call
-    site" at the source level instead of only in production."""
+def _redis_strictredis_kwargs_by_target_in(func):
+    """Parse `func`'s source and return {assigned-variable-name: kwarg-names} for every
+    top-level `<var> = redis.StrictRedis(...)` assignment inside it -- an execution-free
+    regression guard. `main()` itself isn't practically unit-testable (argparse, an
+    infinite consumer loop, Docker), so this catches "the kwarg got dropped from the
+    call site" at the source level instead of only in production.
+
+    Keyed by assignment target rather than collapsed into "any call passes it": both
+    builder.main() and self_contained_coordinator.main() construct MORE than one
+    redis.StrictRedis client (a blocking event-stream/benchmark-stream consumer, plus
+    e.g. a datasink connection) -- an `any(...)` check across every call in the function
+    would still pass if the kwarg landed on the wrong one, missing exactly the drop this
+    guard exists to catch on the connection it's actually meant to protect."""
     tree = ast.parse(inspect.getsource(func))
-    return [
-        {kw.arg for kw in node.keywords if kw.arg is not None}
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "StrictRedis"
-    ]
+    by_target = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "StrictRedis"
+        ):
+            by_target[node.targets[0].id] = {
+                kw.arg for kw in node.value.keywords if kw.arg is not None
+            }
+    return by_target
 
 
-def test_builder_main_wires_keepalive_options_into_blocking_connection():
-    calls = _redis_strictredis_kwargs_in(builder_module.main)
-    assert calls, "no redis.StrictRedis(...) call found in builder.main()"
-    assert any("socket_keepalive_options" in kwargs for kwargs in calls), (
-        "builder.main()'s event-stream connection must pass "
+def _assert_blocking_connection_has_keepalive(by_target, var_name, where):
+    assert (
+        by_target
+    ), "no `<var> = redis.StrictRedis(...)` assignment found in {}".format(where)
+    assert var_name in by_target, (
+        "{} no longer assigns its blocking connection to `{}` (found: {}) -- update "
+        "this test to the new variable name, and verify the kwarg is still present "
+        "before doing so".format(where, var_name, sorted(by_target))
+    )
+    assert "socket_keepalive_options" in by_target[var_name], (
+        "{}'s `{}` (the long-blocking-read connection) must pass "
         "socket_keepalive_options=redis_long_blocking_read_keepalive_options() -- "
         "without it, a genuinely idle BLOCK 0 read can be silently killed by an "
-        "intermediate NAT/LB hop"
+        "intermediate NAT/LB hop. Other redis.StrictRedis(...) connections in {} "
+        "having it is not sufficient.".format(where, var_name, where)
     )
 
 
+def test_builder_main_wires_keepalive_options_into_blocking_connection():
+    by_target = _redis_strictredis_kwargs_by_target_in(builder_module.main)
+    _assert_blocking_connection_has_keepalive(by_target, "conn", "builder.main()")
+
+
 def test_coordinator_main_wires_keepalive_options_into_blocking_connection():
-    calls = _redis_strictredis_kwargs_in(coordinator_module.main)
-    assert (
-        calls
-    ), "no redis.StrictRedis(...) call found in self_contained_coordinator.main()"
-    assert any("socket_keepalive_options" in kwargs for kwargs in calls), (
-        "self_contained_coordinator.main()'s benchmark-stream connection must pass "
-        "socket_keepalive_options=redis_long_blocking_read_keepalive_options()"
+    by_target = _redis_strictredis_kwargs_by_target_in(coordinator_module.main)
+    _assert_blocking_connection_has_keepalive(
+        by_target, "gh_event_conn", "self_contained_coordinator.main()"
     )


### PR DESCRIPTION
## Summary

`socket_keepalive=True` alone only enables the OS's default keepalive timers — on
Linux that means no probe is sent for 2 hours (`net.ipv4.tcp_keepalive_time`),
far longer than many cloud NAT/security-group/LB idle-connection reap windows
(commonly single-digit minutes — e.g. AWS NAT gateway's default is ~350s).
Without an earlier probe, a connection sitting inside an indefinitely-blocking
`XREADGROUP ... BLOCK 0` read can be silently killed by an intermediate hop
while genuinely idle, surfacing as `ConnectionError: Connection closed by
server` on the *next* read attempt with no warning beforehand. 30s idle /
10s interval / 6 probes keeps every probe well under that ~350s window so it
refreshes any middlebox connection-tracking state before it expires.

Reproduced against the builder's event-stream connection on 3 independent
fresh-process attempts.

## Changes

- New `redis_long_blocking_read_keepalive_options()` helper in `__common__/env.py`:
  returns `{TCP_KEEPIDLE: 30, TCP_KEEPINTVL: 10, TCP_KEEPCNT: 6}` on platforms
  that support the Linux-specific socket options, `{}` otherwise (e.g. macOS
  local dev — redis-py accepts an empty dict, so callers can pass this straight
  through unconditionally).
- Wired into the two connections that issue long-blocking reads: the builder's
  event-stream consumer and the coordinator's benchmark-stream consumer.
- Added a source-level regression test (`test_redis_keepalive_options.py`) that
  parses each `main()`'s AST and asserts the *specific* long-blocking connection
  variable (`conn` / `gh_event_conn`, not just "any `StrictRedis` call in
  `main()`") passes `socket_keepalive_options` — `main()` itself isn't
  practically unit testable (argparse, an infinite consumer loop, Docker), so
  this catches a future dropped-or-misplaced kwarg at the source level instead
  of only in production.

## Test plan

- [x] `pytest utils/tests/test_redis_keepalive_options.py` — 6/6 pass, 100% line+branch coverage on the new helper
- [x] `black --check` / `flake8` clean on touched files
- [x] Full local suite (`pytest utils/tests/`) — no new failures vs. `main`
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow networking change on two long-lived consumer connections plus unit tests; no auth, data, or benchmark logic changes.
> 
> **Overview**
> Adds **`redis_long_blocking_read_keepalive_options()`** so Redis clients that sit in indefinitely blocking stream reads (`XREADGROUP … BLOCK 0`) send TCP keepalive probes on a short interval instead of relying on Linux’s default ~2h idle timer, which is often longer than NAT/LB idle timeouts and can drop the socket without warning.
> 
> On Linux the helper returns **30s idle / 10s interval / 6 probes**; on platforms without `TCP_KEEPIDLE`/`TCP_KEEPINTVL`/`TCP_KEEPCNT` it returns `{}` so redis-py can still be called unconditionally. That helper is passed as **`socket_keepalive_options`** on the builder’s event-stream **`conn`** and the coordinator’s **`gh_event_conn`** (the blocking consumers only—not e.g. the datasink client).
> 
> **`utils/tests/test_redis_keepalive_options.py`** covers the helper’s shape and platform fallback, and AST checks that those two `main()` entrypoints still wire keepalive options into the correct `StrictRedis` variable names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae28bb8488dec783371da1f78025646c8cf2b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
