### PR TITLE
fix(test-suites): rename mismatched dataset_name on 7 hash-expire specs (#510)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hexpire-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hexpire-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   Encoding: listpack (50 fields x 10B values, below hash-max-listpack-entries 128 and
   hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hexpireat-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hexpireat-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   expire second is 2038, January 1 ). Encoding: listpack (50 fields x 10B values, below
   hash-max-listpack-entries 128 and hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hgetex-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hgetex-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   Encoding: listpack (50 fields x 10B values, below hash-max-listpack-entries 128 and
   hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hgetex-persist-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hgetex-persist-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   Encoding: listpack (50 fields x 10B values, below hash-max-listpack-entries 128 and
   hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hpexpire-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hpexpire-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   Encoding: listpack (50 fields x 10B values, below hash-max-listpack-entries 128 and
   hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hpexpireat-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-hpexpireat-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   expire ms is 2038, January 1 ). Encoding: listpack (50 fields x 10B values, below
   hash-max-listpack-entries 128 and hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-htll-50-fields-10B-values.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-100Kkeys-hash-htll-50-fields-10B-values.yml
@@ -5,7 +5,7 @@ description: 'Runs memtier_benchmark, for a keyspace length of 100K keys pre-loa
   Encoding: listpack (50 fields x 10B values, below hash-max-listpack-entries 128 and
   hash-max-listpack-value 64).'
 dbconfig:
-  dataset_name: 1Mkeys-hash-50-fields-10B-size
+  dataset_name: 100Kkeys-hash-50-fields-10B-size
   configuration-parameters:
     save: '""'
   check:


### PR DESCRIPTION
## Summary

Fixes #510. Seven `100Kkeys-hash-*` specs (hexpire, hexpireat, hpexpire, hpexpireat, htll, hgetex, hgetex-persist) declared `dataset_name: 1Mkeys-hash-50-fields-10B-size` -- the same `dataset_name` used by genuinely different, much larger 1M-key specs.

## Verification

Confirmed via `check.keyspacelen` on every file:
- The 7 mismatched specs: `keyspacelen: 100000` (100K keys, `-n allkeys -c 1 -t 1`)
- The true owners of the shared name: `memtier_benchmark-1Mkeys-hash-hgetall-50-fields-10B-values.yml` + its `-template.yml` sibling (fixed in #489), plus `hkeys-50-fields-with-10B-values-with-expiration-pipeline-10.yml` -- all three verified at `keyspacelen: 1000000` (`-n 5000 -c 50 -t 4` or `-n allkeys` against a genuine 1M-key range)

`dataset_name` drives the runner's memory-comparison-mode preload dedup, so two families sharing a name while actually seeding different-sized datasets could silently reuse the wrong preloaded data depending on run order.

## Fix

Pure metadata rename -- no preload, client, or measured-command behavior change. Renamed `dataset_name` to `100Kkeys-hash-50-fields-10B-size` on all 7 mismatched specs, matching the existing single-owner `100Kkeys-hash-50-fields-100B-size` naming convention already used elsewhere in the suite.

- `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff`: exit 0
- `pytest utils/tests/test_spec.py utils/tests/test_scope.py`: 27/27 passed
- `black --check`: clean
- Confirmed the old `dataset_name` now has exactly 3 remaining owners, all independently verified as true 1M-key datasets

Fixes #510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only YAML renames with no changes to preload or benchmark commands; reduces risk of incorrect preload reuse in memory-comparison runs.
> 
> **Overview**
> Seven **100K-key** hash benchmark specs (HEXPIRE, HEXPIREAT, HPEXPIRE, HPEXPIREAT, HTTL, HGETEX, HGETEX PERSIST) incorrectly used `dataset_name: 1Mkeys-hash-50-fields-10B-size`, the same identifier as true **1M-key** suites.
> 
> This PR renames `dataset_name` to **`100Kkeys-hash-50-fields-10B-size`** in each of those YAML files so the label matches `keyspacelen: 100000` and aligns with other 100K hash naming. Preload and client commands are unchanged.
> 
> That matters because the runner **deduplicates preloads by `dataset_name`** in memory-comparison mode; a shared name across different keyspace sizes could skip or reuse the wrong dataset depending on run order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31888cf7b29e4b971b49120138f98dd18109a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->