### PR TITLE
fix: close the socket_keepalive-without-socket_keepalive_options gap

### DIFF
--- a/utils/tests/test_redis_keepalive_options.py
+++ b/utils/tests/test_redis_keepalive_options.py
@@ -122,6 +122,20 @@ def _assert_blocking_connection_has_keepalive(by_target, var_name, where):
         "intermediate NAT/LB hop. Other redis.StrictRedis(...) connections in {} "
         "having it is not sufficient.".format(where, var_name, where)
     )
+    # redis-py only applies socket_keepalive_options when socket_keepalive is
+    # truthy (Connection._connect: `if self.socket_keepalive: ... for k, v in
+    # self.socket_keepalive_options.items(): ...`) -- socket_keepalive_options
+    # alone is a silent no-op. A refactor that drops the bare
+    # `socket_keepalive=True` kwarg while leaving socket_keepalive_options in
+    # place would pass the assertion above yet fully disable the feature.
+    assert "socket_keepalive" in by_target[var_name], (
+        "{}'s `{}` sets socket_keepalive_options but not socket_keepalive=True -- "
+        "redis-py only applies socket_keepalive_options when socket_keepalive is "
+        "truthy (see redis.connection.Connection._connect), so this combination "
+        "silently disables keepalive entirely rather than tuning it.".format(
+            where, var_name
+        )
+    )
 
 
 def test_builder_main_wires_keepalive_options_into_blocking_connection():


### PR DESCRIPTION
Follow-up to #501, filed from a 7-lens adversarial review round.

## Problem

The regression guard added in #501 (`_assert_blocking_connection_has_keepalive`) only asserted `socket_keepalive_options` was present on the two long-blocking-read `StrictRedis(...)` calls (`builder.main()`, `self_contained_coordinator.main()`). It never checked that the bare `socket_keepalive=True` kwarg stayed alongside it.

redis-py's `Connection._connect` only applies `socket_keepalive_options` when `socket_keepalive` is truthy:
```python
if self.socket_keepalive:
    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
    for k, v in self.socket_keepalive_options.items():
        sock.setsockopt(socket.IPPROTO_TCP, k, v)
```
So a future refactor that dropped `socket_keepalive=True` while leaving `socket_keepalive_options=...` in place would silently disable keepalive entirely on both connections — the exact regression class #501 exists to prevent — and every existing test in this file would still pass, since none of them checked for that specific pairing.

## Fix

Adds one more assertion to the shared helper: `socket_keepalive` must also be present in the same call's kwargs. Covers both call sites since the helper is shared.

## Testing

`utils/tests/test_redis_keepalive_options.py` — 6 passed locally (4 pre-existing + confirms the new assertion holds against the real, already-correct call sites).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production Redis wiring is modified.
> 
> **Overview**
> Tightens the AST-based regression guard in `_assert_blocking_connection_has_keepalive` so it no longer only checks for `socket_keepalive_options` on the long-blocking-read `StrictRedis` clients in `builder.main()` and `self_contained_coordinator.main()`.
> 
> It now also requires the `socket_keepalive` kwarg on the same call, because redis-py only applies `socket_keepalive_options` when `socket_keepalive` is truthy—dropping `socket_keepalive=True` while leaving the options in place would silently disable keepalive yet still pass the old test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc8f337e2c1895dc971f6ef50f2d14625816f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->