### PR TITLE
fix(test-suites): correct zset cardinality claims and two independent hit-rate bugs (#508)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zrank-1M-elements-pipeline-1.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zrank-1M-elements-pipeline-1.yml
@@ -1,8 +1,13 @@
 version: 0.4
 name: memtier_benchmark-1key-zrank-1M-elements-pipeline-1
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements and we query it using ZRANK. Encoding: skiplist+hashtable (1,000,000
-  elements, exceeds zset-max-listpack-entries 128).'
+  contains 949,996 elements (verified via ZCARD), not the nominal 1,000,000 -- the shared
+  preload command (ZADD lb __key__ __key__) has two __key__ occurrences, and memtier''s P
+  key-pattern draws a fresh sequential value per occurrence rather than one shared value, so
+  cross-connection wraparound leaves the set ~5% short of the nominal count (see #508). Query
+  member lookups (ZRANK) still hit real, densely-packed members at a ~95%+ rate since the
+  populated range still spans close to the full nominal domain. Encoding: skiplist+hashtable
+  (949,996 elements, exceeds zset-max-listpack-entries 128).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -17,8 +22,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 949,996 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
@@ -1,9 +1,9 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  is pre-loaded with a nominal 1M elements (integer scores drawn from the 1..1,000,000 range --
-  the actual populated count is somewhat lower than 1M due to a separate, pre-existing preload
-  quirk tracked in #508) then we ZADD members named newmember__key__ with a score, where the
+  is pre-loaded with 949,996 elements (verified via ZCARD, not the nominal 1,000,000 -- the
+  shared preload has a dual-__key__-draw mechanic documented in #508 and its fix) then we ZADD
+  members named newmember__key__ with a score, where the
   member-name suffix and the score are each drawn independently and uniformly at random from that
   SAME 1..1,000,000 range -- memtier evaluates every __key__ occurrence in a command as its own
   independent draw, not one shared value, so the score is not simply "the member''s number" (the
@@ -34,8 +34,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 949,996 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zadd-new-random-members.yml
@@ -16,7 +16,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key.
   "new member" insert as the name states. The run is bounded to -n 300000 rather than an unbounded
   --test-time so revisits stay infrequent (empirically verified on the smaller 250-element sibling
   spec at an equivalent domain fraction: 90% of ops grew the zset). Encoding: skiplist+hashtable /
-  B+tree (nominal 1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  B+tree (949,996 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
   Ops/sec. Designed to stress the score-ordered structure''s top-down descent/insert-position
   lookup, unlike the existing zincrby/zrank specs whose update-in-place and hash-indexed-lookup
   paths bypass it.'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcard-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zcard-pipeline-10.yml
@@ -1,8 +1,12 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zcard-pipeline-10
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements in it and we query it using ZCARD. Encoding: skiplist+hashtable (1,000,000
-  elements, exceeds zset-max-listpack-entries 128).'
+  contains 998,950 elements (verified via ZCARD), not the nominal 1,000,000 -- the shared preload
+  command (ZADD lb __key__ __key__) has two __key__ occurrences, and memtier''s P key-pattern
+  draws a fresh sequential value per occurrence rather than one shared value, leaving the set
+  slightly short of the nominal count (see #508). ZCARD itself does not reference the key domain
+  so it is unaffected functionally, only the "1M" claim was inaccurate. Encoding: skiplist+hashtable
+  (998,950 elements, exceeds zset-max-listpack-entries 128).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -17,8 +21,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 998,950 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position.yml
@@ -1,12 +1,12 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zrangebyscore-random-position
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains a nominal 1M elements (integer scores drawn from the 1..1,000,000 range -- the actual
-  populated count and score distribution evenness are somewhat affected by a separate, pre-existing
-  preload quirk tracked in #508) and we query it using ZRANGEBYSCORE starting from a score drawn
-  uniformly at random from that same nominal range up to +inf, LIMIT 0 10 -- so every call seeks a
-  fresh, arbitrary position rather than always starting from an edge. Encoding: skiplist+hashtable
-  / B+tree (nominal 1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of interest:
+  contains 949,996 elements (verified via ZCARD, not the nominal 1,000,000 -- the shared preload
+  has a dual-__key__-draw mechanic documented in #508 and its fix) and we query it using
+  ZRANGEBYSCORE starting from a score drawn uniformly at random from the same nominal 1..1,000,000
+  range up to +inf, LIMIT 0 10 -- so every call seeks a fresh, arbitrary position rather than
+  always starting from an edge. Encoding: skiplist+hashtable / B+tree (949,996 elements, exceeds
+  zset-max-listpack-entries 128). Metric of interest:
   Ops/sec. Designed to stress the score-ordered structure''s top-down seek-to-position path,
   complementing the existing zrangebyscore-all-elements specs (which only cover a 100-element
   listpack-encoded set) and the zrangestore specs (which copy a contiguous range and mostly hit an
@@ -25,8 +25,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 949,996 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zremrangebyscore-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zremrangebyscore-pipeline-10.yml
@@ -1,9 +1,24 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zremrangebyscore-pipeline-10
-description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements in it and we query it using ZREVRANGE with a range of 5 elements. This
-  benchmarks helps assessing: https://github.com/redis/redis/issues/10310 Encoding:
-  skiplist+hashtable (1,000,000 elements, exceeds zset-max-listpack-entries 128).'
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key preloaded with
+  998,950 elements (verified via ZCARD; the ~5% shortfall vs. the nominal 1,000,000 is the same
+  dual-__key__ preload mechanic tracked in #508) and we remove ranges from it using
+  ZREMRANGEBYSCORE. FIX (more severe than the cardinality issue above): the client command
+  previously omitted BOTH --key-maximum and --key-prefix. Without --key-prefix, memtier defaulted
+  to prefixing substituted values with "memtier-" (e.g. "memtier-138344"), so every
+  ZREMRANGEBYSCORE call sent non-numeric score bounds -- confirmed live via MONITOR and 0 net
+  ZCARD change across hundreds of thousands of calls: this spec has never actually removed a
+  single real element, only measured Redis''s error-reply latency for an invalid-float score
+  argument. Added --key-maximum 1000000 --key-prefix "" to send real numeric bounds within the
+  populated range. CAVEAT (documented, not fully resolved -- see follow-up issue): because both
+  range endpoints are still drawn independently and uniformly across the full 0..1,000,000 span,
+  a single call has a high chance of spanning a huge fraction of the domain -- verified live: the
+  set drops to <1% of its original size within the first ~100 calls, after which the remainder of
+  the run measures the fast empty-range no-op path, not steady-state removal cost. A proper fix
+  needs a producer that continuously refills the key (the multi-clientconfig pattern used by the
+  BLPOP/BZPOPMIN/XREADGROUP blocking suites), which is a larger redesign tracked separately.
+  Encoding: skiplist+hashtable (998,950 elements at test start, exceeds zset-max-listpack-entries
+  128).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -18,8 +33,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 998,950 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:
@@ -33,8 +48,8 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="ZREMRANGEBYSCORE lb __key__ __key__"  --hide-histogram --test-time
-    120 --pipeline 10
+  arguments: --command="ZREMRANGEBYSCORE lb __key__ __key__" --key-maximum 1000000 --key-prefix
+    "" --hide-histogram --test-time 120 --pipeline 10
   resources:
     requests:
       cpus: '4'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrevrange-5-elements.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrevrange-5-elements.yml
@@ -1,9 +1,13 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zrevrange-5-elements
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements in it and we query it using ZREVRANGE with a range of 5 elements. This
-  benchmarks helps assessing: https://github.com/redis/redis/issues/10310 Encoding:
-  skiplist+hashtable (1,000,000 elements, exceeds zset-max-listpack-entries 128).'
+  contains 998,950 elements (verified via ZCARD), not the nominal 1,000,000 -- the shared preload
+  command (ZADD lb __key__ __key__) has two __key__ occurrences, and memtier''s P key-pattern
+  draws a fresh sequential value per occurrence rather than one shared value, leaving the set
+  slightly short of the nominal count (see #508). ZREVRANGE is index-based (not key-domain-based)
+  so it is unaffected functionally, only the "1M" claim was inaccurate. This benchmarks helps
+  assessing: https://github.com/redis/redis/issues/10310 Encoding: skiplist+hashtable (998,950
+  elements, exceeds zset-max-listpack-entries 128).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -18,8 +22,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 998,950 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrevrange-withscores-5-elements-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zrevrange-withscores-5-elements-pipeline-10.yml
@@ -1,9 +1,13 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zrevrange-withscores-5-elements-pipeline-10
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements in it and we query it using ZREVRANGE with a range of 5 elements. This
-  benchmarks helps assessing: https://github.com/redis/redis/issues/10310 Encoding:
-  skiplist+hashtable (1,000,000 elements, exceeds zset-max-listpack-entries 128).'
+  contains 998,950 elements (verified via ZCARD), not the nominal 1,000,000 -- the shared preload
+  command (ZADD lb __key__ __key__) has two __key__ occurrences, and memtier''s P key-pattern
+  draws a fresh sequential value per occurrence rather than one shared value, leaving the set
+  slightly short of the nominal count (see #508). ZREVRANGE is index-based (not key-domain-based)
+  so it is unaffected functionally, only the "1M" claim was inaccurate. This benchmarks helps
+  assessing: https://github.com/redis/redis/issues/10310 Encoding: skiplist+hashtable (998,950
+  elements, exceeds zset-max-listpack-entries 128).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -18,8 +22,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 998,950 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zscore-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zscore-pipeline-10.yml
@@ -1,8 +1,15 @@
 version: 0.4
 name: memtier_benchmark-1key-zset-1M-elements-zscore-pipeline-10
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
-  contains 1M elements in it and we query it using ZCARD. Encoding: skiplist+hashtable (1,000,000
-  elements, exceeds zset-max-listpack-entries 128).'
+  contains 998,950 elements (verified via ZCARD), not the nominal 1,000,000 -- the shared preload
+  command (ZADD lb __key__ __key__) has two __key__ occurrences, and memtier''s P key-pattern
+  draws a fresh sequential value per occurrence rather than one shared value, leaving the set
+  slightly short of the nominal count (see #508). We query it using ZSCORE. FIX: the client
+  command previously omitted --key-maximum, so memtier defaulted to its own 10,000,000 key range
+  -- with real members only populated up to ~1,000,000, ~90% of ZSCORE calls missed entirely
+  (confirmed live: 89.72% miss rate). Added --key-maximum 1000000 to match the real populated
+  range; re-verified live at 99.87% hit rate (0.13% residual miss from the ZCARD shortfall above).
+  Encoding: skiplist+hashtable (998,950 elements, exceeds zset-max-listpack-entries 128).'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -17,8 +24,8 @@ dbconfig:
     requests:
       memory: 1g
   dataset_name: 1key-zset-1M-elements-integer
-  dataset_description: This dataset contains 1 sorted set key with 1 million elements,
-    each with an integer score.
+  dataset_description: This dataset contains 1 sorted set key with 998,950 elements (verified
+    via ZCARD, not the nominal 1,000,000 -- see #508), each with an integer score.
 tested-groups:
 - sorted-set
 tested-commands:
@@ -32,8 +39,8 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="zscore lb __key__" --key-prefix "" --hide-histogram --test-time
-    180 --pipeline 10
+  arguments: --command="zscore lb __key__" --key-maximum 1000000 --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 10
   resources:
     requests:
       cpus: '4'


### PR DESCRIPTION
## Summary

Fixes #508 by correcting the `1 million elements` claim across 8 specs sharing the `1key-zset-1M-elements-integer` dataset (preload: `ZADD lb __key__  __key__`, P key-pattern) to the true, empirically-verified cardinality.

The preload's two `__key__` occurrences are each independently drawn by memtier's P pattern rather than sharing one value, so real cardinality falls short of the nominal 1,000,000 by an amount that depends on each spec's concurrency shape (verified live per shape):

| Shape | Files | Real cardinality |
|---|---|---|
| `-n 100000 -t 10 -c 1` | zrank, zadd-new-random-members, zrangebyscore-random-position | 949,996 |
| `-t 4 -c 100` (default `-n`=10000) | zscore, zremrangebyscore, zcard, zrevrange x2 | 998,950 |
| `-n 1000000 -t 1 -c 1` | zrevrank, zincrby | 1,000,000 (accurate as-is, unchanged) |

**Why description-only, not a preload fix:** a domain-widening fix (the approach used for the still-unmerged #512/#513 specs, which had no shipped history) would regress these specs' hit rate from ~95%+ down to ~50%, since real members would become a sparse even-only sub-range that memtier's client-side `R` pattern can't selectively target. Correcting the documentation to match reality is the safe fix here; #508's own text flagged this needs design thought rather than a copy-paste.

## Two more severe bugs found on adjacent files

While verifying #508's claim empirically, found two independent, more severe defects on files in the same dataset family:

- **`zscore-pipeline-10`**: client omitted `--key-maximum`, defaulting to memtier's own `10,000,000` range against a ~1M-element dataset. Confirmed live: **89.72% miss rate**. Fixed by adding `--key-maximum 1000000`; re-verified at 99.87% hit rate.
- **`zremrangebyscore-pipeline-10`**: client omitted **both** `--key-maximum` and `--key-prefix`. Without `--key-prefix`, memtier defaults substituted values to a `"memtier-"` prefix (e.g. `"memtier-138344"`), so every call sent non-numeric score bounds. Confirmed live via `MONITOR` and zero net `ZCARD` change across hundreds of thousands of calls: **this spec has never removed a single real element** -- it only measured Redis's invalid-float error-reply latency. Fixed both flags. Documented in the description that, once functional, the wide-range random-draw design still drains the set to <1% within ~100 calls (verified live), so most of the run measures the empty-range fast path -- a proper steady-state fix needs a producer/refill design (tracked as a follow-up, out of scope here).

## Verification

- `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff`: exit 0
- `pytest utils/tests/test_spec.py utils/tests/test_scope.py`: 27/27 passed
- `black --check`: clean
- All cardinality/hit-rate numbers above verified live against a real `redis-server` + `redislabs/memtier_benchmark:edge`, not derived from reasoning alone (multiple earlier assumptions in this investigation turned out wrong empirically).

Fixes #508

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> YAML-only, but fixing ZSCORE and ZREMRANGEBYSCORE client args changes real benchmark workloads and will shift reported performance versus prior broken runs.
> 
> **Overview**
> Updates **eight** memtier specs on the `1key-zset-1M-elements-integer` dataset so descriptions and `dataset_description` state **ZCARD-verified** sizes (~949,996 or ~998,950) instead of a nominal 1M, and document the shared preload quirk where two `__key__` tokens under pattern `P` get independent draws ([#508](https://github.com/redis/redis/issues/508)).
> 
> **`zscore-pipeline-10`** now passes `--key-maximum 1000000` on the client so lookups target the loaded score range (~90% misses before).
> 
> **`zremrangebyscore-pipeline-10`** adds `--key-maximum 1000000` and `--key-prefix ""` so score bounds are numeric (previously default `memtier-` prefixes made every call an invalid-score error with no removals); the description also notes the spec still drains the set quickly once removals work, with steady-state refill left as follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d8894a335f3c260dc12caba49d529b833048f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->