### PR TITLE
fix: always ack the message id the broker delivered, not the processor's return value

### DIFF
--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -1054,10 +1054,18 @@ def self_contained_coordinator_blocking_read(
     else:
         # Update heartbeat: running
         _heartbeat_status = "running"
+        # Capture the delivered message id up front. This is the id we MUST
+        # ack no matter what happens below -- `stream_id` gets reassigned to
+        # whatever process_self_contained_coordinator_stream() returns, which
+        # can be a sentinel that acks nothing, silently leaving the real
+        # message pending in the consumer group's PEL forever (see
+        # redis/redis-benchmarks-specification#519).
+        received_stream_id = newTestInfo[0][1][0][0]
         try:
-            sid_raw = newTestInfo[0][1][0][0]
             _heartbeat_current_stream = (
-                sid_raw.decode() if isinstance(sid_raw, bytes) else str(sid_raw)
+                received_stream_id.decode()
+                if isinstance(received_stream_id, bytes)
+                else str(received_stream_id)
             )
         except Exception:
             pass
@@ -1069,49 +1077,67 @@ def self_contained_coordinator_blocking_read(
 
         args = Args()
 
-        (
-            stream_id,
-            overall_result,
-            total_test_suite_runs,
-        ) = process_self_contained_coordinator_stream(
-            github_event_conn,
-            datasink_push_results_redistimeseries,
-            docker_client,
-            home,
-            newTestInfo,
-            datasink_conn,
-            testsuite_spec_files,
-            topologies_map,
-            platform_name,
-            profilers_enabled,
-            profilers_list,
-            grafana_profile_dashboard,
-            cpuset_start_pos,
-            redis_proc_start_port,
-            docker_air_gap,
-            "defaults.yml",
-            override_test_time,
-            default_metrics,
-            arch,
-            github_token,
-            priority_lower_limit,
-            priority_upper_limit,
-            default_baseline_branch,
-            default_metrics_str,
-            docker_keep_env,
-            restore_build_artifacts_default,
-            args,
-            explicit_only=explicit_only,
-        )
-        num_process_streams = num_process_streams + 1
-        num_process_test_suites = num_process_test_suites + total_test_suite_runs
+        try:
+            (
+                stream_id,
+                overall_result,
+                total_test_suite_runs,
+            ) = process_self_contained_coordinator_stream(
+                github_event_conn,
+                datasink_push_results_redistimeseries,
+                docker_client,
+                home,
+                newTestInfo,
+                datasink_conn,
+                testsuite_spec_files,
+                topologies_map,
+                platform_name,
+                profilers_enabled,
+                profilers_list,
+                grafana_profile_dashboard,
+                cpuset_start_pos,
+                redis_proc_start_port,
+                docker_air_gap,
+                "defaults.yml",
+                override_test_time,
+                default_metrics,
+                arch,
+                github_token,
+                priority_lower_limit,
+                priority_upper_limit,
+                default_baseline_branch,
+                default_metrics_str,
+                docker_keep_env,
+                restore_build_artifacts_default,
+                args,
+                explicit_only=explicit_only,
+            )
+            num_process_streams = num_process_streams + 1
+            num_process_test_suites = num_process_test_suites + total_test_suite_runs
+        except Exception as e:
+            # Never let a single bad job wedge this consumer's PEL. Log and
+            # fall through to the unconditional ack below on the *captured*
+            # message id, then let the caller's while-loop poll for the next
+            # message.
+            logging.critical(
+                "Unhandled exception while processing BENCHMARK variation "
+                "stream with id {}: {}. Acknowledging the message anyway "
+                "to avoid wedging the consumer group.".format(received_stream_id, e)
+            )
+            # Mirror the success path's stream_id type (decoded str) so the
+            # next blocking-read call's PEL-history lookup behaves the same
+            # way it would have after a normal ack.
+            stream_id = _heartbeat_current_stream
+            overall_result = False
 
-        # Always acknowledge the message, even if it was filtered out
+        # Always acknowledge the ORIGINAL delivered message, even if it was
+        # filtered out or the processor raised -- never ack `stream_id` here,
+        # it may have been reassigned to a sentinel by the processor.
         arch_specific_stream = get_arch_specific_stream_name(arch)
         ack_reply = github_event_conn.xack(
             arch_specific_stream,
             get_runners_consumer_group_name(platform_name),
-            stream_id,
+            received_stream_id,
         )
         if type(ack_reply) == bytes:
             ack_reply = ack_reply.decode()
@@ -1119,19 +1145,19 @@ def self_contained_coordinator_blocking_read(
             if overall_result is True:
                 logging.info(
                     "Successfully acknowledged BENCHMARK variation stream with id {} (processed).".format(
-                        stream_id
+                        received_stream_id
                     )
                 )
             else:
                 logging.info(
                     "Successfully acknowledged BENCHMARK variation stream with id {} (filtered/skipped).".format(
-                        stream_id
+                        received_stream_id
                     )
                 )
         else:
             logging.error(
                 "Unable to acknowledge build variation stream with id {}. XACK reply {}".format(
-                    stream_id, ack_reply
+                    received_stream_id, ack_reply
                 )
             )
     return overall_result, stream_id, num_process_streams, num_process_test_suites

--- a/utils/tests/test_self_contained_coordinator_ack.py
+++ b/utils/tests/test_self_contained_coordinator_ack.py
@@ -1,0 +1,123 @@
+# Regression tests for redis/redis-benchmarks-specification#519:
+# a consumer must always XACK the message it was actually delivered,
+# even when process_self_contained_coordinator_stream() raises or
+# returns a stream_id that doesn't match the delivered one. Pure
+# mock-based unit tests -- no live redis/docker required.
+from unittest.mock import MagicMock, patch
+
+from redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator import (
+    self_contained_coordinator_blocking_read,
+)
+
+
+def _make_delivered_message(msg_id=b"1787194724560-0"):
+    # Shape of redis-py's xreadgroup() response:
+    # [[stream_name, [(msg_id, {field: value, ...})]]]
+    return [[b"oss:api:gh/redis/redis/builds:amd64", [(msg_id, {b"f": b"v"})]]]
+
+
+def test_blocking_read_acks_captured_id_when_processor_raises():
+    msg_id = b"1787194724560-0"
+    conn = MagicMock()
+    conn.xreadgroup.return_value = _make_delivered_message(msg_id)
+    conn.xack.return_value = 1
+
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.process_self_contained_coordinator_stream",
+        side_effect=RuntimeError("boom"),
+    ):
+        overall_result, stream_id, num_streams, num_suites = (
+            self_contained_coordinator_blocking_read(
+                conn,
+                None,
+                None,
+                "/tmp",
+                ">",
+                None,
+                {},
+                {},
+                "x86-aws-m8a.metal-24xl",
+                False,
+                [],
+                arch="amd64",
+            )
+        )
+
+    # The message must be acked exactly once, on the id it was ACTUALLY
+    # delivered under -- never left pending because the processor blew up.
+    conn.xack.assert_called_once()
+    acked_id = conn.xack.call_args[0][2]
+    assert acked_id == msg_id
+    assert overall_result is False
+
+
+def test_blocking_read_acks_delivered_id_not_processor_sentinel():
+    msg_id = b"1787194724560-0"
+    conn = MagicMock()
+    conn.xreadgroup.return_value = _make_delivered_message(msg_id)
+    conn.xack.return_value = 1
+
+    # Processor "succeeds" but returns an unrelated sentinel stream_id
+    # (e.g. "n/a", or an early-return id) instead of the real one.
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.process_self_contained_coordinator_stream",
+        return_value=("n/a", True, 1),
+    ):
+        self_contained_coordinator_blocking_read(
+            conn,
+            None,
+            None,
+            "/tmp",
+            ">",
+            None,
+            {},
+            {},
+            "x86-aws-m8a.metal-24xl",
+            False,
+            [],
+            arch="amd64",
+        )
+
+    conn.xack.assert_called_once()
+    acked_id = conn.xack.call_args[0][2]
+    assert acked_id == msg_id, (
+        "must ack the id the broker actually delivered, not whatever "
+        "sentinel the processor happens to return"
+    )
+
+
+def test_blocking_read_acks_delivered_id_on_normal_success():
+    msg_id = b"1787194724560-0"
+    conn = MagicMock()
+    conn.xreadgroup.return_value = _make_delivered_message(msg_id)
+    conn.xack.return_value = 1
+
+    # Processor succeeds and (correctly) echoes the same id back -- pins the
+    # ack-id contract for the common case too, not just the two failure
+    # modes above.
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.process_self_contained_coordinator_stream",
+        return_value=(msg_id.decode(), True, 1),
+    ):
+        overall_result, stream_id, num_streams, num_suites = (
+            self_contained_coordinator_blocking_read(
+                conn,
+                None,
+                None,
+                "/tmp",
+                ">",
+                None,
+                {},
+                {},
+                "x86-aws-m8a.metal-24xl",
+                False,
+                [],
+                arch="amd64",
+            )
+        )
+
+    conn.xack.assert_called_once()
+    acked_id = conn.xack.call_args[0][2]
+    assert acked_id == msg_id
+    assert overall_result is True
+    assert num_streams == 1


