### PR TITLE
Add ZADD listpack-overflow-to-BTREE conversion spec

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-200Kkeys-zset-listpack-overflow-to-btree.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-200Kkeys-zset-listpack-overflow-to-btree.yml
@@ -1,0 +1,55 @@
+version: 0.4
+name: memtier_benchmark-200Kkeys-zset-listpack-overflow-to-btree
+description: 'Runs memtier_benchmark over 200,000 independent SORTED SET keys, each preloaded
+  with exactly 8 listpack-encoded members (zset-max-listpack-entries set to 8), then each
+  measured ZADD adds a 9th member to its own key -- crossing the threshold and triggering
+  exactly one zsetConvertAndExpand() LISTPACK->BTREE conversion per op. Isolates the
+  conversion cost as the dominant per-op cost (unlike a single large key growing past the
+  threshold once across hundreds of thousands of unrelated ops, where the one-time
+  conversion is diluted to invisibility in the Ops/sec metric). This is the closest
+  memtier-expressible proxy for the LISTPACK->BTREE conversion cost paid during RDB load of
+  a listpack-encoded zset that exceeds the loading instance''s zset-max-listpack-entries
+  (ZADD''s own listpack-overflow path and RDB listpack-promotion both call the exact same
+  zsetConvertAndExpand() code, so the per-conversion cost measured here transfers directly)
+  -- an actual RDB-load-time benchmark is not expressible in this memtier-command-throughput
+  framework, since RDB load happens once at server startup rather than as a repeatable
+  client-issued command. Encoding: listpack (8 elements, at zset-max-listpack-entries) ->
+  btree (9 elements, past it). Metric of interest: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+    zset-max-listpack-entries: '8'
+  check:
+    keyspacelen: 200000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command="ZADD zset:__key__ 1 m1 2 m2 3 m3 4 m4 5 m5 6 m6 7 m7 8 m8"
+      --command-key-pattern=P --key-minimum 1 --key-maximum 200000 --key-prefix ""
+      -n 200000 --hide-histogram -t 10 -c 1 --pipeline 50
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 200Kkeys-zset-8-elements-listpack
+  dataset_description: 200,000 sorted-set keys, each listpack-encoded with 8 integer-scored
+    members (m1..m8), exactly at zset-max-listpack-entries 8.
+tested-groups:
+- sorted-set
+tested-commands:
+- zadd
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZADD zset:__key__ 9 m9" --command-key-pattern=P --key-minimum 1
+    --key-maximum 200000 --key-prefix "" --hide-histogram -n 200000 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 74


### PR DESCRIPTION
## Summary
- Adds `memtier_benchmark-200Kkeys-zset-listpack-overflow-to-btree`, exercising `zsetConvertAndExpand()`'s LISTPACK->BTREE conversion path in isolation (200,000 independent zset keys, each preloaded with 8 listpack-encoded members at `zset-max-listpack-entries`, with each measured ZADD adding a 9th member that crosses the threshold and triggers exactly one conversion per op)
- No existing spec isolates this cost: existing zadd specs grow a single key past the threshold once across hundreds of thousands of unrelated ops, diluting the one-time conversion cost to invisibility in the aggregate Ops/sec metric

## Test plan
- [x] Validated locally via `--dry-run` (matches 1 test, 1 topology)
- [x] YAML parses cleanly with `yaml.safe_load`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only YAML addition with no runtime or product code changes.
> 
> **Overview**
> Adds a new memtier benchmark suite **`memtier_benchmark-200Kkeys-zset-listpack-overflow-to-btree`** so CI can track **ZADD** throughput when every op forces **listpack → BTREE** via `zsetConvertAndExpand()`.
> 
> The suite sets **`zset-max-listpack-entries: 8`**, preloads **200,000** distinct zset keys with **8** members each, then measures **`ZADD … 9 m9`** with **pipeline 1** so each measured command adds a 9th member on its own key and triggers **one conversion per op**—making conversion cost visible in **Ops/sec** instead of being drowned out by specs that only convert a single key once.
> 
> Runs on **oss-standalone** with the usual **gcc** and **dockerhub** build variants; primary metric is **Ops/sec** (priority **74**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173ac4412160b2c6f4263ae37ed26a940a485a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->