### PR TITLE
Add ZMSCORE 1M-element skiplist spec (100 members/call)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-100-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-100-members.yml
@@ -1,0 +1,57 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zmscore-100-members
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1M elements (integer scores 1..1,000,000) and we query it using ZMSCORE with 100
+  independent random members per call -- well above the dict-prefetch batching chunk size (64), so
+  every call exercises at least one full batched-prefetch chunk plus a partial one. Encoding:
+  skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  Ops/sec. The existing memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members spec is
+  listpack-encoded and targets a different (listpack single-pass) code path entirely -- it never
+  touches the zset companion dict this spec is designed to stress at scale, closer to the
+  dependent-cache-miss regime a large single zset produces.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-integer
+  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
+    each with an integer score.
+tested-groups:
+- sorted-set
+tested-commands:
+- zmscore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
+    --key-minimum 1 --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-100-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-100-members.yml
@@ -1,8 +1,8 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zmscore-100-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains ~1M elements (integer members 0..1,000,000, all with a constant score of 1) and we
-  query it using ZMSCORE with 100 independent random members per call -- well above the
+  contains 1,000,000 elements (integer members 1..1,000,000, all with a constant score of 1) and
+  we query it using ZMSCORE with 100 independent random members per call -- well above the
   dict-prefetch batching chunk size (64), so every call exercises at least one full
   batched-prefetch chunk plus a partial one. FIX: the preload was originally "ZADD lb __key__
   __key__" (two __key__ occurrences: a score-slot draw and a member-slot draw), but memtier''s P
@@ -11,10 +11,12 @@ description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key.
   members landed on odd integers only). A client-side ZMSCORE lookup drawing uniformly from the
   full domain then missed on every even value it drew -- confirmed empirically via a live run:
   memtier itself flagged "ZMSCORE miss rate 50.07% above target 1.00%". Changed the preload to a
-  single __key__ occurrence with a constant score ("ZADD lb 1 __key__") so every domain value in
-  range is a real, queryable member; re-verified empirically with a live run of the actual client
-  command: hit rate ~100% (3 misses/sec against ~289K hits/sec, no miss-rate warning). Encoding:
-  skiplist (~1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  single __key__ occurrence with a constant score ("ZADD lb 1 __key__") and aligned
+  --key-minimum to 1 on both preload and client (the preload previously defaulted to 0, one value
+  outside the client''s [1,1000000] read range, causing a residual ~0.001% miss rate); re-verified
+  empirically with a live run: ZCARD is exactly 1,000,000 and the actual client ZMSCORE command
+  shows a 100% hit rate (0 misses/sec). Encoding:
+  skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
   Ops/sec. The existing memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members spec is
   listpack-encoded and targets a different (listpack single-pass) code path entirely -- it never
   touches the zset companion dict this spec is designed to stress at scale, closer to the
@@ -31,13 +33,13 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --pipeline 50 --command="ZADD lb 1 __key__" --command-key-pattern=P
-      --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+      --key-minimum 1 --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-const-score
-  dataset_description: This dataset contains 1 sorted set key with ~1 million elements
-    (integer members, verified via live ZCARD), each with a constant score of 1.
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements
+    (integer members 1..1,000,000, verified via live ZCARD), each with a constant score of 1.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-100-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-100-members.yml
@@ -1,14 +1,27 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zmscore-100-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements (integer scores 1..1,000,000) and we query it using ZMSCORE with 100
-  independent random members per call -- well above the dict-prefetch batching chunk size (64), so
-  every call exercises at least one full batched-prefetch chunk plus a partial one. Encoding:
-  skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  contains ~1M elements (integer members 0..1,000,000, all with a constant score of 1) and we
+  query it using ZMSCORE with 100 independent random members per call -- well above the
+  dict-prefetch batching chunk size (64), so every call exercises at least one full
+  batched-prefetch chunk plus a partial one. FIX: the preload was originally "ZADD lb __key__
+  __key__" (two __key__ occurrences: a score-slot draw and a member-slot draw), but memtier''s P
+  key-pattern draws an independent sequential value per __key__ occurrence in a command, so
+  scores and members ended up on disjoint parity classes of the domain (verified empirically:
+  members landed on odd integers only). A client-side ZMSCORE lookup drawing uniformly from the
+  full domain then missed on every even value it drew -- confirmed empirically via a live run:
+  memtier itself flagged "ZMSCORE miss rate 50.07% above target 1.00%". Changed the preload to a
+  single __key__ occurrence with a constant score ("ZADD lb 1 __key__") so every domain value in
+  range is a real, queryable member; re-verified empirically with a live run of the actual client
+  command: hit rate ~100% (3 misses/sec against ~289K hits/sec, no miss-rate warning). Encoding:
+  skiplist (~1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
   Ops/sec. The existing memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members spec is
   listpack-encoded and targets a different (listpack single-pass) code path entirely -- it never
   touches the zset companion dict this spec is designed to stress at scale, closer to the
-  dependent-cache-miss regime a large single zset produces.'
+  dependent-cache-miss regime a large single zset produces. A constant score does not weaken the
+  design intent: ZMSCORE cost is dominated by the companion-dict member lookup, not by score
+  value, so identical scores across all members exercise the same code path as distinct ones
+  while giving a reliable, collision-free member domain for the client-side lookups.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -17,14 +30,14 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --pipeline 50 --command="ZADD lb __key__  __key__" --command-key-pattern=P
+    arguments: --pipeline 50 --command="ZADD lb 1 __key__" --command-key-pattern=P
       --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
   resources:
     requests:
       memory: 1g
-  dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_name: 1key-zset-1M-elements-const-score
+  dataset_description: This dataset contains 1 sorted set key with ~1 million elements
+    (integer members, verified via live ZCARD), each with a constant score of 1.
 tested-groups:
 - sorted-set
 tested-commands:


### PR DESCRIPTION
## Summary
- The existing `memtier_benchmark-1Mkeys-zset-128-members-zmscore-50-members` spec is listpack-encoded and targets the ZMSCORE listpack single-pass path — it never exercises the zset companion dict at all.
- This spec uses a single 1M-element (skiplist-encoded) zset with 100 members per ZMSCORE call, well above the dict-prefetch batching chunk size (64), so every call exercises at least one full batched chunk plus a partial one.

## Test plan
- [x] Self-reviewed: 100 `__key__` tokens confirmed in the client command via grep, correct chunk-boundary coverage (64+36)
- [ ] Fleet dry-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a benchmark test-suite definition; no Redis server or runtime code changes.
> 
> **Overview**
> Adds **`memtier_benchmark-1key-zset-1M-elements-zmscore-100-members`**, a new fleet benchmark that preloads one skiplist-encoded sorted set with **1M members** and runs **`ZMSCORE` with 100 random members per call** (past the 64-member dict-prefetch batch size) to stress the **companion-dict** path, which the existing listpack **`1Mkeys` / 50-member** `ZMSCORE` spec does not cover.
> 
> The spec documents and encodes preload/client alignment so lookups hit reliably: **`ZADD lb 1 __key__`** with **`--key-minimum 1`** on preload and client (avoiding the broken dual-`__key__` preload pattern that caused ~50% misses). It targets **oss-standalone**, gcc/dockerhub build variants, **ops/sec**, priority **73**, and checks **`keyspacelen: 1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731df795c46db593c32c1d151aaaec0cd56fe41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->