### PR DESCRIPTION
## Problem

`self_contained_coordinator_blocking_read()` XACKed whatever `stream_id`
`process_self_contained_coordinator_stream()` returned, instead of the id
captured directly off the `XREADGROUP` response. If a future change to that
~1900-line processor ever reassigns `stream_id` for an unrelated purpose, or
returns before the id is set, the real delivered message would never get
acked and stays pending in the consumer's PEL forever, while the runner
keeps reporting a healthy heartbeat.

## What this does NOT confirm

Issue #519 reports 62 messages stuck in this exact way on one runner
(`x86-aws-m8a.metal-24xl`), with a theory that the processor's normal
exception handling could return a `"n/a"` sentinel. Adversarial review of
this fix found that on both current `main` and the deployed `v0.3.35` tag,
`process_self_contained_coordinator_stream()` already decodes the real id
as the first two statements inside its top-level `try`, and its matching
`except` re-returns whatever `stream_id` is bound to at that point --
so the specific "sentinel"/"never assigned" mechanism described in #519
does not reproduce against the actual source. The real mechanism behind
the observed backlog is still unexplained (most likely something in the
`XACK` call's own reliability under real network conditions between this
process and Redis, which this change doesn't touch).

## What this does do

Decouples the ack entirely from the processor's return value: capture the
id up front from the `XREADGROUP` response, wrap the processing call in
`try/except` so a raise can't skip the ack either, and always XACK the
captured id. This closes off a whole class of future "id got reassigned
somewhere in the processor" bugs regardless of whether it's the exact bug
hit today, and is a self-contained, easily-tested change.

Given the uncertainty above, **not** using a closing keyword for #519 --
leaving it open with these findings for further investigation into the
actual XACK-reliability mechanism.

## Testing

Three new mock-based unit tests (`utils/tests/test_self_contained_coordinator_ack.py`,
no live redis/docker needed) pin the ack-id contract: processor raises,
processor returns a mismatched sentinel, and the normal success path. All
three fail against the pre-fix code and pass against the fix (verified by
diffing against the parent commit). Existing integration tests
(`test_self_contained_coordinator.py`, `test_self_contained_coordinator_memtier.py`
`-k blocking_read`) still pass unmodified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Redis consumer-group ACK behavior for the benchmark runner. A wrong ack id can drop work or leave messages pending, but the change is small and covered by targeted tests.
> 
> **Overview**
> Stops the self-contained coordinator from XACKing whatever `stream_id` `process_self_contained_coordinator_stream()` returns. It now captures the id from the `XREADGROUP` payload and always acks that id.
> 
> Processing is wrapped so an unhandled exception still acks the delivered message instead of leaving it in the consumer PEL. The processor return value is no longer used for ack.
> 
> Adds mock unit tests covering processor raise, a mismatched sentinel return (`n/a`), and the success path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c8ff643ac01cf05a01bd2103d8b2acde781207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->