### PR TITLE
Ship submodule contents in the source archive; add a matched-cpu-budget topology ladder

### DIFF
--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import logging
+import stat
 import tempfile
 import time
 import traceback
@@ -125,7 +126,18 @@ class ZipFileWithPermissions(ZipFile):
 
         attr = member.external_attr >> 16
         if attr != 0:
-            os.chmod(targetpath, attr)
+            if stat.S_ISLNK(attr):
+                # git-style symlink zip encoding: the "file" super() just wrote
+                # contains the link target string, not real content — swap it
+                # for an actual symlink. (Written by the submodule-aware archive
+                # path in builder_schema.py; a plain `git archive`/GitHub zip
+                # never sets this bit today, so this is a no-op for those.)
+                with open(targetpath, "rb") as f:
+                    link_target = f.read().decode("utf-8")
+                os.remove(targetpath)
+                os.symlink(link_target, targetpath)
+            else:
+                os.chmod(targetpath, attr)
         return targetpath
 
 
@@ -434,18 +446,22 @@ def builder_process_stream(
             if b"tests_groups_regexp" in testDetails:
                 tests_groups_regexp = testDetails[b"tests_groups_regexp"].decode()
 
-            deployment_name_regexp = ".*"
-            if b"deployment_name_regexp" in testDetails:
-                deployment_name_regexp = testDetails[b"deployment_name_regexp"].decode()
+            # Hand-rolled byte-key membership-check-then-decode extraction is exactly the
+            # pattern that let override_deployment_regexp silently go missing here before
+            # (present on the incoming stream entry, but never read into a variable) --
+            # route both through the shared, declared-field helper instead.
+            deployment_name_regexp, matched_dnr = read_stream_field(
+                testDetails, "deployment_name_regexp", default=".*"
+            )
+            if matched_dnr is not None:
                 logging.info(
                     f"detected deployment_name_regexp on build stream: {deployment_name_regexp}"
                 )
 
-            override_deployment_regexp = ""
-            if b"override_deployment_regexp" in testDetails:
-                override_deployment_regexp = testDetails[
-                    b"override_deployment_regexp"
-                ].decode()
+            override_deployment_regexp, matched_odr = read_stream_field(
+                testDetails, "override_deployment_regexp", default=""
+            )
+            if matched_odr is not None:
                 logging.info(
                     f"detected override_deployment_regexp on build stream: {override_deployment_regexp}"
                 )

--- a/redis_benchmarks_specification/__builder__/builder.py
+++ b/redis_benchmarks_specification/__builder__/builder.py
@@ -441,6 +441,15 @@ def builder_process_stream(
                     f"detected deployment_name_regexp on build stream: {deployment_name_regexp}"
                 )
 
+            override_deployment_regexp = ""
+            if b"override_deployment_regexp" in testDetails:
+                override_deployment_regexp = testDetails[
+                    b"override_deployment_regexp"
+                ].decode()
+                logging.info(
+                    f"detected override_deployment_regexp on build stream: {override_deployment_regexp}"
+                )
+
             command_regexp = ".*"
             if b"command_regexp" in testDetails:
                 command_regexp = testDetails[b"command_regexp"].decode()
@@ -650,7 +659,7 @@ def builder_process_stream(
                         github_repo,
                         artifact_keys,  # Pass existing artifact keys
                         deployment_name_regexp,
-                        "",  # override_deployment_regexp - not used for reuse case
+                        override_deployment_regexp,
                     )
                     # Add to benchmark stream even when reusing artifacts
                     if result is True:
@@ -810,7 +819,7 @@ def builder_process_stream(
                     github_repo,
                     None,  # existing_artifact_keys - None for new builds
                     deployment_name_regexp,
-                    "",  # override_deployment_regexp - not available at builder level
+                    override_deployment_regexp,
                 )
                 if result is True:
                     arch_specific_stream = get_arch_specific_stream_name(build_arch)

--- a/redis_benchmarks_specification/__cli__/args.py
+++ b/redis_benchmarks_specification/__cli__/args.py
@@ -147,6 +147,18 @@ def spec_cli_args(parser):
     parser.add_argument("--gh_org", type=str, default="redis")
     parser.add_argument("--gh_repo", type=str, default="redis")
     parser.add_argument("--server_name", type=str, default=None)
+    parser.add_argument(
+        "--recurse_submodules",
+        action="store_true",
+        default=False,
+        help="Ship submodule contents (e.g. Dragonfly's helio/) in the source archive. "
+        "Default OFF — a no-op for redis/valkey, whose plain `git archive` path is "
+        "unchanged. When set, checks out the requested commit and runs "
+        "`git submodule update --init --recursive` in the local clone (a disposable "
+        "temp clone unless --redis_repo is also given, in which case that directory "
+        "IS checked out/mutated — never point this at a working dir with local changes "
+        "you care about).",
+    )
     parser.add_argument("--run_image", type=str, default="redis")
     parser.add_argument("--arch", type=str, default="amd64")
     parser.add_argument(

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -581,8 +581,18 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
     conn.ping()
     for rep in range(0, 1):
         for cdict in filtered_hash_commits:
-            # Pass local repository path if using local repo
-            local_repo_path = redisDirPath if args.redis_repo is not None else None
+            # Pass local repository path if using local repo, OR if --recurse_submodules
+            # was requested and we own the clone (cleanUp==True, our own disposable temp
+            # dir from get_repo()) — recurse_submodules needs a real local checkout to
+            # `git submodule update` into, since GitHub's archive endpoint (the no-local-
+            # repo-path fallback) can never include submodule content. If the user passed
+            # both --redis_repo and --recurse_submodules, that directory is used (and
+            # checked out into) too — they opted into the mutation explicitly.
+            local_repo_path = (
+                redisDirPath
+                if (args.redis_repo is not None or (args.recurse_submodules and cleanUp))
+                else None
+            )
 
             (
                 result,
@@ -600,6 +610,7 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                 args.gh_token,
                 None,  # gh_branch
                 local_repo_path,
+                args.recurse_submodules,
             )
             if args.platform:
                 commit_dict["platform"] = args.platform
@@ -630,6 +641,15 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
                 logging.info(f"Targeting specific runner: {args.target_platform}")
             if args.deployment_name_regexp != ".*":
                 commit_dict["deployment_name_regexp"] = args.deployment_name_regexp
+            if getattr(args, "override_deployment_regexp", ""):
+                commit_dict["override_deployment_regexp"] = (
+                    args.override_deployment_regexp
+                )
+                logging.info(
+                    "Overriding deployment topology to: {}".format(
+                        args.override_deployment_regexp
+                    )
+                )
             if args.command_regex != ".*":
                 commit_dict["command_regexp"] = args.command_regex
             if pull_request is not None:

--- a/redis_benchmarks_specification/__cli__/cli.py
+++ b/redis_benchmarks_specification/__cli__/cli.py
@@ -590,7 +590,9 @@ def trigger_tests_cli_command_logic(args, project_name, project_version):
             # checked out into) too — they opted into the mutation explicitly.
             local_repo_path = (
                 redisDirPath
-                if (args.redis_repo is not None or (args.recurse_submodules and cleanUp))
+                if (
+                    args.redis_repo is not None or (args.recurse_submodules and cleanUp)
+                )
                 else None
             )
 

--- a/redis_benchmarks_specification/__common__/builder_schema.py
+++ b/redis_benchmarks_specification/__common__/builder_schema.py
@@ -108,13 +108,21 @@ def get_archive_zip_from_hash(
                 # inside every currently-materialized submodule too, so leftovers
                 # from a tree transition one level down (e.g. inside a nested
                 # submodule like Dragonfly's helio/) can't leak into a later
-                # commit's archive either. Errors if no submodule is initialized
-                # yet (first run on a fresh clone) -- harmless, nothing to clean.
+                # commit's archive either. `foreach` aborts the WHOLE recursive
+                # walk on the first submodule it can't clean (does not continue
+                # to healthy siblings) -- log rather than silently swallow that,
+                # since a swallowed failure here means unlogged stale content can
+                # survive in whichever submodule(s) came after the failing one.
                 repo.git.clean("-ffdx")
                 try:
                     repo.git.submodule("foreach", "--recursive", "git clean -ffdx")
-                except git.GitCommandError:
-                    pass
+                except git.GitCommandError as e:
+                    logging.warning(
+                        "submodule foreach --recursive git clean -ffdx failed "
+                        "(%s); some submodule working directories may not have "
+                        "been cleaned",
+                        e,
+                    )
 
             _clean_worktree_including_submodules()
             repo.git.checkout("--force", git_hash)

--- a/redis_benchmarks_specification/__common__/builder_schema.py
+++ b/redis_benchmarks_specification/__common__/builder_schema.py
@@ -26,6 +26,7 @@ def commit_schema_to_stream(
     gh_repo,
     gh_token=None,
     local_repo_path=None,
+    recurse_submodules=False,
 ):
     """uses to the provided JSON dict of fields and pushes that info to the corresponding stream"""
     fields = fields
@@ -54,6 +55,7 @@ def commit_schema_to_stream(
             gh_token,
             None,  # gh_branch
             local_repo_path,
+            recurse_submodules,
         )
         reply_fields["use_git_timestamp"] = fields["use_git_timestamp"]
         if "git_timestamp_ms" in fields:
@@ -69,13 +71,70 @@ def commit_schema_to_stream(
     return result, reply_fields, error_msg
 
 
-def get_archive_zip_from_hash(gh_org, gh_repo, git_hash, fields, local_repo_path=None):
+def get_archive_zip_from_hash(
+    gh_org, gh_repo, git_hash, fields, local_repo_path=None, recurse_submodules=False
+):
     error_msg = None
     result = False
     binary_value = None
     bin_key = "zipped:source:{}/{}/archive/{}.zip".format(gh_org, gh_repo, git_hash)
 
-    if local_repo_path is not None:
+    if local_repo_path is not None and recurse_submodules:
+        # Submodule-aware path (opt-in, default OFF): `git archive` — and GitHub's own
+        # /archive/{ref}.zip endpoint — both exclude submodule content by design, so a
+        # repo like dragonflydb/dragonfly (helio/ as a submodule) can never build from
+        # the plain archive path below. Instead check out the exact commit in the local
+        # clone, materialize submodules there, and zip the *worktree* file list
+        # (`git ls-files --recurse-submodules`, which walks into every submodule in one
+        # call) rather than using `git archive`. This mutates local_repo_path (checkout +
+        # submodule update) — callers must only pass a disposable/dedicated clone here,
+        # never a developer's own working directory with uncommitted changes.
+        try:
+            logging.info(
+                "Creating submodule-aware ZIP archive from local repository: {} "
+                "(commit {})".format(local_repo_path, git_hash)
+            )
+            repo = git.Repo(local_repo_path)
+            repo.git.checkout("--force", git_hash)
+            repo.git.submodule("update", "--init", "--recursive")
+
+            archive_prefix = "{}-{}/".format(gh_repo, git_hash)
+            tracked_files = repo.git.ls_files("--recurse-submodules").splitlines()
+
+            temp_zip = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+            temp_zip.close()
+            with zipfile.ZipFile(temp_zip.name, "w", zipfile.ZIP_DEFLATED) as zf:
+                for rel_path in tracked_files:
+                    abs_path = os.path.join(local_repo_path, rel_path)
+                    if not os.path.isfile(abs_path):
+                        # submodule gitlink entries / symlinks with no regular file
+                        # target are not archivable content; skip rather than abort.
+                        continue
+                    zf.write(abs_path, arcname=archive_prefix + rel_path)
+
+            with open(temp_zip.name, "rb") as zip_file:
+                binary_value = zip_file.read()
+            os.unlink(temp_zip.name)
+
+            fields["zip_archive_key"] = bin_key
+            fields["zip_archive_len"] = len(binary_value)
+            result = True
+            logging.info(
+                "Successfully created submodule-aware ZIP archive ({} files). "
+                "Size: {} bytes ({:.2f} MB)".format(
+                    len(tracked_files),
+                    len(binary_value),
+                    len(binary_value) / (1024 * 1024),
+                )
+            )
+        except Exception as e:
+            error_msg = (
+                "Error creating submodule-aware ZIP archive from local repository "
+                "{}: {}".format(local_repo_path, str(e))
+            )
+            logging.error(error_msg)
+            result = False
+    elif local_repo_path is not None:
         # Create ZIP archive from local repository
         try:
             logging.info(
@@ -154,6 +213,7 @@ def get_commit_dict_from_sha(
     gh_token=None,
     gh_branch=None,
     local_repo_path=None,
+    recurse_submodules=False,
 ):
     commit = None
     # using an access token - but only if we're not using a local repository
@@ -190,6 +250,7 @@ def get_commit_dict_from_sha(
         git_hash,
         commit_dict,
         local_repo_path,
+        recurse_submodules,
     )
     return result, error_msg, commit_dict, commit, binary_key, binary_value
 

--- a/redis_benchmarks_specification/__common__/builder_schema.py
+++ b/redis_benchmarks_specification/__common__/builder_schema.py
@@ -5,6 +5,7 @@
 #
 import logging
 import os
+import stat
 import tempfile
 import zipfile
 import git
@@ -95,8 +96,23 @@ def get_archive_zip_from_hash(
                 "(commit {})".format(local_repo_path, git_hash)
             )
             repo = git.Repo(local_repo_path)
+            # local_repo_path is reused across every commit in a multi-hash trigger
+            # batch (one clone, checked out+re-checked-out in a loop) — clean any
+            # untracked leftovers from the PREVIOUS commit's checkout (e.g. a
+            # submodule dir left behind by a tree that removed/relocated it) before
+            # moving to this one, so stale content can never leak into this zip.
+            repo.git.clean("-ffdx")
             repo.git.checkout("--force", git_hash)
-            repo.git.submodule("update", "--init", "--recursive")
+            try:
+                repo.git.submodule("update", "--init", "--recursive", "--force")
+            except git.GitCommandError:
+                # A transient failure (e.g. a network blip fetching a nested
+                # submodule) can leave the shared clone's submodule state dirty,
+                # which would otherwise poison every subsequent commit reusing
+                # this same local_repo_path. One clean+retry recovers in place
+                # instead of cascading failures across the rest of the batch.
+                repo.git.clean("-ffdx")
+                repo.git.submodule("update", "--init", "--recursive", "--force")
 
             archive_prefix = "{}-{}/".format(gh_repo, git_hash)
             tracked_files = repo.git.ls_files("--recurse-submodules").splitlines()
@@ -106,10 +122,29 @@ def get_archive_zip_from_hash(
             with zipfile.ZipFile(temp_zip.name, "w", zipfile.ZIP_DEFLATED) as zf:
                 for rel_path in tracked_files:
                     abs_path = os.path.join(local_repo_path, rel_path)
-                    if not os.path.isfile(abs_path):
-                        # submodule gitlink entries / symlinks with no regular file
-                        # target are not archivable content; skip rather than abort.
+                    if os.path.islink(abs_path):
+                        # os.path.isfile()/zf.write() both follow symlinks, which
+                        # would either silently drop a dangling tracked symlink or
+                        # silently replace it with its target's content under the
+                        # link's name. Encode it the way git's own archive formats
+                        # do instead: entry content is the link target string, and
+                        # the S_IFLNK bit lives in external_attr for the extractor
+                        # to reconstruct a real symlink from.
+                        link_target = os.readlink(abs_path)
+                        zi = zipfile.ZipInfo(archive_prefix + rel_path)
+                        zi.external_attr = (stat.S_IFLNK | 0o777) << 16
+                        zf.writestr(zi, link_target)
                         continue
+                    if not os.path.isfile(abs_path):
+                        # A tracked path with no file/symlink content on disk after
+                        # checkout + submodule update means the worktree isn't what
+                        # `git ls-files` claims it is — the whole point of this path
+                        # is exact tree reconstruction, so fail loudly (caught below)
+                        # rather than silently ship an incomplete archive as success.
+                        raise RuntimeError(
+                            "tracked path {!r} has no file/symlink content on disk "
+                            "after checkout + submodule update".format(rel_path)
+                        )
                     zf.write(abs_path, arcname=archive_prefix + rel_path)
 
             with open(temp_zip.name, "rb") as zip_file:

--- a/redis_benchmarks_specification/__common__/builder_schema.py
+++ b/redis_benchmarks_specification/__common__/builder_schema.py
@@ -96,12 +96,27 @@ def get_archive_zip_from_hash(
                 "(commit {})".format(local_repo_path, git_hash)
             )
             repo = git.Repo(local_repo_path)
-            # local_repo_path is reused across every commit in a multi-hash trigger
-            # batch (one clone, checked out+re-checked-out in a loop) — clean any
-            # untracked leftovers from the PREVIOUS commit's checkout (e.g. a
-            # submodule dir left behind by a tree that removed/relocated it) before
-            # moving to this one, so stale content can never leak into this zip.
-            repo.git.clean("-ffdx")
+
+            def _clean_worktree_including_submodules():
+                # local_repo_path is reused across every commit in a multi-hash
+                # trigger batch (one clone, checked out+re-checked-out in a loop).
+                # Plain `git clean` only reaches the superproject's own working
+                # tree -- it does NOT descend into an already-initialized
+                # submodule's working directory (verified: an untracked file left
+                # inside a live submodule survives `git clean -ffdx` at the parent
+                # level). `submodule foreach --recursive` runs the same clean
+                # inside every currently-materialized submodule too, so leftovers
+                # from a tree transition one level down (e.g. inside a nested
+                # submodule like Dragonfly's helio/) can't leak into a later
+                # commit's archive either. Errors if no submodule is initialized
+                # yet (first run on a fresh clone) -- harmless, nothing to clean.
+                repo.git.clean("-ffdx")
+                try:
+                    repo.git.submodule("foreach", "--recursive", "git clean -ffdx")
+                except git.GitCommandError:
+                    pass
+
+            _clean_worktree_including_submodules()
             repo.git.checkout("--force", git_hash)
             try:
                 repo.git.submodule("update", "--init", "--recursive", "--force")
@@ -111,7 +126,7 @@ def get_archive_zip_from_hash(
                 # which would otherwise poison every subsequent commit reusing
                 # this same local_repo_path. One clean+retry recovers in place
                 # instead of cascading failures across the rest of the batch.
-                repo.git.clean("-ffdx")
+                _clean_worktree_including_submodules()
                 repo.git.submodule("update", "--init", "--recursive", "--force")
 
             archive_prefix = "{}-{}/".format(gh_repo, git_hash)
@@ -119,37 +134,43 @@ def get_archive_zip_from_hash(
 
             temp_zip = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
             temp_zip.close()
-            with zipfile.ZipFile(temp_zip.name, "w", zipfile.ZIP_DEFLATED) as zf:
-                for rel_path in tracked_files:
-                    abs_path = os.path.join(local_repo_path, rel_path)
-                    if os.path.islink(abs_path):
-                        # os.path.isfile()/zf.write() both follow symlinks, which
-                        # would either silently drop a dangling tracked symlink or
-                        # silently replace it with its target's content under the
-                        # link's name. Encode it the way git's own archive formats
-                        # do instead: entry content is the link target string, and
-                        # the S_IFLNK bit lives in external_attr for the extractor
-                        # to reconstruct a real symlink from.
-                        link_target = os.readlink(abs_path)
-                        zi = zipfile.ZipInfo(archive_prefix + rel_path)
-                        zi.external_attr = (stat.S_IFLNK | 0o777) << 16
-                        zf.writestr(zi, link_target)
-                        continue
-                    if not os.path.isfile(abs_path):
-                        # A tracked path with no file/symlink content on disk after
-                        # checkout + submodule update means the worktree isn't what
-                        # `git ls-files` claims it is — the whole point of this path
-                        # is exact tree reconstruction, so fail loudly (caught below)
-                        # rather than silently ship an incomplete archive as success.
-                        raise RuntimeError(
-                            "tracked path {!r} has no file/symlink content on disk "
-                            "after checkout + submodule update".format(rel_path)
-                        )
-                    zf.write(abs_path, arcname=archive_prefix + rel_path)
+            try:
+                with zipfile.ZipFile(temp_zip.name, "w", zipfile.ZIP_DEFLATED) as zf:
+                    for rel_path in tracked_files:
+                        abs_path = os.path.join(local_repo_path, rel_path)
+                        if os.path.islink(abs_path):
+                            # os.path.isfile()/zf.write() both follow symlinks,
+                            # which would either silently drop a dangling tracked
+                            # symlink or silently replace it with its target's
+                            # content under the link's name. Encode it the way
+                            # git's own archive formats do instead: entry content
+                            # is the link target string, and the S_IFLNK bit lives
+                            # in external_attr for the extractor to reconstruct a
+                            # real symlink from.
+                            link_target = os.readlink(abs_path)
+                            zi = zipfile.ZipInfo(archive_prefix + rel_path)
+                            zi.external_attr = (stat.S_IFLNK | 0o777) << 16
+                            zf.writestr(zi, link_target)
+                            continue
+                        if not os.path.isfile(abs_path):
+                            # A tracked path with no file/symlink content on disk
+                            # after checkout + submodule update means the worktree
+                            # isn't what `git ls-files` claims it is -- the whole
+                            # point of this path is exact tree reconstruction, so
+                            # fail loudly (caught below) rather than silently ship
+                            # an incomplete archive as success.
+                            raise RuntimeError(
+                                "tracked path {!r} has no file/symlink content on "
+                                "disk after checkout + submodule update".format(
+                                    rel_path
+                                )
+                            )
+                        zf.write(abs_path, arcname=archive_prefix + rel_path)
 
-            with open(temp_zip.name, "rb") as zip_file:
-                binary_value = zip_file.read()
-            os.unlink(temp_zip.name)
+                with open(temp_zip.name, "rb") as zip_file:
+                    binary_value = zip_file.read()
+            finally:
+                os.unlink(temp_zip.name)
 
             fields["zip_archive_key"] = bin_key
             fields["zip_archive_len"] = len(binary_value)

--- a/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/docker.py
@@ -66,12 +66,15 @@ def generate_standalone_dragonfly_server_args(
     proactor_threads = "1"
     if redis_arguments != "":
         toks = redis_arguments.split(" ")
+        parsed = False
         for i, tok in enumerate(toks):
             if tok.startswith("--proactor_threads="):
                 proactor_threads = tok.split("=", 1)[1]
+                parsed = True
             elif tok == "--proactor_threads" and i + 1 < len(toks):
                 proactor_threads = toks[i + 1]
-        if "proactor_threads" in redis_arguments and proactor_threads == "1":
+                parsed = True
+        if "proactor_threads" in redis_arguments and not parsed:
             logging.warning(
                 "redis_arguments contains 'proactor_threads' but no value was parsed; "
                 "defaulting Dragonfly to --proactor_threads=1. redis_arguments=%r",

--- a/redis_benchmarks_specification/setups/topologies/topologies.yml
+++ b/redis_benchmarks_specification/setups/topologies/topologies.yml
@@ -97,6 +97,103 @@ spec:
       requests:
         cpus: "65"
         memory: "10g"
+
+  # Dragonfly proactor-thread ladder — cpus budget matches the oss-standalone-NN-io-threads
+  # rows above 1:1 (same core count at each rung) so a multi-core scaling comparison is on
+  # equal hardware, not equal flag values (Redis's N io-threads run alongside the always-on
+  # main thread, so its cpus is N+1; Dragonfly's N proactor threads have no separate main
+  # thread, so pinning it to the same N+1 cpus hands it one spare core too, mirroring the
+  # headroom convention above rather than shorting it a core). Requires --server_name
+  # dragonfly at trigger time; see competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md for
+  # what still blocks an actual fleet build (INTERNAL — never reference in public output).
+  - name: dragonfly-01-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 1
+    resources:
+      requests:
+        cpus: "1"
+        memory: "10g"
+
+  - name: dragonfly-02-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 2
+    resources:
+      requests:
+        cpus: "3"
+        memory: "10g"
+
+  - name: dragonfly-04-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 4
+    resources:
+      requests:
+        cpus: "5"
+        memory: "10g"
+
+  - name: dragonfly-08-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 8
+    resources:
+      requests:
+        cpus: "9"
+        memory: "10g"
+
+  - name: dragonfly-12-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 12
+    resources:
+      requests:
+        cpus: "13"
+        memory: "10g"
+
+  - name: dragonfly-16-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 16
+    resources:
+      requests:
+        cpus: "17"
+        memory: "10g"
+
+  - name: dragonfly-32-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 32
+    resources:
+      requests:
+        cpus: "33"
+        memory: "10g"
+
+  - name: dragonfly-64-proactor-threads
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+    redis_arguments: --proactor_threads 64
+    resources:
+      requests:
+        cpus: "65"
+        memory: "10g"
+
   - name: oss-standalone-01-replicas
     type: oss-standalone
     redis_topology:

--- a/redis_benchmarks_specification/setups/topologies/topologies.yml
+++ b/redis_benchmarks_specification/setups/topologies/topologies.yml
@@ -103,9 +103,18 @@ spec:
   # equal hardware, not equal flag values (Redis's N io-threads run alongside the always-on
   # main thread, so its cpus is N+1; Dragonfly's N proactor threads have no separate main
   # thread, so pinning it to the same N+1 cpus hands it one spare core too, mirroring the
-  # headroom convention above rather than shorting it a core). Requires --server_name
-  # dragonfly at trigger time; see competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md for
-  # what still blocks an actual fleet build (INTERNAL — never reference in public output).
+  # headroom convention above rather than shorting it a core — a deliberately generous
+  # choice, not a proven-neutral one: it's the simplest reproducible rule available without
+  # asserting more than is known about Dragonfly's other background/fiber-scheduler threads).
+  # EXCEPTION — the 01 rung: there is no oss-standalone-01-io-threads entry (the io-threads
+  # ladder above starts at 02), so dragonfly-01-proactor-threads has no N+1 counterpart to
+  # mirror and is instead pinned to cpus=1 (=N, not N+1), matching the single-threaded base
+  # `oss-standalone` entry below the io-threads ladder. It is therefore the one strict,
+  # ungenerous floor/control rung in this ladder, not part of the N+1 pattern used by every
+  # other rung — use it to sanity-check the rest of the ladder for systematic bias.
+  # Requires --server_name dragonfly at trigger time; see
+  # competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md for what still blocks an actual
+  # fleet build (INTERNAL — never reference in public output).
   - name: dragonfly-01-proactor-threads
     type: oss-standalone
     redis_topology:

--- a/redis_benchmarks_specification/setups/topologies/topologies.yml
+++ b/redis_benchmarks_specification/setups/topologies/topologies.yml
@@ -112,9 +112,7 @@ spec:
   # `oss-standalone` entry below the io-threads ladder. It is therefore the one strict,
   # ungenerous floor/control rung in this ladder, not part of the N+1 pattern used by every
   # other rung — use it to sanity-check the rest of the ladder for systematic bias.
-  # Requires --server_name dragonfly at trigger time; see
-  # competitive-tracking/dragonfly/PHASE-B-ENABLEMENT.md for what still blocks an actual
-  # fleet build (INTERNAL — never reference in public output).
+  # Requires --server_name dragonfly at trigger time.
   - name: dragonfly-01-proactor-threads
     type: oss-standalone
     redis_topology:

--- a/utils/tests/test_archive_submodules.py
+++ b/utils/tests/test_archive_submodules.py
@@ -324,6 +324,92 @@ def test_recurse_submodules_broken_submodule_fails_loudly(tmp_path, monkeypatch)
     assert binary_value is None
 
 
+def test_recurse_submodules_foreach_clean_failure_is_logged_not_swallowed(
+    tmp_path, monkeypatch, caplog
+):
+    """`git submodule foreach --recursive` aborts its whole walk (and can leave
+    healthy siblings uncleaned) on the first submodule it can't reach -- that
+    failure must be logged, not silently swallowed by a bare except/pass. Corrupt
+    `.gitmodules` between two calls on the same reused clone so the pre-checkout
+    clean's `foreach` genuinely fails, and assert the warning fires."""
+    import logging
+
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    # First call materializes the submodule normally.
+    result1 = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+    assert result1[0] is True
+
+    # Corrupt the tracked .gitmodules file's on-disk content (not committed) so
+    # `submodule foreach` fails to even parse it on the next call's pre-checkout
+    # clean. `git clean -ffdx` (untracked-only) won't touch this, since .gitmodules
+    # is a tracked file being locally modified, not an untracked leftover.
+    gitmodules_path = os.path.join(parent_dir, ".gitmodules")
+    with open(gitmodules_path, "a") as f:
+        f.write("this is not valid git-config syntax [[[\n")
+
+    with caplog.at_level(logging.WARNING):
+        result2 = get_archive_zip_from_hash(
+            "testorg",
+            "testrepo",
+            head,
+            {},
+            local_repo_path=parent_dir,
+            recurse_submodules=True,
+        )
+
+    assert any(
+        "submodule foreach" in rec.message and "failed" in rec.message
+        for rec in caplog.records
+    ), "expected a logged warning naming the failed `submodule foreach` clean, got: {}".format(
+        [rec.message for rec in caplog.records]
+    )
+    # The subsequent `checkout --force` restores .gitmodules from the committed
+    # blob, so the call still completes successfully despite the mid-way warning --
+    # this is a diagnostic log, not a fatal error.
+    assert result2[0] is True
+
+
+def test_recurse_submodules_missing_tracked_content_fails_loudly(tmp_path, monkeypatch):
+    """A tracked path that `git ls-files` claims exists but has no file/symlink
+    content on disk after checkout + submodule update must fail the whole call
+    loudly (result=False, error_msg naming the path) rather than silently produce
+    an incomplete archive while still reporting success."""
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    real_isfile = os.path.isfile
+
+    def fake_isfile(path):
+        if isinstance(path, str) and path.endswith("top_file.txt"):
+            return False
+        return real_isfile(path)
+
+    monkeypatch.setattr("os.path.isfile", fake_isfile)
+
+    result, bin_key, binary_value, error_msg = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+
+    assert result is False
+    assert error_msg is not None
+    assert "top_file.txt" in error_msg
+    assert binary_value is None
+
+
 def test_recurse_submodules_tracked_symlink_preserved(tmp_path, monkeypatch):
     """A tracked symlink must round-trip through the zip as a symlink (git-style
     encoding: content = link target, external_attr carries S_IFLNK) -- not be silently

--- a/utils/tests/test_archive_submodules.py
+++ b/utils/tests/test_archive_submodules.py
@@ -64,7 +64,15 @@ def _make_fixture(tmp_path):
     _run(["git", "add", "."], cwd=parent_dir, env=env)
     _run(["git", "commit", "-q", "-m", "top"], cwd=parent_dir, env=env)
     _run(
-        ["git", "-c", "protocol.file.allow=always", "submodule", "add", sub_dir, "subdir"],
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            sub_dir,
+            "subdir",
+        ],
         cwd=parent_dir,
         env=env,
     )
@@ -107,7 +115,9 @@ def test_recurse_submodules_includes_submodule_content(tmp_path, monkeypatch):
     assert prefix + ".gitmodules" in names
     assert (
         prefix + "subdir/sub_file.txt" in names
-    ), "submodule content missing from recurse_submodules=True archive: {}".format(names)
+    ), "submodule content missing from recurse_submodules=True archive: {}".format(
+        names
+    )
 
 
 def test_default_path_excludes_submodule_content(tmp_path, monkeypatch):
@@ -132,7 +142,9 @@ def test_default_path_excludes_submodule_content(tmp_path, monkeypatch):
     assert prefix + "top_file.txt" in names
     assert not any(
         n.endswith("subdir/sub_file.txt") for n in names
-    ), "submodule content leaked into the default (non-recursive) archive: {}".format(names)
+    ), "submodule content leaked into the default (non-recursive) archive: {}".format(
+        names
+    )
 
 
 def test_recurse_submodules_false_explicit_matches_default(tmp_path, monkeypatch):
@@ -151,3 +163,155 @@ def test_recurse_submodules_false_explicit_matches_default(tmp_path, monkeypatch
         recurse_submodules=False,
     )
     assert default_result[2] == explicit_false_result[2]  # identical zip bytes
+
+
+def test_recurse_submodules_reused_clone_reflects_each_commit(tmp_path, monkeypatch):
+    """A single local_repo_path is reused across every commit in a multi-hash trigger
+    batch (one clone, checked out in a loop) -- the second call on the same clone must
+    reflect the SECOND commit's tree, not stale content left behind by the first call's
+    checkout+submodule-update (the gap the missing `git clean` used to leave open)."""
+    parent_dir, head1 = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+    env = dict(os.environ)
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+
+    # Second commit: add a new top-level file, independent of the submodule.
+    with open(os.path.join(parent_dir, "second_file.txt"), "w") as f:
+        f.write("second commit content\n")
+    _run(["git", "add", "second_file.txt"], cwd=parent_dir, env=env)
+    _run(["git", "commit", "-q", "-m", "second"], cwd=parent_dir, env=env)
+    head2 = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=parent_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+    assert head2 != head1
+
+    result1 = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head1,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+    result2 = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head2,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+
+    assert result1[0] is True and result2[0] is True
+
+    names1 = zipfile.ZipFile(io.BytesIO(result1[2])).namelist()
+    names2 = zipfile.ZipFile(io.BytesIO(result2[2])).namelist()
+    prefix1 = "testrepo-{}/".format(head1)
+    prefix2 = "testrepo-{}/".format(head2)
+
+    assert not any(n.endswith("second_file.txt") for n in names1), (
+        "reused clone leaked the SECOND commit's file into the FIRST commit's "
+        "archive: {}".format(names1)
+    )
+    assert prefix2 + "second_file.txt" in names2
+    assert prefix2 + "subdir/sub_file.txt" in names2, (
+        "reused clone lost submodule content when moving to the second "
+        "commit: {}".format(names2)
+    )
+
+
+def test_recurse_submodules_broken_submodule_fails_loudly(tmp_path, monkeypatch):
+    """If `git submodule update --init --recursive` cannot succeed (e.g. the submodule's
+    remote is gone), the call must return result=False with a populated error_msg --
+    never silently produce a zip missing the submodule while still claiming success."""
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    # Delete the submodule's source repo out from under the parent so
+    # `submodule update --init` has nothing to clone/fetch from.
+    import shutil
+
+    shutil.rmtree(str(tmp_path / "sub"))
+
+    # Force a fresh clone of `parent_dir` so the submodule isn't already
+    # materialized on disk from `_make_fixture`'s own `submodule add` step.
+    fresh_parent = str(tmp_path / "parent_fresh")
+    env = dict(os.environ)
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+    _run(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "clone",
+            "-q",
+            parent_dir,
+            fresh_parent,
+        ],
+        cwd=str(tmp_path),
+        env=env,
+    )
+
+    result, bin_key, binary_value, error_msg = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head,
+        {},
+        local_repo_path=fresh_parent,
+        recurse_submodules=True,
+    )
+
+    assert result is False
+    assert error_msg is not None
+    assert binary_value is None
+
+
+def test_recurse_submodules_tracked_symlink_preserved(tmp_path, monkeypatch):
+    """A tracked symlink must round-trip through the zip as a symlink (git-style
+    encoding: content = link target, external_attr carries S_IFLNK) -- not be silently
+    dropped (dangling target) or silently replaced by its target's file content under
+    the link's name (both of which os.path.isfile()/zf.write() would do unguarded)."""
+    import stat
+
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+    env = dict(os.environ)
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+
+    os.symlink("top_file.txt", os.path.join(parent_dir, "top_file_link.txt"))
+    _run(["git", "add", "top_file_link.txt"], cwd=parent_dir, env=env)
+    _run(["git", "commit", "-q", "-m", "add symlink"], cwd=parent_dir, env=env)
+    head_with_link = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=parent_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+
+    result, bin_key, binary_value, error_msg = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head_with_link,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+
+    assert error_msg is None
+    assert result is True
+
+    zf = zipfile.ZipFile(io.BytesIO(binary_value))
+    prefix = "testrepo-{}/".format(head_with_link)
+    info = zf.getinfo(prefix + "top_file_link.txt")
+    assert stat.S_ISLNK(info.external_attr >> 16), (
+        "symlink lost its S_IFLNK bit in the archive -- would extract as a "
+        "regular file containing the literal target path"
+    )
+    assert zf.read(info).decode("utf-8") == "top_file.txt"

--- a/utils/tests/test_archive_submodules.py
+++ b/utils/tests/test_archive_submodules.py
@@ -267,13 +267,12 @@ def test_recurse_submodules_reused_clone_cleans_inside_submodule_too(
     )
     assert result2[0] is True
 
-    names2 = zipfile.ZipFile(io.BytesIO(result2[2])).namelist()
-    assert not any(n.endswith("stale_leftover.txt") for n in names2), (
-        "untracked content left inside an already-initialized submodule leaked "
-        "into a later archive from the same reused clone -- git clean at the "
-        "parent level alone does not reach into submodule working "
-        "directories: {}".format(names2)
-    )
+    # Note: the zip itself is built from `git ls-files --recurse-submodules` (tracked
+    # paths only), so an untracked file can never appear in it regardless of whether
+    # the clean fix works -- the real assertion is that the fix actually removes the
+    # stale file from disk, checked below. (An earlier version of this test also
+    # asserted the file was absent from the zip namelist; that assertion was always
+    # true and never exercised the fix, so it's been dropped as misleading.)
     assert not os.path.exists(
         stale_path
     ), "stale file inside the submodule was not actually removed from disk"

--- a/utils/tests/test_archive_submodules.py
+++ b/utils/tests/test_archive_submodules.py
@@ -1,0 +1,153 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+"""Pure unit tests (no docker / no redis / no network — local git fixtures only) for the
+opt-in --recurse_submodules archive path in builder_schema.get_archive_zip_from_hash().
+
+Context: `git archive` (used by the default local-repo path) and GitHub's own
+/archive/{ref}.zip endpoint (used by the no-local-repo-path fallback) BOTH exclude
+submodule content by design — this is what blocks a Dragonfly build (helio/ is a
+submodule) from ever reaching the builder container. These tests build a throwaway
+parent+submodule git fixture and verify:
+  * default (recurse_submodules=False) behavior is byte-for-byte the old `git archive`
+    path — submodule content absent, exactly as before this change,
+  * recurse_submodules=True includes the submodule's tracked files in the zip,
+  * a genuinely dirty/uninitialized submodule state doesn't silently produce a
+    submodule-less zip while claiming success.
+"""
+import io
+import os
+import subprocess
+import zipfile
+
+from redis_benchmarks_specification.__common__.builder_schema import (
+    get_archive_zip_from_hash,
+)
+
+
+def _run(cmd, cwd, env=None):
+    subprocess.run(cmd, cwd=cwd, check=True, env=env, capture_output=True)
+
+
+def _make_fixture(tmp_path):
+    """Build <tmp_path>/sub (a standalone repo) and <tmp_path>/parent (which embeds
+    `sub` as a submodule at path `subdir`), returning (parent_dir, head_hash).
+
+    Adding a submodule via a local filesystem path requires opting into the file://
+    transport (git blocks it by default since the CVE-2022-39253 hardening) — this is
+    purely a test-fixture concern for a local-path submodule; a real Dragonfly build
+    uses an https:// GitHub URL, which is unaffected either way.
+    """
+    env = dict(os.environ)
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+
+    sub_dir = str(tmp_path / "sub")
+    parent_dir = str(tmp_path / "parent")
+    os.makedirs(sub_dir)
+    os.makedirs(parent_dir)
+
+    _run(["git", "init", "-q"], cwd=sub_dir, env=env)
+    _run(["git", "config", "user.email", "t@t.com"], cwd=sub_dir, env=env)
+    _run(["git", "config", "user.name", "t"], cwd=sub_dir, env=env)
+    with open(os.path.join(sub_dir, "sub_file.txt"), "w") as f:
+        f.write("submodule content\n")
+    _run(["git", "add", "."], cwd=sub_dir, env=env)
+    _run(["git", "commit", "-q", "-m", "sub"], cwd=sub_dir, env=env)
+
+    _run(["git", "init", "-q"], cwd=parent_dir, env=env)
+    _run(["git", "config", "user.email", "t@t.com"], cwd=parent_dir, env=env)
+    _run(["git", "config", "user.name", "t"], cwd=parent_dir, env=env)
+    with open(os.path.join(parent_dir, "top_file.txt"), "w") as f:
+        f.write("top-level content\n")
+    _run(["git", "add", "."], cwd=parent_dir, env=env)
+    _run(["git", "commit", "-q", "-m", "top"], cwd=parent_dir, env=env)
+    _run(
+        ["git", "-c", "protocol.file.allow=always", "submodule", "add", sub_dir, "subdir"],
+        cwd=parent_dir,
+        env=env,
+    )
+    _run(["git", "commit", "-q", "-m", "add submodule"], cwd=parent_dir, env=env)
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=parent_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+    return parent_dir, head
+
+
+def test_recurse_submodules_includes_submodule_content(tmp_path, monkeypatch):
+    parent_dir, head = _make_fixture(tmp_path)
+    # The code under test shells out via GitPython, inheriting this process's env —
+    # setting it here (not in production code) is what lets the fixture's local
+    # file:// submodule resolve; a real https:// Dragonfly checkout needs no such override.
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    result, bin_key, binary_value, error_msg = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+
+    assert error_msg is None
+    assert result is True
+    assert binary_value is not None
+
+    names = zipfile.ZipFile(io.BytesIO(binary_value)).namelist()
+    prefix = "testrepo-{}/".format(head)
+    assert prefix + "top_file.txt" in names
+    assert prefix + ".gitmodules" in names
+    assert (
+        prefix + "subdir/sub_file.txt" in names
+    ), "submodule content missing from recurse_submodules=True archive: {}".format(names)
+
+
+def test_default_path_excludes_submodule_content(tmp_path, monkeypatch):
+    """recurse_submodules defaults to False — must reproduce the pre-existing
+    `git archive` behavior exactly (submodule content absent), so redis/valkey
+    triggers (which never pass this flag) see zero behavior change."""
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    result, bin_key, binary_value, error_msg = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head,
+        {},
+        local_repo_path=parent_dir,
+    )
+
+    assert error_msg is None
+    assert result is True
+    names = zipfile.ZipFile(io.BytesIO(binary_value)).namelist()
+    prefix = "testrepo-{}/".format(head)
+    assert prefix + "top_file.txt" in names
+    assert not any(
+        n.endswith("subdir/sub_file.txt") for n in names
+    ), "submodule content leaked into the default (non-recursive) archive: {}".format(names)
+
+
+def test_recurse_submodules_false_explicit_matches_default(tmp_path, monkeypatch):
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    default_result = get_archive_zip_from_hash(
+        "testorg", "testrepo", head, {}, local_repo_path=parent_dir
+    )
+    explicit_false_result = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=False,
+    )
+    assert default_result[2] == explicit_false_result[2]  # identical zip bytes

--- a/utils/tests/test_archive_submodules.py
+++ b/utils/tests/test_archive_submodules.py
@@ -225,6 +225,60 @@ def test_recurse_submodules_reused_clone_reflects_each_commit(tmp_path, monkeypa
     )
 
 
+def test_recurse_submodules_reused_clone_cleans_inside_submodule_too(
+    tmp_path, monkeypatch
+):
+    """Plain `git clean -ffdx` at the parent level does NOT descend into an
+    already-initialized submodule's own working directory -- an untracked file left
+    inside a live submodule survives it. A reused local_repo_path that materialized a
+    submodule on call 1 must not leak untracked content left inside THAT submodule
+    into call 2's archive; the fix recurses the clean into every submodule via
+    `git submodule foreach --recursive`."""
+    parent_dir, head1 = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+
+    # First call materializes the submodule on disk.
+    result1 = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head1,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+    assert result1[0] is True
+
+    # Simulate leftover untracked content inside the now-materialized submodule's
+    # own working directory (e.g. a build artifact, or a file from a submodule
+    # commit that was checked out earlier in a batch and never got cleaned).
+    stale_path = os.path.join(parent_dir, "subdir", "stale_leftover.txt")
+    with open(stale_path, "w") as f:
+        f.write("should never appear in a later archive\n")
+    assert os.path.exists(stale_path)
+
+    # Second call, same clone, same commit -- must not pick up the stale file.
+    result2 = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head1,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+    assert result2[0] is True
+
+    names2 = zipfile.ZipFile(io.BytesIO(result2[2])).namelist()
+    assert not any(n.endswith("stale_leftover.txt") for n in names2), (
+        "untracked content left inside an already-initialized submodule leaked "
+        "into a later archive from the same reused clone -- git clean at the "
+        "parent level alone does not reach into submodule working "
+        "directories: {}".format(names2)
+    )
+    assert not os.path.exists(
+        stale_path
+    ), "stale file inside the submodule was not actually removed from disk"
+
+
 def test_recurse_submodules_broken_submodule_fails_loudly(tmp_path, monkeypatch):
     """If `git submodule update --init --recursive` cannot succeed (e.g. the submodule's
     remote is gone), the call must return result=False with a populated error_msg --
@@ -315,3 +369,61 @@ def test_recurse_submodules_tracked_symlink_preserved(tmp_path, monkeypatch):
         "regular file containing the literal target path"
     )
     assert zf.read(info).decode("utf-8") == "top_file.txt"
+
+
+def test_recurse_submodules_tracked_symlink_extracts_as_real_symlink(
+    tmp_path, monkeypatch
+):
+    """The archive-side symlink encoding (previous test) is only half the round trip --
+    the builder's own extractor (ZipFileWithPermissions) must turn it back into a real
+    symlink, not leave the placeholder regular file (whose content is the literal link
+    target string) that zipfile.ZipFile.extractall() would otherwise produce."""
+    import stat
+
+    from redis_benchmarks_specification.__builder__.builder import (
+        ZipFileWithPermissions,
+    )
+
+    parent_dir, head = _make_fixture(tmp_path)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+    env = dict(os.environ)
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+
+    os.symlink("top_file.txt", os.path.join(parent_dir, "top_file_link.txt"))
+    _run(["git", "add", "top_file_link.txt"], cwd=parent_dir, env=env)
+    _run(["git", "commit", "-q", "-m", "add symlink"], cwd=parent_dir, env=env)
+    head_with_link = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=parent_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+
+    result, bin_key, binary_value, error_msg = get_archive_zip_from_hash(
+        "testorg",
+        "testrepo",
+        head_with_link,
+        {},
+        local_repo_path=parent_dir,
+        recurse_submodules=True,
+    )
+    assert error_msg is None
+    assert result is True
+
+    extract_dir = str(tmp_path / "extracted")
+    os.makedirs(extract_dir)
+    with ZipFileWithPermissions(io.BytesIO(binary_value)) as zf:
+        zf.extractall(extract_dir)
+
+    prefix = "testrepo-{}/".format(head_with_link)
+    link_path = os.path.join(extract_dir, prefix, "top_file_link.txt")
+
+    assert os.path.islink(link_path), (
+        "extractor left a regular file containing the literal target path instead "
+        "of reconstructing a real symlink -- this is the exact failure mode "
+        "test_recurse_submodules_tracked_symlink_preserved does NOT catch, since "
+        "it only inspects the zip bytes and never extracts them"
+    )
+    assert os.readlink(link_path) == "top_file.txt"

--- a/utils/tests/test_builder.py
+++ b/utils/tests/test_builder.py
@@ -3,6 +3,8 @@
 #  Copyright (c) 2021., Redis Labs
 #  All rights reserved.
 #
+import ast
+import inspect
 import os
 import logging
 from pathlib import Path
@@ -21,6 +23,7 @@ from redis_benchmarks_specification.__builder__.builder import (
     builder_consumer_group_create,
     builder_process_stream,
     build_spec_image_prefetch,
+    generate_benchmark_stream_request,
 )
 from redis_benchmarks_specification.__common__.env import (
     STREAM_KEYNAME_GH_EVENTS_COMMIT,
@@ -457,9 +460,7 @@ def test_xack_uses_caller_supplied_group_not_default():
         assert new_builds_count == 0
 
         # The message must have been ACKed against the arch-specific group.
-        pending_custom = conn.xpending(
-            STREAM_KEYNAME_GH_EVENTS_COMMIT, custom_group
-        )
+        pending_custom = conn.xpending(STREAM_KEYNAME_GH_EVENTS_COMMIT, custom_group)
         # Redis returns a dict with 'pending' count on the python client.
         # If entry was XACKed correctly, pending count is 0.
         pending_count = (
@@ -476,3 +477,56 @@ def test_xack_uses_caller_supplied_group_not_default():
 
     except redis.exceptions.ConnectionError:
         pass
+
+
+def _generate_benchmark_stream_request_calls_in(func):
+    """Parse `func`'s source and, for every call to generate_benchmark_stream_request()
+    inside it, return the AST expression node actually passed at each parameter position
+    (resolving both positional and keyword call styles against the real signature) --
+    an execution-free regression guard for a whole-function-reachability problem: hitting
+    both call sites (the artifact-reuse branch and the fresh-build branch) end-to-end
+    would need a Docker build or a hand-rolled fake-artifact-keys fixture matching an
+    internal sha256 build_signature, neither of which is proportionate to the bug class
+    this guards against (an argument silently hardcoded or transposed at the call site --
+    exactly how override_deployment_regexp went missing here before)."""
+    sig = inspect.signature(generate_benchmark_stream_request)
+    param_names = list(sig.parameters.keys())
+
+    tree = ast.parse(inspect.getsource(func))
+    calls = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "generate_benchmark_stream_request"
+        ):
+            resolved = {}
+            for i, arg in enumerate(node.args):
+                resolved[param_names[i]] = arg
+            for kw in node.keywords:
+                resolved[kw.arg] = kw.value
+            calls.append(resolved)
+    return calls
+
+
+def test_deployment_regexps_wired_correctly_at_both_call_sites():
+    """Regression test for the two-layer override_deployment_regexp bug: the field was
+    computed correctly but never reached generate_benchmark_stream_request() because the
+    builder-side call sites didn't forward it (hardcoded ""). Both call sites (the
+    artifact-reuse branch and the fresh-build branch) must pass the correct LOCAL
+    VARIABLE at the deployment_name_regexp / override_deployment_regexp positions -- not
+    a hardcoded literal, and not the two arguments transposed with each other."""
+    calls = _generate_benchmark_stream_request_calls_in(builder_process_stream)
+    assert len(calls) == 2, (
+        "expected exactly 2 generate_benchmark_stream_request(...) call sites "
+        f"(artifact-reuse + fresh-build) inside builder_process_stream, found {len(calls)}"
+    )
+    for call in calls:
+        for param in ("deployment_name_regexp", "override_deployment_regexp"):
+            assert param in call, f"{param} not passed at this call site at all"
+            expr = call[param]
+            assert isinstance(expr, ast.Name) and expr.id == param, (
+                f"{param} must be forwarded as the local variable of the same name, "
+                f"got {ast.dump(expr)} instead -- this is exactly how the field went "
+                f"missing before (hardcoded '' rather than the real variable)"
+            )

--- a/utils/tests/test_dragonfly_launch_args.py
+++ b/utils/tests/test_dragonfly_launch_args.py
@@ -183,6 +183,33 @@ def test_dragonfly_proactor_override_space_form():
     assert "--proactor_threads=1" not in cmd
 
 
+def test_dragonfly_proactor_explicit_one_does_not_warn(caplog):
+    """Explicitly requesting --proactor_threads 1 is a legitimate value (the
+    single-thread baseline topology), not a parse failure — must not warn."""
+    with caplog.at_level("WARNING"):
+        cmd = generate_standalone_dragonfly_server_args(
+            "/mnt/redis/dragonfly-server",
+            6379,
+            "/mnt/redis/",
+            redis_arguments="--proactor_threads 1",
+        )
+    assert "--proactor_threads=1" in cmd
+    assert "no value was parsed" not in caplog.text
+
+
+def test_dragonfly_proactor_genuinely_unparseable_still_warns(caplog):
+    """A dangling --proactor_threads with no value must still warn and default to 1."""
+    with caplog.at_level("WARNING"):
+        cmd = generate_standalone_dragonfly_server_args(
+            "/mnt/redis/dragonfly-server",
+            6379,
+            "/mnt/redis/",
+            redis_arguments="--proactor_threads",
+        )
+    assert "--proactor_threads=1" in cmd
+    assert "no value was parsed" in caplog.text
+
+
 def test_dragonfly_proactor_defaults_to_one_when_absent():
     cmd = generate_standalone_dragonfly_server_args(
         "/mnt/redis/dragonfly-server",

--- a/utils/tests/test_stream_contract.py
+++ b/utils/tests/test_stream_contract.py
@@ -201,6 +201,26 @@ def test_str_keyed_entries_are_supported():
     assert (value, matched) == (5, "tests_priority_upper_limit")
 
 
+def test_override_deployment_regexp_is_read_from_build_stream_entry():
+    """Regression test for the builder-side half of the override_deployment_regexp bug:
+    the CLI computed and sent the field correctly, but builder.py's extraction was a
+    hand-rolled `if b"x" in testDetails` check that (in one historical version) never ran,
+    so a topology override present on the incoming build stream entry was silently dropped
+    before ever reaching generate_benchmark_stream_request. Assert the declared-field
+    reader picks it up exactly like every other stream field."""
+    entry = {b"override_deployment_regexp": b"oss-standalone-0[12]-replicas"}
+    value, matched = read_stream_field(entry, "override_deployment_regexp", default="")
+    assert (value, matched) == (
+        "oss-standalone-0[12]-replicas",
+        "override_deployment_regexp",
+    )
+
+
+def test_override_deployment_regexp_defaults_to_empty_when_absent():
+    value, matched = read_stream_field({}, "override_deployment_regexp", default="")
+    assert (value, matched) == ("", None)
+
+
 def _build_stream_payload(**overrides):
     """Build a builds-stream payload and return it.
 

--- a/utils/tests/test_topologies.py
+++ b/utils/tests/test_topologies.py
@@ -26,6 +26,37 @@ def test_extract_redis_configuration_from_topology():
     assert "--io-threads 4 --io-threads-do-reads yes" in res
 
 
+def test_extract_dragonfly_configuration_from_topology():
+    topologies_map = get_topologies(
+        "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+    )
+    assert "dragonfly-04-proactor-threads" in topologies_map.keys()
+    res = extract_redis_configuration_from_topology(
+        topologies_map, "dragonfly-04-proactor-threads"
+    )
+    assert res != ""
+    assert "--proactor_threads 4" in res
+
+
+def test_dragonfly_topologies_match_io_threads_cpu_budget():
+    """Each dragonfly-NN-proactor-threads rung must request the same cpus as the
+    matching oss-standalone-NN-io-threads rung, so a scaling comparison runs on
+    equal hardware at every step."""
+    topologies_map = get_topologies(
+        "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+    )
+    for n in ["02", "04", "08", "12", "16", "32", "64"]:
+        redis_cpus = topologies_map[f"oss-standalone-{n}-io-threads"]["resources"][
+            "requests"
+        ]["cpus"]
+        dragonfly_cpus = topologies_map[f"dragonfly-{n}-proactor-threads"][
+            "resources"
+        ]["requests"]["cpus"]
+        assert (
+            redis_cpus == dragonfly_cpus
+        ), f"cpu budget mismatch at {n} threads: redis={redis_cpus} dragonfly={dragonfly_cpus}"
+
+
 def test_extract_replica_count():
     topologies_map = get_topologies(
         "./redis_benchmarks_specification/setups/topologies/topologies.yml"

--- a/utils/tests/test_topologies.py
+++ b/utils/tests/test_topologies.py
@@ -41,7 +41,13 @@ def test_extract_dragonfly_configuration_from_topology():
 def test_dragonfly_topologies_match_io_threads_cpu_budget():
     """Each dragonfly-NN-proactor-threads rung must request the same cpus as the
     matching oss-standalone-NN-io-threads rung, so a scaling comparison runs on
-    equal hardware at every step."""
+    equal hardware at every step.
+
+    The "01" rung is deliberately excluded here: there is no
+    oss-standalone-01-io-threads entry to match against (the io-threads ladder
+    starts at 02), so dragonfly-01-proactor-threads is instead the strict N-cpu
+    floor/control rung pinned against the base oss-standalone entry — see the
+    next test and the topologies.yml comment above the ladder."""
     topologies_map = get_topologies(
         "./redis_benchmarks_specification/setups/topologies/topologies.yml"
     )
@@ -49,12 +55,29 @@ def test_dragonfly_topologies_match_io_threads_cpu_budget():
         redis_cpus = topologies_map[f"oss-standalone-{n}-io-threads"]["resources"][
             "requests"
         ]["cpus"]
-        dragonfly_cpus = topologies_map[f"dragonfly-{n}-proactor-threads"][
-            "resources"
-        ]["requests"]["cpus"]
+        dragonfly_cpus = topologies_map[f"dragonfly-{n}-proactor-threads"]["resources"][
+            "requests"
+        ]["cpus"]
         assert (
             redis_cpus == dragonfly_cpus
         ), f"cpu budget mismatch at {n} threads: redis={redis_cpus} dragonfly={dragonfly_cpus}"
+
+
+def test_dragonfly_01_rung_is_the_strict_floor_control():
+    """dragonfly-01-proactor-threads has no oss-standalone-01-io-threads
+    counterpart (the io-threads ladder starts at 02), so it does NOT follow the
+    N+1 pattern every other rung above follows. It is pinned to cpus=1, matching
+    the single-threaded base oss-standalone entry (also cpus=1) instead — the
+    one strict, ungenerous rung in the ladder."""
+    topologies_map = get_topologies(
+        "./redis_benchmarks_specification/setups/topologies/topologies.yml"
+    )
+    assert "oss-standalone-01-io-threads" not in topologies_map
+    assert (
+        topologies_map["dragonfly-01-proactor-threads"]["resources"]["requests"]["cpus"]
+        == topologies_map["oss-standalone"]["resources"]["requests"]["cpus"]
+        == "1"
+    )
 
 
 def test_extract_replica_count():


### PR DESCRIPTION
## Summary

Enables a matched-cpu-budget scaling comparison between Redis's io-threads
topology ladder and an equivalent topology ladder for a gflags-based,
RESP-protocol-compatible server whose build framework is vendored as a nested
git submodule (a benchmark target this repo already supports generically —
see `__self_contained_coordinator__/docker.py`'s existing
`generate_standalone_dragonfly_server_args`).

Three things were needed to make that comparison possible end-to-end:

**1. Ship submodule contents in the source archive.**
Both the local-repo `git archive` path and GitHub's own `/archive/{ref}.zip`
endpoint exclude submodule content by design, which blocks any build for a
target whose build framework is a nested submodule. Adds an opt-in
`--recurse_submodules` flag (default off, byte-identical for every existing
caller): checks out the requested commit in a local clone, runs
`git submodule update --init --recursive`, and zips
`git ls-files --recurse-submodules` instead of using `git archive`.

Tracked symlinks are preserved correctly through this path (encoded the way
git's own archive formats do: entry content = link target, `S_IFLNK` in
`external_attr`; the extractor reconstructs a real symlink from that), and any
tracked path that isn't a file or symlink after checkout fails the whole call
loudly instead of silently shipping an incomplete archive as success.

Since `local_repo_path` is reused across every commit in a multi-hash trigger
batch, the checkout+submodule-update sequence now also cleans the working tree
(recursing into already-initialized submodules too, not just the
superproject) before each checkout, and retries once (force + clean) if the
submodule update itself fails transiently.

**2. Fix `override_deployment_regexp` never reaching the coordinator.**
The CLI computed it correctly for the dry-run preview but never actually sent
it on the stream, and the builder explicitly dropped it (hardcoded empty
string) when forwarding a build request onto the benchmark stream — so a
topology override never reached the coordinator on the real trigger path, only
in local preview output. Both `deployment_name_regexp` and
`override_deployment_regexp` are now routed through the shared declared-field
stream reader already used for other fields, instead of a hand-rolled
membership-check-then-decode (the exact pattern that let this go missing).

**3. New topology ladder + a parse-warning fix.**
Adds an 8-rung proactor-thread-style topology ladder whose `cpus` budget
matches the existing `oss-standalone-NN-io-threads` ladder 1:1 at every rung
that has a counterpart (Redis's N io-threads run alongside an always-on main
thread, so its cpus is N+1; the new ladder mirrors that headroom rather than
shorting the comparison a core). The N=1 rung has no io-threads counterpart to
mirror (that ladder starts at N=2) and is documented as the ladder's
deliberate floor/control case instead. Also fixes a false-positive
parse-warning in the existing launch-arg generator that misfired when a caller
explicitly requested the equivalent of "1" rather than leaving it unset.

## Test plan

- [x] `pytest utils/tests/test_archive_submodules.py utils/tests/test_dragonfly_launch_args.py utils/tests/test_topologies.py utils/tests/test_stream_contract.py utils/tests/test_stream_contract_fuzz.py utils/tests/test_builder_schema.py utils/tests/test_builder.py` — 71/71 pass
- [x] `black --check` / `flake8` clean on touched files
- [x] Manually verified (live git fixtures) that the submodule-clean fix reaches nested submodules and that a genuinely broken submodule fails the call loudly rather than silently

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build/archive extraction (symlinks, mutable local clones) and benchmark stream topology overrides that affect which deployments run; default archive behavior stays off, but misused `--recurse_submodules` on a non-disposable repo could mutate a working tree.
> 
> **Overview**
> Adds an **opt-in `--recurse_submodules`** path so source zips can include nested submodule trees (checkout + `git submodule update --recursive`, zip from `git ls-files --recurse-submodules`) instead of `git archive`/GitHub archives that omit submodules. The default path is unchanged for existing callers. Archives preserve **tracked symlinks** (git-style zip encoding) and **fail loudly** on missing tracked paths or broken submodule init; reused clones get **recursive clean** and a **retry** on submodule update. **`ZipFileWithPermissions`** reconstructs symlinks on extract.
> 
> Fixes **`override_deployment_regexp`** end-to-end: CLI now puts it on the build stream, the builder reads both deployment regex fields via **`read_stream_field`** and forwards the real value (not `""`) at both artifact-reuse and fresh-build call sites.
> 
> Adds an **8-rung `dragonfly-*-proactor-threads` topology ladder** in `topologies.yml` with CPU budgets aligned to the Redis io-threads ladder (with documented exceptions for the N=1 floor). **Dragonfly `--proactor_threads` parsing** no longer warns when explicitly set to `1`.
> 
> Regression coverage includes `test_archive_submodules.py`, stream/builder wiring tests, topology CPU assertions, and Dragonfly launch-arg tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab952c99c688439c7016ae9964313bc740b46d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->