### PR TITLE
fix(test-suites): correct off-by-one in shared 10K-element list preload (#509)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lindex-integer.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lindex-integer.yml
@@ -12,7 +12,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH intlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH intlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "" --command-key-pattern S -c 1 -t 1
       --pipeline 50
   resources:
@@ -20,7 +20,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-integer
-  dataset_description: This dataset contains 1 list key with 10,000 integer elements.
+  dataset_description: This dataset contains 1 list key with 10,000 integer elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lindex-string-pipeline-10.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lindex-string-pipeline-10.yml
@@ -12,7 +12,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "hello" --command-key-pattern S -c 1
       -t 1 --pipeline 50
   resources:
@@ -20,7 +20,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-string
-  dataset_description: This dataset contains 1 list key with 10,000 string elements.
+  dataset_description: This dataset contains 1 list key with 10,000 string elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lindex-string.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lindex-string.yml
@@ -12,7 +12,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "hello" --command-key-pattern S -c 1
       -t 1 --pipeline 50
   resources:
@@ -20,7 +20,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-string
-  dataset_description: This dataset contains 1 list key with 10,000 string elements.
+  dataset_description: This dataset contains 1 list key with 10,000 string elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-linsert-lrem-integer.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-linsert-lrem-integer.yml
@@ -13,7 +13,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH intlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH intlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "" --command-key-pattern S -c 1 -t 1
       --pipeline 50
   resources:
@@ -21,7 +21,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-integer
-  dataset_description: This dataset contains 1 list key with 10,000 integer elements.
+  dataset_description: This dataset contains 1 list key with 10,000 integer elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-linsert-lrem-string.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-linsert-lrem-string.yml
@@ -13,7 +13,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "hello" --command-key-pattern S -c 1
       -t 1 --pipeline 50
   resources:
@@ -21,7 +21,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-string
-  dataset_description: This dataset contains 1 list key with 10,000 string elements.
+  dataset_description: This dataset contains 1 list key with 10,000 string elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lpos-integer.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lpos-integer.yml
@@ -12,7 +12,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH intlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH intlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "" --command-key-pattern S -c 1 -t 1
       --pipeline 50
   resources:
@@ -20,7 +20,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-integer
-  dataset_description: This dataset contains 1 list key with 10,000 integer elements.
+  dataset_description: This dataset contains 1 list key with 10,000 integer elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lpos-string.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lpos-string.yml
@@ -12,7 +12,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "hello" --command-key-pattern S -c 1
       -t 1 --pipeline 50
   resources:
@@ -20,7 +20,7 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-string
-  dataset_description: This dataset contains 1 list key with 10,000 string elements.
+  dataset_description: This dataset contains 1 list key with 10,000 string elements (verified via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lset-quicklist.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lset-quicklist.yml
@@ -1,17 +1,14 @@
 version: 0.4
 name: memtier_benchmark-1key-list-10K-elements-lset-quicklist
-description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST contains 9999
-  string elements in it (quicklist encoded, spanning multiple listpack nodes under
-  list-max-listpack-size -2) and we replace an element in the middle (index 5000) using LSET with a
-  small value. This exercises the SHRINKING branch of the per-call encoding-conversion check
-  (listTypeTryConversionRaw in t_list.c) - on a quicklist the shrink-check runs on every LSET even
-  though the list stays quicklist. Encoding: quicklist (9999 elements). The preload arguments are
-  the ones shared by the whole memtier_benchmark-1key-list-10K-elements-* family (dataset
-  1key-list-10K-elements-string), and with -n allkeys memtier issues key-maximum minus key-minimum
-  requests, so the list holds elements hello1..hello9999 - 9999 rather than a literal 10000. The
-  10K in the test name is the family/dataset label; the element count is kept identical to the
-  sibling LINDEX / LPOS / LINSERT-LREM specs so they all describe the same dataset, and 9999 is
-  far above the quicklist conversion threshold either way.'
+description: 'Runs memtier_benchmark, for a keyspace length of 1 LIST key. The LIST contains
+  10,000 string elements (hello1..hello10000, verified via LLEN) and we replace an element in the
+  middle (index 5000) using LSET with a small value. This exercises the SHRINKING branch of the
+  per-call encoding-conversion check (listTypeTryConversionRaw in t_list.c) - on a quicklist the
+  shrink-check runs on every LSET even though the list stays quicklist. Encoding: quicklist
+  (10,000 elements). The preload arguments are the ones shared by the whole
+  memtier_benchmark-1key-list-10K-elements-* family (dataset 1key-list-10K-elements-string), which
+  uses --key-maximum 10001 with -n allkeys since the S key-pattern stops one short of
+  --key-maximum -- see #509.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -20,7 +17,7 @@ dbconfig:
   preload_tool:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
-    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10000
+    arguments: --hide-histogram --command "RPUSH strlist __key__" --key-maximum 10001
       --key-minimum 1 -n allkeys --key-prefix "hello" --command-key-pattern S -c 1
       -t 1 --pipeline 50
   resources:
@@ -28,7 +25,9 @@ dbconfig:
       cpus: '2'
       memory: 1g
   dataset_name: 1key-list-10K-elements-string
-  dataset_description: This dataset contains 1 list key with 9999 string elements (hello1..hello9999).
+  dataset_description: This dataset contains 1 list key with 10,000 string elements (verified
+    via LLEN; preload uses --key-maximum 10001 with -n allkeys, since the S key-pattern stops
+    one short of --key-maximum -- see #509).
 tested-groups:
 - list
 tested-commands:


### PR DESCRIPTION
## Summary

Fixes #509. The `1key-list-10K-elements-string`/`-integer` family's shared preload (`RPUSH strlist/intlist __key__`, S key-pattern, `--key-maximum 10000 --key-minimum 1 -n allkeys`) actually populates **9,999** elements, not 10,000 as every sibling spec's `dataset_description` claimed. The S (sequential) key-pattern with `-n allkeys` issues `key-maximum minus key-minimum` requests, stopping one short of `key-maximum`.

## Verification

Verified live against a real `redis-server` + `redislabs/memtier_benchmark:edge`:
- `--key-maximum 10000` → `LLEN` = 9999 (`hello1..hello9999`)
- `--key-maximum 10001` → `LLEN` = exactly 10000 (`hello1..hello10000`)

Unlike the #508 zset fix, this carries **no hit-rate-regression risk**: every client command in this family references a fixed literal index/value (`5000`, `hello5000`, `LSET ... 5000 x`, etc.) rather than a domain-derived `__key__` draw, so widening `--key-maximum` by one is a pure, safe cardinality correction.

## Scope

Fixes all 7 specs #509 lists, plus an 8th family member (`lset-quicklist`, added by #441) that shares the same preload and had already documented the true 9,999 count -- updated to 10,000 to stay consistent with the rest of the family now that the underlying preload is fixed.

- `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff`: exit 0
- `pytest utils/tests/test_spec.py utils/tests/test_scope.py`: 27/27 passed
- `black --check`: clean

Fixes #509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark YAML preload and documentation only; client commands use fixed indices, so risk is limited to slightly larger preloaded lists in CI.
> 
> **Overview**
> Fixes **#509** by correcting shared memtier preload for the `memtier_benchmark-1key-list-10K-elements-*` family so lists actually hold **10,000** elements instead of **9,999**.
> 
> Preload `--key-maximum` is bumped from **10000** to **10001** on eight YAML specs (integer/string variants for LINDEX, LPOS, LINSERT/LREM, pipeline LINDEX, and `lset-quicklist`). With `-n allkeys` and sequential (`S`) key-pattern, memtier issues `key-maximum − key-minimum` RPUSHes, so the old cap stopped one element short.
> 
> **`dataset_description`** (and the **`lset-quicklist`** top-level description) now state the true cardinality and point at **#509** for the preload quirk. Benchmark client commands stay on fixed middle indices/values, so this is a dataset-size fix only—not a workload semantics change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7100da473a4f4497d2be1f3e022963a714837208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->