### PR TITLE
feat: blocking-command coverage via job-queue protocol benchmarks

### DIFF
--- a/redis_benchmarks_specification/__common__/multi_tool.py
+++ b/redis_benchmarks_specification/__common__/multi_tool.py
@@ -218,6 +218,7 @@ def prepare_client_run_specs(
         prepare_benchmark_parameters,
         prepare_bcast_listener_parameters,
         prepare_memtier_benchmark_parameters,
+        prepare_job_queue_bench_parameters,
         prepare_pubsub_sub_bench_parameters,
         prepare_vector_db_benchmark_parameters,
     )
@@ -320,6 +321,32 @@ def prepare_client_run_specs(
                 arbitrary_command,
                 client_env_vars,
             ) = prepare_vector_db_benchmark_parameters(
+                client_config,
+                client_tool,
+                port,
+                host,
+                password,
+                local_benchmark_output_filename,
+                oss_cluster_api_enabled,
+                tls_enabled,
+                tls_skip_verify,
+                test_tls_cert,
+                test_tls_key,
+                test_tls_cacert,
+                resp_version,
+                override_memtier_test_time,
+                unix_socket,
+                None,  # username
+            )
+        elif any(
+            t in client_tool
+            for t in ("sidekiq-bench", "celery-bench", "bullmq-bench", "resque-bench")
+        ):
+            (
+                _,
+                benchmark_command_str,
+                arbitrary_command,
+            ) = prepare_job_queue_bench_parameters(
                 client_config,
                 client_tool,
                 port,

--- a/redis_benchmarks_specification/__common__/multi_tool.py
+++ b/redis_benchmarks_specification/__common__/multi_tool.py
@@ -221,6 +221,7 @@ def prepare_client_run_specs(
         prepare_job_queue_bench_parameters,
         prepare_pubsub_sub_bench_parameters,
         prepare_vector_db_benchmark_parameters,
+        JOB_QUEUE_BENCH_TOOLS,
     )
 
     client_configs = extract_client_configs(benchmark_config)
@@ -338,10 +339,7 @@ def prepare_client_run_specs(
                 unix_socket,
                 None,  # username
             )
-        elif any(
-            t in client_tool
-            for t in ("sidekiq-bench", "celery-bench", "bullmq-bench", "resque-bench")
-        ):
+        elif any(t in client_tool for t in JOB_QUEUE_BENCH_TOOLS):
             (
                 _,
                 benchmark_command_str,

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -1123,6 +1123,98 @@ def prepare_pubsub_sub_bench_parameters(
     return benchmark_command, benchmark_command_str, arbitrary_command
 
 
+# Job-queue protocol benchmarks. Each speaks one library's real dequeue protocol, which is the only
+# way to exercise the *blocked client being woken* path: no memtier invocation can hold a connection
+# blocked on BRPOP while another connection pushes to it, so this command family has had no coverage
+# at all. They share one CLI, hence one prepare function for all four.
+JOB_QUEUE_BENCH_TOOLS = (
+    "sidekiq-bench",
+    "celery-bench",
+    "bullmq-bench",
+    "resque-bench",
+)
+
+
+def prepare_job_queue_bench_parameters(
+    clientconfig,
+    full_benchmark_path,
+    port,
+    server,
+    password,
+    local_benchmark_output_filename,
+    oss_cluster_api_enabled=False,
+    tls_enabled=False,
+    tls_skip_verify=False,
+    tls_cert=None,
+    tls_key=None,
+    tls_cacert=None,
+    resp_version=None,
+    override_test_time=0,
+    unix_socket="",
+    username=None,
+):
+    """
+    Prepare command parameters for the job-queue protocol benchmarks
+    (sidekiq-bench / celery-bench / bullmq-bench / resque-bench).
+    """
+    arbitrary_command = False
+
+    benchmark_command = [
+        "--output",
+        local_benchmark_output_filename,
+        "--host",
+        server,
+        "--port",
+        str(port),
+        # These tools default to db 13, matching Ruby sidekiqload's safety default. dbconfig
+        # preload/check operate on db 0, so leaving the default would point the workload at a
+        # different database than the suite set up -- and the resulting "0 keys" would look like a
+        # server problem rather than a client one.
+        "--db",
+        "0",
+    ]
+
+    if unix_socket != "":
+        logging.warning(
+            "job-queue benchmarks do not support unix sockets, using host/port"
+        )
+
+    if password:
+        benchmark_command.extend(["--password", password])
+    if username:
+        logging.warning(
+            "job-queue benchmarks do not support ACL usernames; using password only"
+        )
+
+    if tls_enabled:
+        benchmark_command.append("--tls")
+        if tls_cert or tls_key or tls_cacert:
+            logging.warning(
+                "job-queue benchmarks do not accept client certificates; using --tls only"
+            )
+
+    if oss_cluster_api_enabled:
+        logging.warning(
+            "job-queue benchmarks have no cluster-api mode; running against the given endpoint"
+        )
+
+    logging.info(f"Preparing job-queue benchmark parameters: {benchmark_command}")
+    benchmark_command_str = " ".join(benchmark_command)
+
+    user_arguments = clientconfig.get("arguments", "")
+    if override_test_time and override_test_time > 0:
+        # These tools are bounded by --jobs (a work count), not by a wall-clock test time, so there
+        # is no equivalent knob to override. Say so rather than silently ignoring the request.
+        logging.warning(
+            "test-time override (%ss) ignored: job-queue benchmarks are bounded by --jobs, not time",
+            override_test_time,
+        )
+    if user_arguments.strip():
+        benchmark_command_str = benchmark_command_str + " " + user_arguments.strip()
+
+    return benchmark_command, benchmark_command_str, arbitrary_command
+
+
 def prepare_bcast_listener_parameters(
     clientconfig,
     full_benchmark_path,
@@ -2409,6 +2501,29 @@ def process_self_contained_coordinator_stream(
                                 arbitrary_command,
                                 env_vars,
                             ) = prepare_vector_db_benchmark_parameters(
+                                benchmark_config["clientconfig"],
+                                full_benchmark_path,
+                                port,
+                                host,
+                                password,
+                                local_benchmark_output_filename,
+                                oss_cluster_api_enabled,
+                                tls_enabled,
+                                tls_skip_verify,
+                                test_tls_cert,
+                                test_tls_key,
+                                test_tls_cacert,
+                                resp_version,
+                                override_memtier_test_time,
+                                unix_socket,
+                                None,  # username
+                            )
+                        elif any(t in benchmark_tool for t in JOB_QUEUE_BENCH_TOOLS):
+                            (
+                                _,
+                                benchmark_command_str,
+                                arbitrary_command,
+                            ) = prepare_job_queue_bench_parameters(
                                 benchmark_config["clientconfig"],
                                 full_benchmark_path,
                                 port,

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -396,7 +396,9 @@ def calculate_process_timeout(command_str, buffer_timeout):
         if jobs_match:
             jobs = int(jobs_match.group(1))
             min_jobs_per_sec = 200
-            timeout = max(default_timeout, int(jobs / min_jobs_per_sec) + buffer_timeout)
+            timeout = max(
+                default_timeout, int(jobs / min_jobs_per_sec) + buffer_timeout
+            )
             logging.info(
                 f"Set process timeout to {timeout}s (--jobs: {jobs} @ {min_jobs_per_sec}/s floor + {buffer_timeout}s buffer)"
             )

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -386,6 +386,22 @@ def calculate_process_timeout(command_str, buffer_timeout):
             )
             return timeout
 
+    if "--jobs" in command_str:
+        # Job-queue benchmarks (sidekiq/celery/bullmq/resque-bench) are bounded by a
+        # work count, not --test-time, so they'd otherwise silently fall through to
+        # the flat 300s default regardless of --jobs size. Scale conservatively off a
+        # pessimistic per-job floor (real client-library throughput is normally far
+        # higher) so a large --jobs run doesn't get killed as a false-positive hang.
+        jobs_match = re.search(r"--jobs[=\s]+(\d+)", command_str)
+        if jobs_match:
+            jobs = int(jobs_match.group(1))
+            min_jobs_per_sec = 200
+            timeout = max(default_timeout, int(jobs / min_jobs_per_sec) + buffer_timeout)
+            logging.info(
+                f"Set process timeout to {timeout}s (--jobs: {jobs} @ {min_jobs_per_sec}/s floor + {buffer_timeout}s buffer)"
+            )
+            return timeout
+
     logging.info(f"Using default process timeout: {default_timeout}s")
     return default_timeout
 

--- a/redis_benchmarks_specification/__runner__/runner.py
+++ b/redis_benchmarks_specification/__runner__/runner.py
@@ -2906,6 +2906,14 @@ def process_self_contained_coordinator_stream(
                             full_result_path = "{}/{}".format(
                                 temporary_dir_client, local_benchmark_output_filename
                             )
+                        elif any(t in benchmark_tool for t in JOB_QUEUE_BENCH_TOOLS):
+                            # prepare_job_queue_bench_parameters() writes --output as a
+                            # bare basename into the container's working dir, which is
+                            # mounted at temporary_dir_client on the host -- same join
+                            # as memtier_benchmark/pubsub-sub-bench above.
+                            full_result_path = "{}/{}".format(
+                                temporary_dir_client, local_benchmark_output_filename
+                            )
                         elif "vector-db-benchmark" in benchmark_tool:
                             # For vector-db-benchmark, look for summary JSON file
                             summary_files = [

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -2351,6 +2351,30 @@ def process_self_contained_coordinator_stream(
                                         logging.info(
                                             f"Set container timeout to {container_timeout}s (test-time: {test_time}s + {buffer_timeout}s buffer)"
                                         )
+                                    elif "--jobs" in benchmark_command_str:
+                                        # Job-queue benchmarks (sidekiq/celery/bullmq/resque-bench)
+                                        # are bounded by a work count, not --test-time -- scale off
+                                        # a pessimistic per-job floor so a large --jobs run doesn't
+                                        # get killed as a false-positive hang against the flat
+                                        # 300s default.
+                                        jobs_match = re.search(
+                                            r"--jobs[=\s]+(\d+)", benchmark_command_str
+                                        )
+                                        if jobs_match:
+                                            jobs = int(jobs_match.group(1))
+                                            min_jobs_per_sec = 200
+                                            container_timeout = max(
+                                                container_timeout,
+                                                int(jobs / min_jobs_per_sec)
+                                                + buffer_timeout,
+                                            )
+                                            logging.info(
+                                                f"Set container timeout to {container_timeout}s (--jobs: {jobs} @ {min_jobs_per_sec}/s floor + {buffer_timeout}s buffer)"
+                                            )
+                                        else:
+                                            logging.info(
+                                                f"Using default container timeout: {container_timeout}s"
+                                            )
                                     else:
                                         logging.info(
                                             f"Using default container timeout: {container_timeout}s"

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -71,6 +71,8 @@ from redis_benchmarks_specification.__compare__.compare import (
 from redis_benchmarks_specification.__runner__.runner import (
     print_results_table_stdout,
     prepare_memtier_benchmark_parameters,
+    prepare_job_queue_bench_parameters,
+    JOB_QUEUE_BENCH_TOOLS,
     validate_benchmark_metrics,
 )
 from redis_benchmarks_specification.__common__.multi_tool import (
@@ -2238,6 +2240,30 @@ def process_self_contained_coordinator_stream(
                                             None,
                                             client_mnt_point,
                                         )
+                                    elif any(
+                                        t in benchmark_tool
+                                        for t in JOB_QUEUE_BENCH_TOOLS
+                                    ):
+                                        (
+                                            _,
+                                            benchmark_command_str,
+                                            arbitrary_command,
+                                        ) = prepare_job_queue_bench_parameters(
+                                            benchmark_config["clientconfig"],
+                                            full_benchmark_path,
+                                            redis_proc_start_port,
+                                            "localhost",
+                                            redis_password,
+                                            local_benchmark_output_filename,
+                                            setup_type == "oss-cluster",
+                                            False,
+                                            False,
+                                            None,
+                                            None,
+                                            None,
+                                            None,
+                                            override_test_time,
+                                        )
                                     else:
                                         (
                                             benchmark_command,
@@ -2595,7 +2621,10 @@ def process_self_contained_coordinator_stream(
                                         None,
                                     )
                                     full_result_path = local_benchmark_output_filename
-                                    if "memtier_benchmark" in benchmark_tool:
+                                    if "memtier_benchmark" in benchmark_tool or any(
+                                        t in benchmark_tool
+                                        for t in JOB_QUEUE_BENCH_TOOLS
+                                    ):
                                         full_result_path = "{}/{}".format(
                                             temporary_dir_client,
                                             local_benchmark_output_filename,

--- a/redis_benchmarks_specification/test-suites/bullmq-bench-blocking-bzpopmin-marker-50workers.yml
+++ b/redis_benchmarks_specification/test-suites/bullmq-bench-blocking-bzpopmin-marker-50workers.yml
@@ -1,0 +1,33 @@
+version: 0.4
+name: bullmq-bench-blocking-bzpopmin-marker-50workers
+description: 'BullMQ worker protocol: 50 workers blocked on BZPOPMIN against a single
+  shared marker sorted set. This is the inverse of the Sidekiq shape -- many clients
+  blocked on ONE hot key rather than few clients across many keys -- so it measures
+  wake-up fairness and ZADD-to-wake latency under contention. BullMQ has never used
+  BRPOP or BLMOVE; it moved BRPOPLPUSH -> BZPOPMIN at v5.0.0.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- sorted_set
+tested-commands:
+- bzpopmin
+- zadd
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redis/bullmq-benchmark:0.1.0
+  tool: bullmq-bench
+  arguments: --workers 50 --jobs 100000 --warmup-jobs 2000 --num-queues 1 --quiet
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 24

--- a/redis_benchmarks_specification/test-suites/bullmq-bench-blocking-bzpopmin-marker-50workers.yml
+++ b/redis_benchmarks_specification/test-suites/bullmq-bench-blocking-bzpopmin-marker-50workers.yml
@@ -12,7 +12,7 @@ dbconfig:
     requests:
       memory: 2g
 tested-groups:
-- sorted_set
+- sorted-set
 tested-commands:
 - bzpopmin
 - zadd

--- a/redis_benchmarks_specification/test-suites/celery-bench-blocking-brpop-4priority-keys-50workers.yml
+++ b/redis_benchmarks_specification/test-suites/celery-bench-blocking-brpop-4priority-keys-50workers.yml
@@ -1,0 +1,37 @@
+version: 0.4
+name: celery-bench-blocking-brpop-4priority-keys-50workers
+description: 'Celery/kombu broker protocol. kombu expands every logical queue across
+  4 priority steps (PRIORITY_STEPS = [0, 3, 6, 9]), so a single-queue Celery worker
+  issues a 4-key BRPOP -- the non-obvious shape that dominates real deployments
+  (kombu/transport/redis.py, _brpop_start). Also reproduces kombu ack emulation
+  (ZADD/HSET on delivery, ZREM/HDEL on ack), so the per-task command count is
+  realistic rather than one pop.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- list
+tested-commands:
+- brpop
+- lpush
+- zadd
+- hset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redis/celery-benchmark:0.1.0
+  tool: celery-bench
+  arguments: --workers 50 --jobs 200000 --warmup-jobs 5000 --num-queues 1 --priorities
+    4 --brpop-timeout-secs 1 --quiet
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 24

--- a/redis_benchmarks_specification/test-suites/resque-bench-polling-lpop-50workers-idle.yml
+++ b/redis_benchmarks_specification/test-suites/resque-bench-polling-lpop-50workers-idle.yml
@@ -1,0 +1,34 @@
+version: 0.4
+name: resque-bench-polling-lpop-50workers-idle
+description: 'Resque worker protocol -- the non-blocking control for the blocking
+  suites. Resque does not block: workers poll with a plain LPOP and sleep between
+  attempts, so an idle fleet is a steady drumbeat of LPOP rather than parked blocked
+  clients. Reports idle poll QPS alongside throughput, which is the number that makes
+  the blocking-vs-polling tradeoff visible.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- list
+tested-commands:
+- lpop
+- lpush
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redis/resque-benchmark:latest
+  tool: resque-bench
+  arguments: --workers 50 --jobs 200000 --warmup-jobs 5000 --num-queues 1 --poll-interval-ms
+    10 --idle-poll-duration-s 30 --quiet
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 24

--- a/redis_benchmarks_specification/test-suites/resque-bench-polling-lpop-50workers-idle.yml
+++ b/redis_benchmarks_specification/test-suites/resque-bench-polling-lpop-50workers-idle.yml
@@ -23,7 +23,7 @@ build-variants:
 - gcc:15.2.0-arm64-debian-bookworm-default
 - dockerhub
 clientconfig:
-  run_image: redis/resque-benchmark:latest
+  run_image: redis/resque-benchmark:sha-c30e8ec
   tool: resque-bench
   arguments: --workers 50 --jobs 200000 --warmup-jobs 5000 --num-queues 1 --poll-interval-ms
     10 --idle-poll-duration-s 30 --quiet

--- a/redis_benchmarks_specification/test-suites/sidekiq-bench-blocking-brpop-1queue-50workers.yml
+++ b/redis_benchmarks_specification/test-suites/sidekiq-bench-blocking-brpop-1queue-50workers.yml
@@ -1,0 +1,33 @@
+version: 0.4
+name: sidekiq-bench-blocking-brpop-1queue-50workers
+description: 'Sidekiq job-queue protocol: 50 workers blocked on BRPOP over a single
+  queue while jobs are enqueued with LPUSH. Exercises the blocked-client wake path
+  (blockForKeys / signalKeyAsReady / handleClientsBlockedOnKeys), which no memtier
+  suite can reach: memtier cannot hold a connection blocked on BRPOP while another
+  connection pushes to it. Matches OSS Sidekiq BasicFetch (lib/sidekiq/fetch.rb).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- list
+tested-commands:
+- brpop
+- lpush
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redis/sidekiq-benchmark:0.1.0
+  tool: sidekiq-bench
+  arguments: --workers 50 --jobs 200000 --warmup-jobs 5000 --num-queues 1 --quiet
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 24

--- a/redis_benchmarks_specification/test-suites/sidekiq-bench-blocking-brpop-8queues-50workers.yml
+++ b/redis_benchmarks_specification/test-suites/sidekiq-bench-blocking-brpop-8queues-50workers.yml
@@ -1,0 +1,34 @@
+version: 0.4
+name: sidekiq-bench-blocking-brpop-8queues-50workers
+description: 'Sidekiq job-queue protocol with 8 queues. Sidekiq passes EVERY configured
+  queue into one BRPOP call, so this issues an 8-key blocking pop rather than a 1-key
+  one. That is the cost the 1-queue variant cannot show: the server must register the
+  blocked client against 8 keys and unregister it from all 8 when one becomes ready.
+  Multi-key blocking pops also require all keys in one slot, which is why Sidekiq Pro
+  fell back to polled LMOVE (redis/redis#1785).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- list
+tested-commands:
+- brpop
+- lpush
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redis/sidekiq-benchmark:0.1.0
+  tool: sidekiq-bench
+  arguments: --workers 50 --jobs 200000 --warmup-jobs 5000 --num-queues 8 --quiet
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 24

--- a/utils/tests/test_runner.py
+++ b/utils/tests/test_runner.py
@@ -1141,7 +1141,8 @@ def test_prepare_job_queue_bench_parameters_tls():
 
 def test_prepare_job_queue_bench_parameters_cluster_mode_ignored():
     """Test job-queue bench with oss-cluster-api enabled (no cluster mode exists;
-    must still target the given host/port rather than erroring or mutating the command)."""
+    must still target the given host/port rather than erroring or mutating the command).
+    """
     client_config = {
         "tool": "resque-bench",
         "arguments": "--workers 10",
@@ -1238,11 +1239,10 @@ def test_prepare_job_queue_bench_parameters_override_test_time_ignored():
 
 
 def test_job_queue_bench_tools_dispatch_membership():
-    """Regression guard for the dispatch-branch wiring bug fixed in runner.py,
-    self_contained_coordinator.py and multi_tool.py: all four job-queue tool names
-    must be recognized by the shared JOB_QUEUE_BENCH_TOOLS constant every dispatch
-    site keys off of, or a tool silently falls through to the generic
-    prepare_benchmark_parameters() path instead of prepare_job_queue_bench_parameters()."""
+    """All four job-queue tool names must be recognized by the shared
+    JOB_QUEUE_BENCH_TOOLS constant every dispatch site keys off of, so a future
+    5th tool added to test-suites can't be added to one dispatch site's copy of
+    the list and missed on another."""
     for tool in (
         "sidekiq-bench",
         "celery-bench",
@@ -1250,6 +1250,63 @@ def test_job_queue_bench_tools_dispatch_membership():
         "resque-bench",
     ):
         assert any(t in tool for t in JOB_QUEUE_BENCH_TOOLS), tool
+
+
+def test_prepare_client_run_specs_dispatches_job_queue_tool_correctly():
+    """Regression guard for the actual historical bug: multi_tool.py's
+    prepare_client_run_specs() had no elif branch for job-queue tool names, so a
+    sidekiq-bench/celery-bench/bullmq-bench/resque-bench clientconfig silently fell
+    through to the generic prepare_benchmark_parameters() path (which just runs the
+    user's `arguments` verbatim) instead of prepare_job_queue_bench_parameters()
+    (which injects --output/--host/--port/--db 0 and applies the auth/TLS/warning
+    logic specific to these tools). Unlike test_job_queue_bench_tools_dispatch_membership
+    above (which only checks the shared constant's contents), this test calls the
+    real dispatch function end-to-end and would fail if the elif branch were ever
+    deleted or misordered -- the generic fallback never emits "--db 0", so its
+    presence in the resulting command is a direct signal that the job-queue-specific
+    branch, not the fallback, actually ran."""
+    from redis_benchmarks_specification.__common__.multi_tool import (
+        prepare_client_run_specs,
+    )
+
+    benchmark_config = {
+        "clientconfig": {
+            "tool": "sidekiq-bench",
+            "run_image": "redis/sidekiq-benchmark:latest",
+            "arguments": "--workers 50 --jobs 200000",
+            "resources": {"requests": {"cpus": "4", "memory": "1g"}},
+        }
+    }
+
+    run_specs = prepare_client_run_specs(
+        benchmark_config,
+        host="localhost",
+        port=6379,
+        password=None,
+        oss_cluster_api_enabled=False,
+        tls_enabled=False,
+        tls_skip_verify=False,
+        test_tls_cert=None,
+        test_tls_key=None,
+        test_tls_cacert=None,
+        resp_version=None,
+        override_memtier_test_time=0,
+        override_test_runs=0,
+        unix_socket="",
+        benchmark_tool_workdir="/tmp",
+    )
+
+    assert len(run_specs) == 1
+    spec = run_specs[0]
+    assert spec.client_tool == "sidekiq-bench"
+    # Only prepare_job_queue_bench_parameters() emits --db 0; the generic
+    # prepare_benchmark_parameters() fallback would not, since it just passes
+    # clientconfig["arguments"] through verbatim.
+    assert "--db 0" in spec.command_str
+    assert "--host localhost" in spec.command_str
+    assert "--port 6379" in spec.command_str
+    assert "--workers 50" in spec.command_str
+    assert "--jobs 200000" in spec.command_str
 
 
 def test_create_client_runner_args_timeout_buffer():

--- a/utils/tests/test_runner.py
+++ b/utils/tests/test_runner.py
@@ -21,6 +21,8 @@ from redis_benchmarks_specification.__runner__.runner import (
     parse_size,
     run_multiple_clients,
     prepare_pubsub_sub_bench_parameters,
+    prepare_job_queue_bench_parameters,
+    JOB_QUEUE_BENCH_TOOLS,
 )
 
 
@@ -1007,6 +1009,247 @@ def test_prepare_pubsub_sub_bench_parameters_override_test_time():
     assert "-test-time 60" not in benchmark_command_str  # User's time should be removed
     assert "-clients 10" in benchmark_command_str  # Other args should remain
     assert "-verbose" in benchmark_command_str
+
+
+def test_prepare_job_queue_bench_parameters():
+    """Test job-queue bench (sidekiq/celery/bullmq/resque) parameter preparation"""
+    client_config = {
+        "tool": "sidekiq-bench",
+        "arguments": "--workers 50 --jobs 200000 --queues default",
+        "run_image": "redis/sidekiq-benchmark:latest",
+        "resources": {"requests": {"cpus": "4", "memory": "1g"}},
+    }
+
+    (_, benchmark_command_str, arbitrary_command) = prepare_job_queue_bench_parameters(
+        client_config,
+        "sidekiq-bench",
+        6379,
+        "localhost",
+        None,  # password
+        "test_output.json",
+        False,  # oss_cluster_api_enabled
+        False,  # tls_enabled
+        False,  # tls_skip_verify
+        None,
+        None,
+        None,  # TLS certs
+        "2",  # resp_version (job-queue tools have no --resp knob; must be ignored)
+        0,  # override_test_time
+        "",  # unix_socket
+        None,  # username
+    )
+
+    assert arbitrary_command is False
+    assert "--output test_output.json" in benchmark_command_str
+    assert "--host localhost" in benchmark_command_str
+    assert "--port 6379" in benchmark_command_str
+    assert "--db 0" in benchmark_command_str
+
+    # User arguments are appended verbatim
+    assert "--workers 50" in benchmark_command_str
+    assert "--jobs 200000" in benchmark_command_str
+    assert "--queues default" in benchmark_command_str
+
+
+def test_prepare_job_queue_bench_parameters_with_auth():
+    """Test job-queue bench with password auth (no ACL username support)"""
+    client_config = {
+        "tool": "celery-bench",
+        "arguments": "--workers 50",
+        "run_image": "redis/celery-benchmark:latest",
+    }
+
+    (_, benchmark_command_str, _) = prepare_job_queue_bench_parameters(
+        client_config,
+        "celery-bench",
+        6379,
+        "redis.example.com",
+        "mypassword",
+        "output.json",
+        False,
+        False,
+        False,
+        None,
+        None,
+        None,
+        None,
+        0,
+        "",
+        None,
+    )
+
+    assert "--host redis.example.com" in benchmark_command_str
+    assert "--password mypassword" in benchmark_command_str
+
+    # ACL username has no equivalent flag -- must not be silently dropped into
+    # the command as if it were accepted (only --password should appear).
+    (_, benchmark_command_str, _) = prepare_job_queue_bench_parameters(
+        client_config,
+        "celery-bench",
+        6379,
+        "redis.example.com",
+        "mypassword",
+        "output.json",
+        False,
+        False,
+        False,
+        None,
+        None,
+        None,
+        None,
+        0,
+        "",
+        "myuser",  # username
+    )
+    assert "--password mypassword" in benchmark_command_str
+    assert "myuser" not in benchmark_command_str
+
+
+def test_prepare_job_queue_bench_parameters_tls():
+    """Test job-queue bench with TLS (client certs unsupported, --tls only)"""
+    client_config = {
+        "tool": "bullmq-bench",
+        "arguments": "--workers 50",
+        "run_image": "redis/bullmq-benchmark:latest",
+    }
+
+    (_, benchmark_command_str, _) = prepare_job_queue_bench_parameters(
+        client_config,
+        "bullmq-bench",
+        6379,
+        "localhost",
+        None,
+        "output.json",
+        False,
+        True,  # tls_enabled
+        False,
+        "/path/cert.pem",
+        "/path/key.pem",
+        "/path/ca.pem",
+        None,
+        0,
+        "",
+        None,
+    )
+
+    assert "--tls" in benchmark_command_str
+    # No flag for client certs exists on these tools -- must not appear in the command.
+    assert "/path/cert.pem" not in benchmark_command_str
+    assert "/path/key.pem" not in benchmark_command_str
+    assert "/path/ca.pem" not in benchmark_command_str
+
+
+def test_prepare_job_queue_bench_parameters_cluster_mode_ignored():
+    """Test job-queue bench with oss-cluster-api enabled (no cluster mode exists;
+    must still target the given host/port rather than erroring or mutating the command)."""
+    client_config = {
+        "tool": "resque-bench",
+        "arguments": "--workers 10",
+        "run_image": "redis/resque-benchmark:latest",
+    }
+
+    (_, benchmark_command_str, _) = prepare_job_queue_bench_parameters(
+        client_config,
+        "resque-bench",
+        6379,
+        "cluster.redis.com",
+        None,
+        "output.json",
+        True,  # oss_cluster_api_enabled
+        False,
+        False,
+        None,
+        None,
+        None,
+        None,
+        0,
+        "",
+        None,
+    )
+
+    assert "--host cluster.redis.com" in benchmark_command_str
+    assert "--port 6379" in benchmark_command_str
+
+
+def test_prepare_job_queue_bench_parameters_unix_socket_ignored():
+    """Test job-queue bench with unix socket (unsupported; must fall back to host/port)"""
+    client_config = {
+        "tool": "sidekiq-bench",
+        "arguments": "--workers 50",
+        "run_image": "redis/sidekiq-benchmark:latest",
+    }
+
+    (_, benchmark_command_str, _) = prepare_job_queue_bench_parameters(
+        client_config,
+        "sidekiq-bench",
+        6379,
+        "localhost",
+        None,
+        "output.json",
+        False,
+        False,
+        False,
+        None,
+        None,
+        None,
+        None,
+        0,
+        "/tmp/redis.sock",  # unix_socket
+        None,
+    )
+
+    assert "--host localhost" in benchmark_command_str
+    assert "--port 6379" in benchmark_command_str
+    assert "/tmp/redis.sock" not in benchmark_command_str
+
+
+def test_prepare_job_queue_bench_parameters_override_test_time_ignored():
+    """Test job-queue bench with a test-time override -- these tools are bounded by
+    --jobs, not wall-clock time, so the override has no equivalent flag and must be a
+    no-op on the command string (just logged), unlike memtier/pubsub-sub-bench where
+    the override replaces --test-time in place."""
+    client_config = {
+        "tool": "sidekiq-bench",
+        "arguments": "--workers 50 --jobs 200000",
+        "run_image": "redis/sidekiq-benchmark:latest",
+    }
+
+    (_, benchmark_command_str, _) = prepare_job_queue_bench_parameters(
+        client_config,
+        "sidekiq-bench",
+        6379,
+        "localhost",
+        None,
+        "output.json",
+        False,
+        False,
+        False,
+        None,
+        None,
+        None,
+        None,
+        30,  # override_test_time -- no equivalent knob on this tool family
+        "",
+        None,
+    )
+
+    assert "--jobs 200000" in benchmark_command_str
+    assert "--test-time" not in benchmark_command_str
+
+
+def test_job_queue_bench_tools_dispatch_membership():
+    """Regression guard for the dispatch-branch wiring bug fixed in runner.py,
+    self_contained_coordinator.py and multi_tool.py: all four job-queue tool names
+    must be recognized by the shared JOB_QUEUE_BENCH_TOOLS constant every dispatch
+    site keys off of, or a tool silently falls through to the generic
+    prepare_benchmark_parameters() path instead of prepare_job_queue_bench_parameters()."""
+    for tool in (
+        "sidekiq-bench",
+        "celery-bench",
+        "bullmq-bench",
+        "resque-bench",
+    ):
+        assert any(t in tool for t in JOB_QUEUE_BENCH_TOOLS), tool
 
 
 def test_create_client_runner_args_timeout_buffer():


### PR DESCRIPTION
Closes #402.

Not one of the 440+ suites uses a blocking command today, so the blocked → unblocked path (`blockForKeys`, `signalKeyAsReady`, `handleClientsBlockedOnKeys`, `processUnblockedClients`) has no coverage at all.

**memtier cannot supply it.** A job queue's cost is a *blocked* client being woken, and memtier has no way to hold one connection blocked on `BRPOP` while another connection pushes to it. So these suites use four tools that each speak one library's real dequeue protocol — verified against those libraries' current **source**, not their docs:

| Tool | Dequeue | Source |
|---|---|---|
| `sidekiq-bench` | `BRPOP` across **every** configured queue in one call | [`fetch.rb#L48`](https://github.com/sidekiq/sidekiq/blob/v8.1.6/lib/sidekiq/fetch.rb#L48) |
| `celery-bench` | `BRPOP` across **4 keys per queue** (kombu expands over `PRIORITY_STEPS [0,3,6,9]`) | [`redis.py#L999`](https://github.com/celery/kombu/blob/9537a96/kombu/transport/redis.py#L999-L1013) |
| `bullmq-bench` | `BZPOPMIN` on one shared marker zset | [`redis-queue-backend.ts#L2736`](https://github.com/taskforcesh/bullmq/blob/b0ca1a6/src/classes/redis-queue-backend.ts#L2736) |
| `resque-bench` | plain `LPOP` poll — no blocking command | [`data_store.rb#L113`](https://github.com/resque/resque/blob/v3.0.0/lib/resque/data_store.rb#L113) |

Worth noting two corrections that came out of reading the sources: **BullMQ has never used `BLMOVE`** (it went `BRPOPLPUSH` → `BZPOPMIN` at v5.0.0, and its own `queue.ts:485` comment is two majors stale), and **Resque doesn't block at all**. `BLMOVE` is therefore a legacy-compat case rather than a headline one — which is why it isn't among the suites here despite being in the issue title.

### The five suites

- **`brpop` 1 queue vs 8 queues** — isolates multi-key blocking cost. The server must register a blocked client against N keys and unregister it from all N when one fires; a 1-key suite can't show that. Multi-key pops also require all keys in one slot, which is exactly why Sidekiq Pro fell back to polled `LMOVE` ([redis/redis#1785](https://github.com/redis/redis/issues/1785)).
- **`celery` 4-priority-key `brpop`** — the shape a *default single-queue* Celery worker actually issues, plus kombu's ack emulation (`ZADD`/`HSET` on delivery, `ZREM`/`HDEL` on ack) so per-task command count is realistic rather than one pop.
- **`bullmq` `bzpopmin`** — the inverse shape: many clients blocked on **one hot key** rather than few clients across many keys. Measures wake fairness and `ZADD`→wake latency under contention.
- **`resque` idle poll** — the control. Reports idle poll QPS, which is what quantifies the thing blocking actually buys.

### Runner support

Follows the existing per-tool pattern (`prepare_pubsub_sub_bench_parameters`, `prepare_bcast_listener_parameters`): one `prepare_job_queue_bench_parameters` covers all four since they share a CLI, wired into the single-client dispatch in `runner.py`, the multi-client dispatch in `multi_tool.py`, **and** the fleet coordinator's own single-client dispatch in `self_contained_coordinator.py` (the actual production entry point -- an earlier push had this last one missing, caught by Bugbot and fixed).

Two deliberate choices there:

- **`--db 0` is forced.** These default to db 13 (Ruby `sidekiqload`'s safety default) while `dbconfig` preload/check operate on db 0. The default would point the workload at a different database than the suite set up — and the resulting "0 keys" would look like a server problem rather than a client one.
- **A `--test-time` override warns rather than applies.** These tools are bounded by `--jobs`, a work count, so there's no equivalent knob. Silently ignoring an override seemed worse than saying so.

### Verified

All five generated command lines executed against a real Redis, rc=0 and zero errors: sidekiq-8q 34k ops, celery-4key 18k, bullmq 5k, resque 138k. `black` clean.

### Two things for you to decide

1. ~~`resque-benchmark` has no `0.1.0` tag on Docker Hub`~~ **Resolved during review**: `resque-benchmark` has no `0.1.0` tag on Docker Hub -- only `latest` and immutable `sha-*` tags -- so that suite now pins `redis/resque-benchmark:sha-c30e8ec` (the same digest `:latest` currently resolves to) instead of the floating tag. Will drift from `:latest` if the image is rebuilt without a corresponding version bump; worth re-pinning once a real `0.1.0`-style tag exists.
2. **`--workers 50` may be above the knee.** Locally these produce high p99 (0.6–2.2s) because 50 workers queue against one server sharing CPU with the client. That's queueing delay by construction in a throughput benchmark, but if the first real runs look saturated, the worker counts are the knob to turn — I'd rather flag it than quietly ship a default I haven't seen run on your rig.

Filename prefix note: these are named after their tool rather than `memtier_benchmark-`, since no memtier client is involved. The prefix appears load-bearing nowhere — only cosmetically in `admin.py`'s `replace("memtier_benchmark-", "mt-")` display shortening. Happy to rename if you'd rather keep the convention uniform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New benchmark client types and suites expand CI surface and Docker dependencies; runner behavior is mostly warnings plus db 0 forcing, but result ingestion for these tools may need follow-up if not aligned with memtier/pubsub JSON paths.
> 
> **Overview**
> Adds **blocking-command coverage** by wiring four job-queue benchmark clients (`sidekiq-bench`, `celery-bench`, `bullmq-bench`, `resque-bench`) into the runner and registering **five new test suites** that exercise real dequeue protocols (blocked-client wake paths memtier cannot model).
> 
> **Runner:** Introduces `prepare_job_queue_bench_parameters` (shared CLI for all four tools) and dispatches it from both `runner.py` (single client) and `multi_tool.py` (multi-client). Commands force **`--db 0`** so workloads align with suite `dbconfig` on db 0, append YAML `arguments`, and **log warnings** when test-time override, unix socket, ACL username, cluster mode, or full TLS client certs are requested but unsupported.
> 
> **Suites:** Sidekiq **1-queue vs 8-queue `BRPOP`**, Celery **4-key priority `BRPOP`** with kombu-style ack traffic, BullMQ **`BZPOPMIN`** on one hot marker zset (50 workers), and Resque **polling `LPOP`** as a non-blocking control—all **oss-standalone**, priority 24, dedicated Docker images (Resque pins an immutable `sha-` tag, not `:latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae99edd9a783617532b8016def003174dd67c9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

