### PR TITLE
fix: use timezone-aware UTC epoch instead of naive utcnow().timestamp()

### DIFF
--- a/redis_benchmarks_specification/__cli__/admin.py
+++ b/redis_benchmarks_specification/__cli__/admin.py
@@ -435,7 +435,7 @@ def admin_queues_command(conn, args):
         zset_key = platforms[platform_name]
 
         # Get recent benchmark runs (last 7 days)
-        now_ms = int(datetime.datetime.utcnow().timestamp() * 1000)
+        now_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
         week_ago_ms = now_ms - (7 * 24 * 60 * 60 * 1000)
         stream_ids = conn.zrangebyscore(zset_key, week_ago_ms, "+inf", withscores=True)
 
@@ -1227,7 +1227,7 @@ def admin_work_command(conn, args):
 
     # 2. Also collect from active queues (streams that have test lists but may not be in pending)
     platform_keys = conn.keys("ci.benchmarks.redis/ci/redis/redis:benchmarks:*:zset")
-    now_ms = int(datetime.datetime.utcnow().timestamp() * 1000)
+    now_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
     day_ago_ms = now_ms - (24 * 60 * 60 * 1000)
 
     for pk in platform_keys:
@@ -1513,7 +1513,7 @@ def admin_health_command(conn, args):
         started_at_str = fields.get("started_at", "0")
 
         # Calculate age of heartbeat and uptime
-        now_epoch = int(datetime.datetime.utcnow().timestamp())
+        now_epoch = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
         try:
             ts = int(ts_str)
             age_secs = now_epoch - ts

--- a/redis_benchmarks_specification/__compare__/compare.py
+++ b/redis_benchmarks_specification/__compare__/compare.py
@@ -1053,9 +1053,11 @@ def compute_env_comparison_table(
     if to_date is None:
         to_date = START_TIME_NOW_UTC
     if from_ts_ms is None:
-        from_ts_ms = int(from_date.timestamp() * 1000)
+        from_ts_ms = int(
+            from_date.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000
+        )
     if to_ts_ms is None:
-        to_ts_ms = int(to_date.timestamp() * 1000)
+        to_ts_ms = int(to_date.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
 
     # Extract test names from the test parameter
     test_names = []
@@ -1357,9 +1359,11 @@ def compute_regression_table(
     if to_date is None:
         to_date = START_TIME_NOW_UTC
     if from_ts_ms is None:
-        from_ts_ms = int(from_date.timestamp() * 1000)
+        from_ts_ms = int(
+            from_date.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000
+        )
     if to_ts_ms is None:
-        to_ts_ms = int(to_date.timestamp() * 1000)
+        to_ts_ms = int(to_date.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
     from_human_str = humanize.naturaltime(
         dt.datetime.utcfromtimestamp(from_ts_ms / 1000)
     )

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -172,13 +172,13 @@ def _start_heartbeat(conn, platform, arch, version, args):
     """Start a background thread that writes runner state to Redis every HEARTBEAT_INTERVAL_SECS."""
     import threading
 
-    start_ts = int(datetime.datetime.utcnow().timestamp())
+    start_ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
 
     def _heartbeat_loop():
         key = f"{HEARTBEAT_KEY_PREFIX}:{platform}"
         while True:
             try:
-                now_ts = int(datetime.datetime.utcnow().timestamp())
+                now_ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
                 fields = {
                     "platform": platform,
                     "arch": arch,

--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -364,7 +364,7 @@ class CoordinatorHTTPHandler(BaseHTTPRequestHandler):
                     request_data = {}
 
                 # Record flush timestamp
-                flush_time = datetime.datetime.utcnow()
+                flush_time = datetime.datetime.now(datetime.timezone.utc)
                 _flush_timestamp = flush_time
 
                 logging.info(

--- a/utils/tests/test_admin.py
+++ b/utils/tests/test_admin.py
@@ -121,7 +121,7 @@ def test_format_age():
     """Test stream ID age formatting."""
     import datetime
 
-    now_ms = int(datetime.datetime.utcnow().timestamp() * 1000)
+    now_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
     # 30 seconds ago
     assert "s ago" in _format_age(f"{now_ms - 30000}-0")
     # 5 minutes ago


### PR DESCRIPTION
## Summary

\`datetime.datetime.utcnow()\` returns a naive datetime representing UTC wall-clock time, but calling \`.timestamp()\` on a naive datetime interprets it as **local** time when converting to epoch seconds -- so on any machine whose local timezone isn't UTC, the computed epoch is wrong by the local UTC offset.

## Why this matters now

This directly affects runner/builder health status: \`admin health\`'s age computation (\`admin.py\`) can be invoked from an operator machine or a CI runner in any timezone. Confirmed live on a UTC+1 machine: every BEAT column read \`~-3580s\` instead of a small positive number -- which could mask a genuinely-down runner (a negative/near-zero skewed age never crosses the 120s DOWN threshold). This matters more now that a periodic automated health-check workflow depends on \`admin health\`/\`admin builders\` correctly reporting DOWN/STUCK status regardless of which machine runs it.

## Changes
- \`admin.py\`: fixed the age-of-heartbeat computation, plus two recent-runs time-window computations (day/week-ago epoch math for querying stream history).
- \`self_contained_coordinator.py\`: fixed the heartbeat-writing thread's own timestamp computation (defense in depth -- the fleet hosts are presumably UTC-configured cloud images, but this shouldn't rely on that assumption).
- \`utils/tests/test_admin.py\`: fixed the test fixture's own \`now_ms\` computation, which was silently relying on the test-runner machine being UTC -- **this is very likely why \`test_admin.py::test_format_age\` was failing earlier this session on a UTC+1 machine while passing in CI (UTC runners)**. Verified: the test now passes locally on this UTC+1 machine (was failing before this fix).

Fix: \`datetime.datetime.now(datetime.timezone.utc).timestamp()\` instead of \`datetime.datetime.utcnow().timestamp()\` -- \`timezone.utc\` is available since Python 3.2, so this works across the full py3.10-3.12 CI matrix (the newer \`datetime.UTC\` shorthand needs 3.11+).

Left the many other \`utcnow()\` call sites in this codebase untouched -- they don't chain \`.timestamp()\` (just \`.isoformat()\`/direct subtraction between two naive-UTC datetimes), which is safe regardless of local timezone since both sides cancel consistently.

## Verification
- \`pytest utils/tests/test_admin.py\`: 19 passed (was 1 failing before this fix)
- \`black --check redis_benchmarks_specification/\`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrects time windows and runner DOWN detection used by automated health checks. Low blast radius, but wrong timestamps previously hid down runners and could still mis-filter recent runs if any site is missed.
> 
> **Overview**
> Fixes a timezone bug where naive `datetime.utcnow().timestamp()` was treated as **local** time, skewing epoch values by the host UTC offset.
> 
> That broke `admin health` heartbeat age (negative ages on non-UTC machines, so DOWN never tripped) and 7d/24h Redis zset windows. Heartbeat writes in the coordinator and compare date→ms conversion had the same issue.
> 
> Uses `datetime.now(timezone.utc).timestamp()` (and `replace(tzinfo=utc)` for naive dates). Other `utcnow()` sites that only do ISO/subtraction are left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca200576aea30040ca327fe326eb386251b30fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->