### PR TITLE
Add ZCOUNT/ZPOPMIN/ZRANDMEMBER 1M-element zset coverage

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcount-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcount-random-position.yml
@@ -1,23 +1,30 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zcount-random-position
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains ~1M elements (999,996 verified via ZCARD) and we query it using ZCOUNT starting from a
+  contains 1,000,000 elements (verified via ZCARD) and we query it using ZCOUNT starting from a
   uniformly random score within the populated range up to +inf -- so every call seeks a fresh,
   arbitrary position rather than counting the whole structure. PRELOAD DOMAIN: the ZADD lb __key__
   __key__ preload command has TWO __key__ occurrences, and memtier''s P key-pattern draws a fresh
-  sequential integer per occurrence (not one shared value) -- so each ZADD call consumes 2 domain
-  positions (one becomes the score, the next becomes the member), and --key-maximum is set to
-  2,000,000 (double the ~1M element target) so 10 connections x 100,000 calls each can consume
-  their full domain share without overrunning into a neighboring connection''s range (which, at
-  key-maximum 1,000,000, caused a measured cardinality shortfall to 949,996 via cross-connection
-  collisions). Member and score values both come from the 1..2,000,000 domain (member = score + 1
-  for every element), not a clean 1..1,000,000 range -- verified via ZRANGE sampling; the client
-  phase''s random-start draw below is scoped to the real score domain (0..1,999,999) accordingly.
-  Encoding: skiplist (999,996 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
-  Ops/sec. ZCOUNT had zero benchmark coverage before this spec. Mirrors the seek-cost-representative
-  design of the existing zrangebyscore-random-position spec (random start, unbounded tail) rather
-  than a full -inf +inf traversal, since ZCOUNT''s two-endpoint-seek cost -- not a full scan -- is
-  the code path under study.'
+  sequential integer per occurrence (not one shared value) -- so each ZADD call consumes 2
+  CONSECUTIVE domain positions (the first becomes the score, the second becomes the member). The
+  preload explicitly sets --key-minimum 1 --key-maximum 2000000, a clean 2,000,000-value domain
+  (double the ~1M element target) so the 10 connections x 100,000 calls each consume an exact
+  200,000-value block (2 positions x 100,000 calls) with no fractional boundary and no overrun into
+  a neighbor''s range (an earlier version without an explicit --key-minimum defaulted it to 0,
+  making the domain 2,000,001-wide and not evenly divisible by 10, and at --key-maximum 1,000,000
+  caused a measured cardinality shortfall to 949,996 via cross-connection collisions). Because each
+  call draws its score then its member from two consecutive positions, scores land on the odd
+  values (1, 3, ..., 1999999) and members land on the even values (2, 4, ..., 2000000) -- verified
+  via sampling (ZSCORE lb 2 -> 1, ZSCORE lb 4 -> 3, ZSCORE lb 1 -> nil, member 1 does not exist).
+  This parity split does not affect ZCOUNT''s correctness: ZCOUNT counts elements with score >= a
+  threshold, not an exact match, so the client phase''s random-start draw (below, scoped to
+  1..1999999 -- the real odd-only score span''s bounding range) works correctly whether or not the
+  drawn integer itself lands on an actual (odd) score value. Encoding: skiplist (1,000,000 elements,
+  exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZCOUNT had zero benchmark
+  coverage before this spec. Mirrors the seek-cost-representative design of the existing
+  zrangebyscore-random-position spec (random start, unbounded tail) rather than a full -inf +inf
+  traversal, since ZCOUNT''s two-endpoint-seek cost -- not a full scan -- is the code path under
+  study.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -27,15 +34,15 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
-      --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-minimum 1 --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 999,996 elements (verified
-    via ZCARD), each with an integer score. Member and score values span the 1..2,000,000
-    domain (score = member - 1) rather than 1..1,000,000, due to the preload's dual __key__
-    draw per ZADD call -- see the workload description for detail.
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements (verified
+    via ZCARD), each with an integer score. Member values are the even integers 2..2,000,000
+    and score values are the odd integers 1..1,999,999 (score = member - 1), a byproduct of
+    the preload's dual __key__ draw per ZADD call -- see the workload description for detail.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcount-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcount-random-position.yml
@@ -1,14 +1,23 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zcount-random-position
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements (integer scores 1..1,000,000) and we query it using ZCOUNT starting from a
-  uniformly random score within that range up to +inf -- so every call seeks a fresh, arbitrary
-  position rather than counting the whole structure. Encoding: skiplist (1,000,000 elements,
-  exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZCOUNT had zero benchmark
-  coverage before this spec. Mirrors the seek-cost-representative design of the existing
-  zrangebyscore-random-position spec (random start, unbounded tail) rather than a full -inf +inf
-  traversal, since ZCOUNT''s two-endpoint-seek cost -- not a full scan -- is the code path under
-  study.'
+  contains ~1M elements (999,996 verified via ZCARD) and we query it using ZCOUNT starting from a
+  uniformly random score within the populated range up to +inf -- so every call seeks a fresh,
+  arbitrary position rather than counting the whole structure. PRELOAD DOMAIN: the ZADD lb __key__
+  __key__ preload command has TWO __key__ occurrences, and memtier''s P key-pattern draws a fresh
+  sequential integer per occurrence (not one shared value) -- so each ZADD call consumes 2 domain
+  positions (one becomes the score, the next becomes the member), and --key-maximum is set to
+  2,000,000 (double the ~1M element target) so 10 connections x 100,000 calls each can consume
+  their full domain share without overrunning into a neighboring connection''s range (which, at
+  key-maximum 1,000,000, caused a measured cardinality shortfall to 949,996 via cross-connection
+  collisions). Member and score values both come from the 1..2,000,000 domain (member = score + 1
+  for every element), not a clean 1..1,000,000 range -- verified via ZRANGE sampling; the client
+  phase''s random-start draw below is scoped to the real score domain (0..1,999,999) accordingly.
+  Encoding: skiplist (999,996 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  Ops/sec. ZCOUNT had zero benchmark coverage before this spec. Mirrors the seek-cost-representative
+  design of the existing zrangebyscore-random-position spec (random start, unbounded tail) rather
+  than a full -inf +inf traversal, since ZCOUNT''s two-endpoint-seek cost -- not a full scan -- is
+  the code path under study.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -18,13 +27,15 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
-      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 999,996 elements (verified
+    via ZCARD), each with an integer score. Member and score values span the 1..2,000,000
+    domain (score = member - 1) rather than 1..1,000,000, due to the preload's dual __key__
+    draw per ZADD call -- see the workload description for detail.
 tested-groups:
 - sorted-set
 tested-commands:
@@ -39,7 +50,7 @@ clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
   arguments: --command="ZCOUNT lb __key__ +inf" --key-minimum 1
-    --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --key-maximum 1999999 --command-key-pattern=R --key-prefix "" --hide-histogram
     --test-time 180 --pipeline 1 -c 1 -t 1
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcount-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcount-random-position.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zcount-random-position
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1M elements (integer scores 1..1,000,000) and we query it using ZCOUNT starting from a
+  uniformly random score within that range up to +inf -- so every call seeks a fresh, arbitrary
+  position rather than counting the whole structure. Encoding: skiplist (1,000,000 elements,
+  exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZCOUNT had zero benchmark
+  coverage before this spec. Mirrors the seek-cost-representative design of the existing
+  zrangebyscore-random-position spec (random start, unbounded tail) rather than a full -inf +inf
+  traversal, since ZCOUNT''s two-endpoint-seek cost -- not a full scan -- is the code path under
+  study.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zcount
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZCOUNT lb __key__ +inf" --key-minimum 1
+    --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded.yml
@@ -1,18 +1,21 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key preloaded with
-  ~1M elements (999,996 verified via ZCARD), issuing a BOUNDED number of ZPOPMIN calls. PRELOAD
+  1,000,000 elements (verified via ZCARD), issuing a BOUNDED number of ZPOPMIN calls. PRELOAD
   DOMAIN: the ZADD lb __key__ __key__ preload has TWO __key__ occurrences, and memtier''s P
   key-pattern draws a fresh sequential integer per occurrence -- so each ZADD call consumes 2
-  domain positions (one becomes the score, the next the member) -- --key-maximum is set to
-  2,000,000 (double the ~1M target) so the 10 connections x 100,000 calls each can consume their
-  full domain share without overrunning into a neighbor''s range (which, at key-maximum 1,000,000,
-  caused a measured shortfall to 949,996 via cross-connection collisions). ZPOPMIN is destructive
-  -- to avoid draining the zset (which would fall onto the empty-key fast-return path and corrupt
-  the measurement, the anti-pattern this suite already avoids for LPOP/RPOP via
+  CONSECUTIVE domain positions (the first becomes the score, the second becomes the member). The
+  preload explicitly sets --key-minimum 1 --key-maximum 2000000, a clean 2,000,000-value domain
+  (double the ~1M element target) so the 10 connections x 100,000 calls each consume an exact
+  200,000-value block (2 positions x 100,000 calls) with no fractional boundary and no overrun into
+  a neighbor''s range (an earlier version without an explicit --key-minimum defaulted it to 0,
+  making the domain 2,000,001-wide and not evenly divisible by 10, and at --key-maximum 1,000,000
+  caused a measured cardinality shortfall to 949,996 via cross-connection collisions). ZPOPMIN is
+  destructive -- to avoid draining the zset (which would fall onto the empty-key fast-return path
+  and corrupt the measurement, the anti-pattern this suite already avoids for LPOP/RPOP via
   memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values), the client phase is capped via -n
-  200000 (t=1, c=1, so -n is the exact total pop count) -- roughly 20% of the preloaded 999,996
-  elements, leaving ~799,996 intact for the full run. Encoding: skiplist (999,996 elements,
+  200000 (t=1, c=1, so -n is the exact total pop count) -- exactly 20% of the preloaded 1,000,000
+  elements, leaving 800,000 intact for the full run. Encoding: skiplist (1,000,000 elements,
   exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZPOPMIN had zero
   non-blocking benchmark coverage before this spec (only the blocking BZPOPMIN variant existed).'
 dbconfig:
@@ -24,15 +27,15 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
-      --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-minimum 1 --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 999,996 elements (verified
-    via ZCARD), each with an integer score. Member and score values span the 1..2,000,000
-    domain (score = member - 1) rather than 1..1,000,000, due to the preload's dual __key__
-    draw per ZADD call -- see the workload description for detail.
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements (verified
+    via ZCARD), each with an integer score. Member values are the even integers 2..2,000,000
+    and score values are the odd integers 1..1,999,999 (score = member - 1), a byproduct of
+    the preload's dual __key__ draw per ZADD call -- see the workload description for detail.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded.yml
@@ -1,14 +1,20 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded
-description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key preloaded with 1M
-  elements (integer scores 1..1,000,000), issuing a BOUNDED number of ZPOPMIN calls. ZPOPMIN is
-  destructive -- to avoid draining the zset (which would fall onto the empty-key fast-return path
-  and corrupt the measurement, the anti-pattern this suite already avoids for LPOP/RPOP via
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key preloaded with
+  ~1M elements (999,996 verified via ZCARD), issuing a BOUNDED number of ZPOPMIN calls. PRELOAD
+  DOMAIN: the ZADD lb __key__ __key__ preload has TWO __key__ occurrences, and memtier''s P
+  key-pattern draws a fresh sequential integer per occurrence -- so each ZADD call consumes 2
+  domain positions (one becomes the score, the next the member) -- --key-maximum is set to
+  2,000,000 (double the ~1M target) so the 10 connections x 100,000 calls each can consume their
+  full domain share without overrunning into a neighbor''s range (which, at key-maximum 1,000,000,
+  caused a measured shortfall to 949,996 via cross-connection collisions). ZPOPMIN is destructive
+  -- to avoid draining the zset (which would fall onto the empty-key fast-return path and corrupt
+  the measurement, the anti-pattern this suite already avoids for LPOP/RPOP via
   memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values), the client phase is capped via -n
-  200000 (t=1, c=1, so -n is the exact total pop count) -- 20% of the preloaded 1M elements,
-  leaving 800,000 intact for the full run. Encoding: skiplist (1,000,000 elements, exceeds
-  zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZPOPMIN had zero non-blocking
-  benchmark coverage before this spec (only the blocking BZPOPMIN variant existed).'
+  200000 (t=1, c=1, so -n is the exact total pop count) -- roughly 20% of the preloaded 999,996
+  elements, leaving ~799,996 intact for the full run. Encoding: skiplist (999,996 elements,
+  exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZPOPMIN had zero
+  non-blocking benchmark coverage before this spec (only the blocking BZPOPMIN variant existed).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -18,13 +24,15 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
-      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 999,996 elements (verified
+    via ZCARD), each with an integer score. Member and score values span the 1..2,000,000
+    domain (score = member - 1) rather than 1..1,000,000, due to the preload's dual __key__
+    draw per ZADD call -- see the workload description for detail.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded.yml
@@ -1,0 +1,46 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zpopmin-bounded
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key preloaded with 1M
+  elements (integer scores 1..1,000,000), issuing a BOUNDED number of ZPOPMIN calls. ZPOPMIN is
+  destructive -- to avoid draining the zset (which would fall onto the empty-key fast-return path
+  and corrupt the measurement, the anti-pattern this suite already avoids for LPOP/RPOP via
+  memtier_benchmark-1Mkeys-list-lpop-rpop-with-10B-values), the client phase is capped via -n
+  200000 (t=1, c=1, so -n is the exact total pop count) -- 20% of the preloaded 1M elements,
+  leaving 800,000 intact for the full run. Encoding: skiplist (1,000,000 elements, exceeds
+  zset-max-listpack-entries 128). Metric of interest: Ops/sec. ZPOPMIN had zero non-blocking
+  benchmark coverage before this spec (only the blocking BZPOPMIN variant existed).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zpopmin
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZPOPMIN lb" --hide-histogram -n 200000 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10.yml
@@ -1,15 +1,23 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements (integer scores 1..1,000,000) and we query it using ZRANDMEMBER key 10 --
+  contains ~1M elements (999,996 verified via ZCARD) and we query it using ZRANDMEMBER key 10 --
   a small positive count, well under the ZRANDMEMBER_SUB_STRATEGY_MUL large-fraction threshold, so
   zrandmemberWithCountCommand takes its cheap CASE 1/2 strategy (repeated single-member random
   picks), not the allocation-heavy CASE 3 auxiliary-dict-build path. This is the common
   "fetch a handful of random members" usage pattern, distinct from the existing 10K-element spec
   (memtier_benchmark-1key-zset-10K-elements-skiplist-zrandmember-count-5K.yml), which deliberately
   exercises the opposite, large-fraction CASE 3 path. Before this spec, nothing above 1M members
-  ran for any zset read command in this suite. Encoding: skiplist (1,000,000 elements, exceeds
-  zset-max-listpack-entries 128). Metric of interest: Ops/sec.'
+  ran for any zset read command in this suite. PRELOAD DOMAIN: the ZADD lb __key__ __key__ preload
+  has TWO __key__ occurrences, and memtier''s P key-pattern draws a fresh sequential integer per
+  occurrence -- so each ZADD call consumes 2 domain positions (one becomes the score, the next the
+  member) -- --key-maximum is set to 2,000,000 (double the ~1M target) so the 10 connections x
+  100,000 calls each can consume their full domain share without overrunning into a neighbor''s
+  range (which, at key-maximum 1,000,000, caused a measured shortfall to 949,996 via
+  cross-connection collisions). Member values span the 1..2,000,000 domain rather than
+  1..1,000,000 (irrelevant to ZRANDMEMBER, which does not reference key ranges). Encoding:
+  skiplist (999,996 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -19,13 +27,15 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
-      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 999,996 elements (verified
+    via ZCARD), each with an integer score. Member and score values span the 1..2,000,000
+    domain (score = member - 1) rather than 1..1,000,000, due to the preload's dual __key__
+    draw per ZADD call -- see the workload description for detail.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10.yml
@@ -1,7 +1,7 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains ~1M elements (999,996 verified via ZCARD) and we query it using ZRANDMEMBER key 10 --
+  contains 1,000,000 elements (verified via ZCARD) and we query it using ZRANDMEMBER key 10 --
   a small positive count, well under the ZRANDMEMBER_SUB_STRATEGY_MUL large-fraction threshold, so
   zrandmemberWithCountCommand takes its cheap CASE 1/2 strategy (repeated single-member random
   picks), not the allocation-heavy CASE 3 auxiliary-dict-build path. This is the common
@@ -10,14 +10,17 @@ description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key.
   exercises the opposite, large-fraction CASE 3 path. Before this spec, nothing above 1M members
   ran for any zset read command in this suite. PRELOAD DOMAIN: the ZADD lb __key__ __key__ preload
   has TWO __key__ occurrences, and memtier''s P key-pattern draws a fresh sequential integer per
-  occurrence -- so each ZADD call consumes 2 domain positions (one becomes the score, the next the
-  member) -- --key-maximum is set to 2,000,000 (double the ~1M target) so the 10 connections x
-  100,000 calls each can consume their full domain share without overrunning into a neighbor''s
-  range (which, at key-maximum 1,000,000, caused a measured shortfall to 949,996 via
-  cross-connection collisions). Member values span the 1..2,000,000 domain rather than
-  1..1,000,000 (irrelevant to ZRANDMEMBER, which does not reference key ranges). Encoding:
-  skiplist (999,996 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
-  Ops/sec.'
+  occurrence -- so each ZADD call consumes 2 CONSECUTIVE domain positions (the first becomes the
+  score, the second becomes the member). The preload explicitly sets --key-minimum 1 --key-maximum
+  2000000, a clean 2,000,000-value domain (double the ~1M target) so the 10 connections x 100,000
+  calls each consume an exact 200,000-value block (2 positions x 100,000 calls) with no fractional
+  boundary and no overrun into a neighbor''s range (an earlier version without an explicit
+  --key-minimum defaulted it to 0, making the domain 2,000,001-wide and not evenly divisible by 10,
+  and at --key-maximum 1,000,000 caused a measured cardinality shortfall to 949,996 via
+  cross-connection collisions). Member values are the even integers 2..2,000,000 (irrelevant to
+  ZRANDMEMBER, which does not reference key ranges and does not use the __key__ substitution at
+  all). Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -27,15 +30,15 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
-      --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-minimum 1 --key-maximum 2000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 999,996 elements (verified
-    via ZCARD), each with an integer score. Member and score values span the 1..2,000,000
-    domain (score = member - 1) rather than 1..1,000,000, due to the preload's dual __key__
-    draw per ZADD call -- see the workload description for detail.
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements (verified
+    via ZCARD), each with an integer score. Member values are the even integers 2..2,000,000
+    and score values are the odd integers 1..1,999,999 (score = member - 1), a byproduct of
+    the preload's dual __key__ draw per ZADD call -- see the workload description for detail.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zrandmember-count-10
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1M elements (integer scores 1..1,000,000) and we query it using ZRANDMEMBER key 10 --
+  a small positive count, well under the ZRANDMEMBER_SUB_STRATEGY_MUL large-fraction threshold, so
+  zrandmemberWithCountCommand takes its cheap CASE 1/2 strategy (repeated single-member random
+  picks), not the allocation-heavy CASE 3 auxiliary-dict-build path. This is the common
+  "fetch a handful of random members" usage pattern, distinct from the existing 10K-element spec
+  (memtier_benchmark-1key-zset-10K-elements-skiplist-zrandmember-count-5K.yml), which deliberately
+  exercises the opposite, large-fraction CASE 3 path. Before this spec, nothing above 1M members
+  ran for any zset read command in this suite. Encoding: skiplist (1,000,000 elements, exceeds
+  zset-max-listpack-entries 128). Metric of interest: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zrandmember
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZRANDMEMBER lb 10" --hide-histogram --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73


### PR DESCRIPTION
## Summary
- ZCOUNT had zero benchmark coverage in this suite.
- ZPOPMIN had zero non-blocking coverage (only the blocking BZPOPMIN variant existed).
- ZRANDMEMBER's only existing spec tops out at 10K elements.

Adds three specs, all on a 1M-element skiplist-encoded zset:
- `zcount-random-position` — mirrors the existing `zrangebyscore-random-position` spec's seek-cost design (random start score, unbounded tail) rather than a full `-inf +inf` traversal.
- `zpopmin-bounded` — destructive command, bounded via `-n` to pop exactly 20% of the preloaded set (200K of 1M), avoiding the drain-to-empty-key anti-pattern; follows the existing `lpop`/`rpop` spec's precedent for bounding destructive commands.
- `zrandmember-count-10` — small positive count (cheap CASE 1/2 path), distinct from the existing 10K-element spec which deliberately exercises the large-fraction CASE 3 allocation-heavy path.

## Test plan
- [x] Self-reviewed against the memtier-benchmark-design checklist (keyspace off-by-one, drain safety, tested-commands match sent verbs, encoding matches description)
- [ ] Fleet dry-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only benchmark suite additions; no Redis server or runtime code changes.
> 
> **Overview**
> Adds **three new memtier benchmark specs** on a single **1M-element, skiplist-encoded** sorted set (`1key-zset-1M-elements-integer`), filling gaps where **ZCOUNT** had no coverage, **ZPOPMIN** had only blocking variants, and **ZRANDMEMBER** at scale was only exercised via the 10K / large-count CASE 3 spec.
> 
> All three share an updated **ZADD preload** (`--key-minimum 1 --key-maximum 2000000`, dual `__key__` per call) so ten connections get exact 200K-value blocks and a full **ZCARD ≈ 1M**, avoiding the cardinality shortfall seen with older `key-maximum 1M` preloads.
> 
> Workload choices: **ZCOUNT** with a random lower score through `+inf` (seek-style, aligned with `zrangebyscore-random-position`); **ZPOPMIN** capped at **`-n 200000`** (20% pops, avoids draining the key); **ZRANDMEMBER lb 10** for the small-count fast path at 1M members.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d91367d5fe96961811ccf820f4c3e308c709c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->