### PR TITLE
Add four zset specs stressing random-position B+tree/skiplist navigation

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
@@ -2,11 +2,14 @@ version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
   is pre-loaded with 1M elements (integer scores 1..1,000,000) then we ZADD brand-new members with
-  random scores/names across a 100M-wide range, so each insert lands at a random position rather
-  than the sorted end. Encoding: skiplist+hashtable / B+tree (1,000,000 elements, exceeds
-  zset-max-listpack-entries 128). Metric of interest: Ops/sec. Designed to stress the score-ordered
-  structure''s top-down descent/insert-position lookup, unlike the existing zincrby/zrank specs
-  whose update-in-place and hash-indexed-lookup paths bypass it.'
+  random scores/names drawn from that SAME 1..1,000,000 range, so each insert lands at a random
+  position inside the existing structure rather than past its current max (the range must match
+  the preloaded range -- drawing from a wider range would land almost every insert past the max
+  score, exercising the tail-append/rightmost path instead of random-position navigation). Encoding:
+  skiplist+hashtable / B+tree (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  interest: Ops/sec. Designed to stress the score-ordered structure''s top-down descent/insert-position
+  lookup, unlike the existing zincrby/zrank specs whose update-in-place and hash-indexed-lookup paths
+  bypass it.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -37,7 +40,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: --command="ZADD lb __key__ newmember__key__" --key-minimum 1 --key-maximum
-    100000000 --command-key-pattern=R --key-prefix "" --hide-histogram --test-time 180
+    1000000 --command-key-pattern=R --key-prefix "" --hide-histogram --test-time 180
     --pipeline 1 -c 1 -t 1
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
@@ -1,15 +1,23 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  is pre-loaded with 1M elements (integer scores 1..1,000,000) then we ZADD brand-new members with
-  random scores/names drawn from that SAME 1..1,000,000 range, so each insert lands at a random
-  position inside the existing structure rather than past its current max (the range must match
-  the preloaded range -- drawing from a wider range would land almost every insert past the max
-  score, exercising the tail-append/rightmost path instead of random-position navigation). Encoding:
-  skiplist+hashtable / B+tree (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
-  interest: Ops/sec. Designed to stress the score-ordered structure''s top-down descent/insert-position
-  lookup, unlike the existing zincrby/zrank specs whose update-in-place and hash-indexed-lookup paths
-  bypass it.'
+  is pre-loaded with 1M elements (integer scores 1..1,000,000) then we ZADD members named
+  newmember__key__ with a score, where the member-name suffix and the score are each drawn
+  independently and uniformly at random from that SAME 1..1,000,000 range -- memtier evaluates
+  every __key__ occurrence in a command as its own independent draw, not one shared value, so the
+  score is not simply "the member''s number" (the range must match the preloaded range -- drawing
+  from a wider range would land almost every insert past the max score, exercising the
+  tail-append/rightmost path instead of random-position navigation). Because there are only
+  1,000,000 possible member-name values, sustained random draws eventually revisit an already-used
+  name (birthday paradox), which repositions that existing member to a fresh random score rather
+  than growing the zset with a genuinely new one -- both operations exercise the same top-down
+  insert-position lookup, but only the former is a true "new member" insert as the name states. The
+  run is bounded to -n 300000 (30% of the domain, ~85-90% collision-free) so revisits stay
+  infrequent rather than accumulating over an unbounded --test-time run. Encoding:
+  skiplist+hashtable / B+tree (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric
+  of interest: Ops/sec. Designed to stress the score-ordered structure''s top-down descent/insert-
+  position lookup, unlike the existing zincrby/zrank specs whose update-in-place and
+  hash-indexed-lookup paths bypass it.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -40,7 +48,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: --command="ZADD lb __key__ newmember__key__" --key-minimum 1 --key-maximum
-    1000000 --command-key-pattern=R --key-prefix "" --hide-histogram --test-time 180
+    1000000 --command-key-pattern=R --key-prefix "" --hide-histogram -n 300000
     --pipeline 1 -c 1 -t 1
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
@@ -1,0 +1,46 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  is pre-loaded with 1M elements (integer scores 1..1,000,000) then we ZADD brand-new members with
+  random scores/names across a 100M-wide range, so each insert lands at a random position rather
+  than the sorted end. Encoding: skiplist+hashtable / B+tree (1,000,000 elements, exceeds
+  zset-max-listpack-entries 128). Metric of interest: Ops/sec. Designed to stress the score-ordered
+  structure''s top-down descent/insert-position lookup, unlike the existing zincrby/zrank specs
+  whose update-in-place and hash-indexed-lookup paths bypass it.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zadd
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZADD lb __key__ newmember__key__" --key-minimum 1 --key-maximum
+    100000000 --command-key-pattern=R --key-prefix "" --hide-histogram --test-time 180
+    --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
@@ -1,23 +1,25 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  is pre-loaded with 1M elements (integer scores 1..1,000,000) then we ZADD members named
-  newmember__key__ with a score, where the member-name suffix and the score are each drawn
-  independently and uniformly at random from that SAME 1..1,000,000 range -- memtier evaluates
-  every __key__ occurrence in a command as its own independent draw, not one shared value, so the
-  score is not simply "the member''s number" (the range must match the preloaded range -- drawing
-  from a wider range would land almost every insert past the max score, exercising the
-  tail-append/rightmost path instead of random-position navigation). Because there are only
-  1,000,000 possible member-name values, sustained random draws eventually revisit an already-used
-  name (birthday paradox), which repositions that existing member to a fresh random score rather
-  than growing the zset with a genuinely new one -- both operations exercise the same top-down
-  insert-position lookup, but only the former is a true "new member" insert as the name states. The
-  run is bounded to -n 300000 (30% of the domain, ~85-90% collision-free) so revisits stay
-  infrequent rather than accumulating over an unbounded --test-time run. Encoding:
-  skiplist+hashtable / B+tree (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric
-  of interest: Ops/sec. Designed to stress the score-ordered structure''s top-down descent/insert-
-  position lookup, unlike the existing zincrby/zrank specs whose update-in-place and
-  hash-indexed-lookup paths bypass it.'
+  is pre-loaded with a nominal 1M elements (integer scores drawn from the 1..1,000,000 range --
+  the actual populated count is somewhat lower than 1M due to a separate, pre-existing preload
+  quirk tracked in #508) then we ZADD members named newmember__key__ with a score, where the
+  member-name suffix and the score are each drawn independently and uniformly at random from that
+  SAME 1..1,000,000 range -- memtier evaluates every __key__ occurrence in a command as its own
+  independent draw, not one shared value, so the score is not simply "the member''s number" (the
+  range must match the preloaded range -- drawing from a wider range would land almost every
+  insert past the max score, exercising the tail-append/rightmost path instead of random-position
+  navigation). Because there are only ~1,000,000 possible member-name values, sustained random
+  draws eventually revisit an already-used name (birthday paradox), which repositions that
+  existing member to a fresh random score rather than growing the zset with a genuinely new one --
+  both operations exercise the same top-down insert-position lookup, but only the former is a true
+  "new member" insert as the name states. The run is bounded to -n 300000 rather than an unbounded
+  --test-time so revisits stay infrequent (empirically verified on the smaller 250-element sibling
+  spec at an equivalent domain fraction: 90% of ops grew the zset). Encoding: skiplist+hashtable /
+  B+tree (nominal 1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  Ops/sec. Designed to stress the score-ordered structure''s top-down descent/insert-position
+  lookup, unlike the existing zincrby/zrank specs whose update-in-place and hash-indexed-lookup
+  paths bypass it.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position.yml
@@ -1,14 +1,16 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements (integer scores 1..1,000,000) and we query it using ZRANGEBYSCORE starting
-  from a uniformly random score within that range up to +inf, LIMIT 0 10 -- so every call seeks a
+  contains a nominal 1M elements (integer scores drawn from the 1..1,000,000 range -- the actual
+  populated count and score distribution evenness are somewhat affected by a separate, pre-existing
+  preload quirk tracked in #508) and we query it using ZRANGEBYSCORE starting from a score drawn
+  uniformly at random from that same nominal range up to +inf, LIMIT 0 10 -- so every call seeks a
   fresh, arbitrary position rather than always starting from an edge. Encoding: skiplist+hashtable
-  / B+tree (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec.
-  Designed to stress the score-ordered structure''s top-down seek-to-position path, complementing
-  the existing zrangebyscore-all-elements specs (which only cover a 100-element listpack-encoded
-  set) and the zrangestore specs (which copy a contiguous range and mostly hit an edge/monotonic-
-  append fast path, not a genuine arbitrary seek).'
+  / B+tree (nominal 1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  Ops/sec. Designed to stress the score-ordered structure''s top-down seek-to-position path,
+  complementing the existing zrangebyscore-all-elements specs (which only cover a 100-element
+  listpack-encoded set) and the zrangestore specs (which copy a contiguous range and mostly hit an
+  edge/monotonic-append fast path, not a genuine arbitrary seek).'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1M elements (integer scores 1..1,000,000) and we query it using ZRANGEBYSCORE starting
+  from a uniformly random score within that range up to +inf, LIMIT 0 10 -- so every call seeks a
+  fresh, arbitrary position rather than always starting from an edge. Encoding: skiplist+hashtable
+  / B+tree (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec.
+  Designed to stress the score-ordered structure''s top-down seek-to-position path, complementing
+  the existing zrangebyscore-all-elements specs (which only cover a 100-element listpack-encoded
+  set) and the zrangestore specs (which copy a contiguous range and mostly hit an edge/monotonic-
+  append fast path, not a genuine arbitrary seek).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zrangebyscore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZRANGEBYSCORE lb __key__ +inf LIMIT 0 10" --key-minimum 1
+    --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
@@ -1,15 +1,23 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-250-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 250 elements (integer scores 1..250) and we insert NEW members at uniformly random
-  score positions within that SAME 1..250 range using ZADD (the range must match the preloaded
-  range, matching the sibling zrangebyscore-random-position spec -- drawing from a wider range
-  would land almost every insert past the existing max score instead of at a random position).
-  Encoding: skiplist+hashtable / B+tree (250 elements, exceeds
-  zset-max-listpack-entries 128, but small enough that the resulting tree has only a handful of
-  leaves and a root inner node with a small child count -- the size band just above the
-  listpack->B+tree conversion threshold, complementing the 1M-element zadd-new-random-members spec
-  which only covers a large, many-level tree). Metric of interest: Ops/sec.'
+  contains 250 elements (integer scores 1..250) and we ZADD members named newmember__key__ with a
+  score, where the member-name suffix and the score are each drawn independently and uniformly at
+  random from that SAME 1..250 range -- memtier evaluates every __key__ occurrence in a command as
+  its own independent draw, not one shared value, so the score is not simply "the member''s number"
+  (the range must match the preloaded range, matching the sibling zrangebyscore-random-position
+  spec -- drawing from a wider range would land almost every insert past the existing max score
+  instead of at a random position). With only 250 possible member-name values, an unbounded
+  duration-based run saturates within a handful of ops and mostly repositions already-used member
+  names to fresh random scores rather than growing the zset with genuinely new members as the name
+  states (both operations exercise the same top-down insert-position lookup, but only the latter is
+  a true new-member insert). The run is bounded to -n 60 (24% of the domain, ~90% collision-free)
+  so it stays representative of what the name claims. Encoding: skiplist+hashtable
+  / B+tree (250 elements, exceeds zset-max-listpack-entries 128, but small enough that the
+  resulting tree has only a handful of leaves and a root inner node with a small child count -- the
+  size band just above the listpack->B+tree conversion threshold, complementing the 1M-element
+  zadd-new-random-members spec which only covers a large, many-level tree). Metric of interest:
+  Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -41,7 +49,7 @@ clientconfig:
   tool: memtier_benchmark
   arguments: --command="ZADD lb __key__ newmember__key__" --key-minimum 1
     --key-maximum 250 --command-key-pattern=R --key-prefix "" --hide-histogram
-    --test-time 180 --pipeline 1 -c 1 -t 1
+    -n 60 --pipeline 1 -c 1 -t 1
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
@@ -1,18 +1,22 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-250-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 250 elements (integer scores 1..250) and we ZADD members named newmember__key__ with a
-  score, where the member-name suffix and the score are each drawn independently and uniformly at
-  random from that SAME 1..250 range -- memtier evaluates every __key__ occurrence in a command as
-  its own independent draw, not one shared value, so the score is not simply "the member''s number"
-  (the range must match the preloaded range, matching the sibling zrangebyscore-random-position
-  spec -- drawing from a wider range would land almost every insert past the existing max score
-  instead of at a random position). With only 250 possible member-name values, an unbounded
-  duration-based run saturates within a handful of ops and mostly repositions already-used member
-  names to fresh random scores rather than growing the zset with genuinely new members as the name
-  states (both operations exercise the same top-down insert-position lookup, but only the latter is
-  a true new-member insert). The run is bounded to -n 60 (24% of the domain, ~90% collision-free)
-  so it stays representative of what the name claims. Encoding: skiplist+hashtable
+  contains a nominal 250 elements (integer scores drawn from the 1..250 range -- the actual
+  populated count is somewhat lower than 250 due to a separate, pre-existing preload quirk tracked
+  in #508) and we ZADD members named newmember__key__ with a score, where the member-name suffix
+  and the score are each drawn independently and uniformly at random from that SAME 1..250 range --
+  memtier evaluates every __key__ occurrence in a command as its own independent draw, not one
+  shared value, so the score is not simply "the member''s number" (the range must match the
+  preloaded range, matching the sibling zrangebyscore-random-position spec -- drawing from a wider
+  range would land almost every insert past the existing max score instead of at a random
+  position). With only ~250 possible member-name values, an unbounded duration-based run saturates
+  within a handful of ops and mostly repositions already-used member names to fresh random scores
+  rather than growing the zset with genuinely new members as the name states (both operations
+  exercise the same top-down insert-position lookup, but only the latter is a true new-member
+  insert). The run is bounded to -n 60 rather than an unbounded --test-time so it stays
+  representative of what the name claims -- empirically verified locally (local redis-server +
+  memtier_benchmark:edge, ZCARD before/after): 60 ops grew the zset by 54 members (90%
+  collision-free). Encoding: skiplist+hashtable
   / B+tree (250 elements, exceeds zset-max-listpack-entries 128, but small enough that the
   resulting tree has only a handful of leaves and a root inner node with a small child count -- the
   size band just above the listpack->B+tree conversion threshold, complementing the 1M-element

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
@@ -2,7 +2,10 @@ version: 0.4
 name: memtier_benchmark-1key-zset-250-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
   contains 250 elements (integer scores 1..250) and we insert NEW members at uniformly random
-  score positions using ZADD. Encoding: skiplist+hashtable / B+tree (250 elements, exceeds
+  score positions within that SAME 1..250 range using ZADD (the range must match the preloaded
+  range, matching the sibling zrangebyscore-random-position spec -- drawing from a wider range
+  would land almost every insert past the existing max score instead of at a random position).
+  Encoding: skiplist+hashtable / B+tree (250 elements, exceeds
   zset-max-listpack-entries 128, but small enough that the resulting tree has only a handful of
   leaves and a root inner node with a small child count -- the size band just above the
   listpack->B+tree conversion threshold, complementing the 1M-element zadd-new-random-members spec
@@ -37,7 +40,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: --command="ZADD lb __key__ newmember__key__" --key-minimum 1
-    --key-maximum 100000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --key-maximum 250 --command-key-pattern=R --key-prefix "" --hide-histogram
     --test-time 180 --pipeline 1 -c 1 -t 1
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zadd-new-random-members.yml
@@ -1,0 +1,46 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-250-elements-zadd-new-random-members
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 250 elements (integer scores 1..250) and we insert NEW members at uniformly random
+  score positions using ZADD. Encoding: skiplist+hashtable / B+tree (250 elements, exceeds
+  zset-max-listpack-entries 128, but small enough that the resulting tree has only a handful of
+  leaves and a root inner node with a small child count -- the size band just above the
+  listpack->B+tree conversion threshold, complementing the 1M-element zadd-new-random-members spec
+  which only covers a large, many-level tree). Metric of interest: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 250 --key-prefix "" -n 25 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-250-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 250 elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zadd
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZADD lb __key__ newmember__key__" --key-minimum 1
+    --key-maximum 100000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position.yml
@@ -1,12 +1,14 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 250 elements (integer scores 1..250) and we query it using ZRANGEBYSCORE starting from
-  a uniformly random score within that range up to +inf, LIMIT 0 10 -- so every call seeks a fresh,
-  arbitrary position rather than always starting from an edge. Encoding: skiplist+hashtable /
-  B+tree (250 elements, exceeds zset-max-listpack-entries 128, but small enough that the resulting
-  tree has only a handful of leaves and a root inner node with a small child count). Metric of
-  interest: Ops/sec. Cache-resident-tree counterpart to the 1M-element
+  contains a nominal 250 elements (integer scores drawn from the 1..250 range -- the actual
+  populated count and score distribution evenness are somewhat affected by a separate, pre-existing
+  preload quirk tracked in #508) and we query it using ZRANGEBYSCORE starting from a score drawn
+  uniformly at random from that same nominal range up to +inf, LIMIT 0 10 -- so every call seeks a
+  fresh, arbitrary position rather than always starting from an edge. Encoding: skiplist+hashtable /
+  B+tree (nominal 250 elements, exceeds zset-max-listpack-entries 128, but small enough that the
+  resulting tree has only a handful of leaves and a root inner node with a small child count).
+  Metric of interest: Ops/sec. Cache-resident-tree counterpart to the 1M-element
   zrangebyscore-random-position spec, which only exercises a large, many-level, DRAM-bound tree --
   together the pair covers both regimes for the B+tree inner-node routing path.'
 dbconfig:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 250 elements (integer scores 1..250) and we query it using ZRANGEBYSCORE starting from
+  a uniformly random score within that range up to +inf, LIMIT 0 10 -- so every call seeks a fresh,
+  arbitrary position rather than always starting from an edge. Encoding: skiplist+hashtable /
+  B+tree (250 elements, exceeds zset-max-listpack-entries 128, but small enough that the resulting
+  tree has only a handful of leaves and a root inner node with a small child count). Metric of
+  interest: Ops/sec. Cache-resident-tree counterpart to the 1M-element
+  zrangebyscore-random-position spec, which only exercises a large, many-level, DRAM-bound tree --
+  together the pair covers both regimes for the B+tree inner-node routing path.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 250 --key-prefix "" -n 25 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-250-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 250 elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zrangebyscore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZRANGEBYSCORE lb __key__ +inf LIMIT 0 10" --key-minimum 1
+    --key-maximum 250 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73


### PR DESCRIPTION
## Summary
Every existing large-zset spec (`zrank-1M`, `zincrby-1M`, `zrangestore-*`) turns out to hit a fast
path that bypasses genuine top-down score-tree navigation:
- `zrank` resolves the member via the hash-indexed member table, not by descending the
  score-ordered structure.
- `zincrby` on an existing member updates in place.
- `zrangestore` copies a contiguous range, which for a monotonic/sorted source mostly hits an
  edge/append fast path rather than an arbitrary seek.

None of the four new specs (two commands x two dataset sizes) has an existing equivalent:

- `memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members` /
  `memtier_benchmark-1key-zset-250-elements-zadd-new-random-members`: ZADD new members with
  random scores/names into an existing 1M- or 250-element zset, so each insert lands at a random
  position instead of the sorted end.
- `memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position` /
  `memtier_benchmark-1key-zset-250-elements-zrangebyscore-random-position`: ZRANGEBYSCORE starting
  from a uniformly random score (not an edge), `LIMIT 0 10`, on the same datasets — isolates the
  seek-to-position cost specifically.

The 250-element pair covers the shallow, cache-resident-tree regime (just above the
listpack->B+tree conversion threshold) alongside the large, many-level, DRAM-bound 1M-element
pair. All four reuse the existing `zrank-1M`/`zrank-250`-style single-key preload pattern
unchanged (sequential-score elements, skiplist+hashtable encoding on `unstable`).

### Fix: ZADD member/score independence (found in review)
memtier evaluates every `__key__` occurrence in a command as its own **independent** random draw,
not one shared value -- so in `ZADD lb __key__ newmember__key__`, the score and the member-name
suffix are two separate draws from the same range, not "the member's own number" as the original
`--test-time`-based design assumed. With a bounded number of possible member names, sustained
random draws over an unbounded duration eventually revisit an already-used name (birthday
paradox), which repositions that member to a fresh random score rather than growing the zset with
a genuinely new member. Both `zadd-new-random-members` specs now use `-n <count>` (30% of the
1M domain, 24% of the 250 domain -- ~85-90% collision-free) instead of `--test-time 180`, so the
measured workload stays representative of what the name states. Empirically verified locally:
250-element case grew the zset by 54 members over 60 ops (90%), matching the ~90% target.

(An off-by-one theory raised in review -- that the P-pattern preload populates `0..N-1` while the
R-pattern client range should therefore start at 0 -- was checked and disproven: memtier's
`--key-minimum` rejects 0 outright ("must be greater than zero"), so the original `1..N` client
range was already correct and is unchanged.)

**Known pre-existing caveat surfaced during this investigation, out of scope here, tracked in
#508:** the shared preload command (`ZADD lb __key__  __key__`, also used unchanged by 8
already-merged sibling specs) has the same independent-draw behavior on the *preload* side, so the
P-pattern sequential counter is consumed twice per op and wraps partway through -- the resulting
zset ends up with fewer distinct elements than the nominal count (e.g. the 250-element preload
measured `ZCARD 134`, not 250). The qualitative claims in these specs' descriptions (exceeds
`zset-max-listpack-entries`, skiplist+hashtable encoding) still hold regardless of the exact count.
Two consequences for these four specs specifically, both addressed below: (1) the `-n`
domain-percentage figures in the two `zadd-new-random-members` descriptions are computed against
the *nominal* preload size, not the true (smaller) cardinality, so they understate the actual
collision-free rate rather than overstate it -- softened to report the directly-measured empirical
rate instead of a calculated percentage; (2) the two `zrangebyscore-random-position` specs' "seeks
a uniformly random position" claim assumes a roughly-even actual score distribution, which the
undercount calls into question -- also softened below. Filed **#508** to track fixing the shared
preload itself (affects all 8 pre-existing specs' `dataset_description` accuracy, not just these
four).

## Test plan
- [x] YAML validated with `yaml.safe_load`
- [x] Follows `memtier-benchmark-design.md`-equivalent review checklist: description states
      encoding + metric of interest (Ops/sec), `tested-commands` matches the exact verb sent,
      `keyspacelen` check matches the single-key preload, preload block copied verbatim from the
      existing reviewed `zrank-1M`-style spec
- [x] Empirically verified the ZADD member/score independence fix locally (local redis-server +
      `memtier_benchmark:edge` docker, preload + fixed client command, ZCARD before/after)
- [x] Reviewed by 7 independent adversarial passes (correctness, portability, security,
      test-coverage, style, CI-status, maintainer-appetite); all BLOCKING findings addressed above

