### PR TITLE
feat: surface abandoned PEL messages in admin health, cross-checked against each runner's consumer group

### DIFF
--- a/redis_benchmarks_specification/__cli__/admin.py
+++ b/redis_benchmarks_specification/__cli__/admin.py
@@ -18,6 +18,27 @@ from redis_benchmarks_specification.__common__.env import (
     STREAM_GH_NEW_BUILD_RUNNERS_CG,
     get_arch_specific_stream_name,
 )
+from redis_benchmarks_specification.__self_contained_coordinator__.runners import (
+    get_runners_consumer_group_name,
+)
+
+# A runner's own consumer group can hold abandoned (delivered, never ACK'd) messages
+# indefinitely while its heartbeat still reports a healthy "waiting"/"idle" status --
+# the heartbeat only reflects in-memory process state, it never cross-checks the PEL.
+# See redis/redis-benchmarks-specification#519: one runner sat on 62 abandoned
+# messages (oldest 16.9 days) while every liveness view showed it idle-and-available.
+#
+# This threshold deliberately does NOT try to catch "processing is taking too long" --
+# a single legitimate message stays pending for the entire duration of its work, which
+# for a full test suite can be many hours (see the GA-baseline-seed cost note: an
+# n=1 full-suite pass is 11.7h+), so any fixed idle-time cutoff alone would false-positive
+# on every long-running legitimate benchmark. The actual #519 fingerprint is narrower and
+# unambiguous: heartbeat status is idle/waiting (i.e. NOT "running") while the PEL still
+# has a pending message -- a healthy runner always acks before flipping back to waiting,
+# so that combination can only mean an abandoned message. See
+# _get_stale_pel_summary()'s status gate. This grace window just absorbs the brief
+# window around a heartbeat write (every 30s) and the ack/status-flip ordering.
+STALE_PEL_IDLE_MS = 60 * 1000  # 1 minute
 
 
 def _get_caller_identity():
@@ -1468,11 +1489,67 @@ def admin_work_command(conn, args):
     print()
 
 
+def _get_stale_pel_summary(conn, platform, heartbeat_status):
+    """Check platform's own runner consumer group for abandoned (pending, never
+    ACK'd) messages older than STALE_PEL_IDLE_MS, across both arch streams.
+
+    Only meaningful when the heartbeat itself claims the runner is NOT
+    actively processing anything (idle/waiting): a single legitimate message
+    stays pending in the PEL for the *entire* duration of that message's
+    work, which for a full test suite can be many hours (a busy runner with
+    status "running" is expected to have an old-looking pending message --
+    that's not a bug). The #519 fingerprint is specifically the combination
+    of "heartbeat says idle/waiting" + "PEL still has an old pending
+    message" -- that mismatch is what a healthy runner can never produce on
+    its own, since it always acks before going back to "waiting".
+
+    Returns "" when clean or when the runner is legitimately busy, otherwise
+    a short "N msgs, oldest=Xm/h/d" summary (see
+    redis/redis-benchmarks-specification#519).
+    """
+    # Also suppresses "DOWN"/"?": a runner with no recent heartbeat at all is
+    # already alerted separately via the heartbeat-age check in admin_health_command
+    # and fleet-health-watch.sh -- reporting stale PEL too would be redundant
+    # noise for the same underlying "this runner is unreachable" condition.
+    if heartbeat_status not in ("waiting", "idle"):
+        return ""
+    group_name = get_runners_consumer_group_name(platform)
+    worst_count = 0
+    worst_idle_ms = 0
+    for arch in ("amd64", "arm64"):
+        stream = get_arch_specific_stream_name(arch)
+        try:
+            pending_msgs = conn.xpending_range(stream, group_name, "-", "+", 1000)
+        except redis.exceptions.ResponseError:
+            continue  # group doesn't exist on this arch stream -- not an error
+        if not pending_msgs:
+            continue
+        idle_values = [m.get("time_since_delivered", 0) for m in pending_msgs]
+        max_idle = max(idle_values)
+        if max_idle > STALE_PEL_IDLE_MS:
+            worst_count += len(pending_msgs)
+            worst_idle_ms = max(worst_idle_ms, max_idle)
+    if worst_idle_ms == 0:
+        return ""
+    idle_secs = worst_idle_ms / 1000
+    if idle_secs < 3600:
+        age = f"{int(idle_secs // 60)}m"
+    elif idle_secs < 86400:
+        age = f"{int(idle_secs // 3600)}h"
+    else:
+        age = f"{idle_secs / 86400:.1f}d"
+    return f"{worst_count} msgs, oldest={age}"
+
+
 def admin_health_command(conn, args):
     """Show runner health table from heartbeat keys.
 
     Each runner writes a heartbeat HASH every 30s with platform, arch, version,
     status, filters, and current work. Missing heartbeat = runner is down.
+
+    Also cross-checks each runner's own consumer group PEL for abandoned
+    messages -- the heartbeat alone cannot detect this, since it only reflects
+    in-memory process state and never queries the PEL (see #519).
     """
     print("\n=== RUNNER HEALTH ===\n")
 
@@ -1568,12 +1645,20 @@ def admin_health_command(conn, args):
                 short_test = current_test.replace("memtier_benchmark-", "mt-")
                 work += f" ({short_test})"
 
+        # Cross-check this runner's own consumer group PEL: a healthy-looking
+        # heartbeat (idle/waiting/running) can coexist with abandoned messages
+        # the heartbeat itself has no way to see (#519). Single space-free
+        # token ("-" when clean) so it stays positionally parseable.
+        stale_pel = _get_stale_pel_summary(conn, platform, status)
+        pel_flag = ("STALE:" + stale_pel.replace(" ", "")) if stale_pel else "-"
+
         rows.append(
             {
                 "platform": platform,
                 "arch": arch,
                 "version": version,
                 "status": status,
+                "pel": pel_flag,
                 "heartbeat": age,
                 "uptime": uptime,
                 "filters": filters_str,
@@ -1583,12 +1668,14 @@ def admin_health_command(conn, args):
 
     # Print table
     print(
-        f"  {'PLATFORM':<45} {'ARCH':<6} {'VERSION':<10} {'STATUS':<9} {'BEAT':<6} {'UPTIME':<8} {'FILTERS':<25} {'CURRENT WORK'}"
+        f"  {'PLATFORM':<45} {'ARCH':<6} {'VERSION':<10} {'STATUS':<9} {'PEL':<28} {'BEAT':<6} {'UPTIME':<8} {'FILTERS':<25} {'CURRENT WORK'}"
     )
-    print(f"  {'-'*45} {'-'*6} {'-'*10} {'-'*9} {'-'*6} {'-'*8} {'-'*25} {'-'*40}")
+    print(
+        f"  {'-'*45} {'-'*6} {'-'*10} {'-'*9} {'-'*28} {'-'*6} {'-'*8} {'-'*25} {'-'*40}"
+    )
     for r in rows:
         print(
-            f"  {r['platform']:<45} {r['arch']:<6} {r['version']:<10} {r['status']:<9} {r['heartbeat']:<6} {r['uptime']:<8} {r['filters']:<25} {r['work']}"
+            f"  {r['platform']:<45} {r['arch']:<6} {r['version']:<10} {r['status']:<9} {r['pel']:<28} {r['heartbeat']:<6} {r['uptime']:<8} {r['filters']:<25} {r['work']}"
         )
     print()
 

--- a/utils/tests/test_admin.py
+++ b/utils/tests/test_admin.py
@@ -28,8 +28,10 @@ from redis_benchmarks_specification.__cli__.admin import (
     _format_idle,
     _format_age,
     _get_queue_progress,
+    _get_stale_pel_summary,
     _short_hash,
     _short_info,
+    STALE_PEL_IDLE_MS,
 )
 from redis_benchmarks_specification.__builder__.builder import (
     generate_benchmark_stream_request,
@@ -41,6 +43,9 @@ from redis_benchmarks_specification.__common__.env import (
     STREAM_GH_NEW_BUILD_RUNNERS_CG,
     get_arch_specific_stream_name,
     REDIS_BINS_EXPIRE_SECS,
+)
+from redis_benchmarks_specification.__self_contained_coordinator__.runners import (
+    get_runners_consumer_group_name,
 )
 
 
@@ -655,6 +660,161 @@ def test_admin_cancel_command():
         # Clean up
         conn.delete(zset_key)
 
+    except redis.exceptions.ConnectionError:
+        pass
+
+
+def _reset_runner_group(conn, stream, group_name):
+    """Drop any leftover consumer group from a prior run (e.g. one that
+    crashed before its own cleanup ran, or a concurrent test run) so each
+    stale-PEL test starts from a known-empty PEL."""
+    try:
+        conn.xgroup_destroy(stream, group_name)
+    except redis.exceptions.ResponseError:
+        pass
+    conn.xgroup_create(stream, group_name, id="$", mkstream=True)
+
+
+def test_get_stale_pel_summary_flags_abandoned_message_when_idle():
+    """A pending message idle past STALE_PEL_IDLE_MS is flagged when the
+    heartbeat reports idle/waiting -- the #519 fingerprint: a runner that
+    looks perfectly healthy while it silently abandoned a message."""
+    try:
+        conn = redis.StrictRedis(decode_responses=False)
+        conn.ping()
+
+        platform = "test-platform-stale-pel"
+        stream = get_arch_specific_stream_name("amd64")
+        group_name = get_runners_consumer_group_name(platform)
+        _reset_runner_group(conn, stream, group_name)
+
+        msg_id = None
+        try:
+            msg_id = conn.xadd(stream, {"f": "v"})
+            conn.xreadgroup(group_name, "consumer-1", {stream: ">"}, count=1)
+
+            # Force this specific message's idle time past the threshold
+            # without actually waiting -- XCLAIM's IDLE option exists for
+            # exactly this.
+            conn.xclaim(
+                stream,
+                group_name,
+                "consumer-1",
+                min_idle_time=0,
+                message_ids=[msg_id],
+                idle=STALE_PEL_IDLE_MS + 1000,
+            )
+
+            summary = _get_stale_pel_summary(conn, platform, "waiting")
+            assert summary != ""
+            assert "1 msgs" in summary
+        finally:
+            conn.xgroup_destroy(stream, group_name)
+            if msg_id is not None:
+                conn.xdel(stream, msg_id)
+
+    except redis.exceptions.ConnectionError:
+        pass
+
+
+def test_get_stale_pel_summary_ignores_pending_message_while_running():
+    """The exact same old pending message must NOT be flagged while the
+    heartbeat reports "running" -- a message legitimately stays pending for
+    the entire duration of a benchmark run (a full suite can take many
+    hours), so idle time alone is not a valid abandonment signal."""
+    try:
+        conn = redis.StrictRedis(decode_responses=False)
+        conn.ping()
+
+        platform = "test-platform-stale-pel-busy"
+        stream = get_arch_specific_stream_name("amd64")
+        group_name = get_runners_consumer_group_name(platform)
+        _reset_runner_group(conn, stream, group_name)
+
+        msg_id = None
+        try:
+            msg_id = conn.xadd(stream, {"f": "v"})
+            conn.xreadgroup(group_name, "consumer-1", {stream: ">"}, count=1)
+            conn.xclaim(
+                stream,
+                group_name,
+                "consumer-1",
+                min_idle_time=0,
+                message_ids=[msg_id],
+                idle=STALE_PEL_IDLE_MS + 1000,
+            )
+
+            assert _get_stale_pel_summary(conn, platform, "running") == ""
+        finally:
+            conn.xgroup_destroy(stream, group_name)
+            if msg_id is not None:
+                conn.xdel(stream, msg_id)
+
+    except redis.exceptions.ConnectionError:
+        pass
+
+
+def test_get_stale_pel_summary_combines_both_arch_streams():
+    """A platform whose runner has stale pending messages on BOTH arch
+    streams (unusual, but not prevented by anything) must report the
+    combined count and the oldest of the two ages, not just one arch's."""
+    try:
+        conn = redis.StrictRedis(decode_responses=False)
+        conn.ping()
+
+        platform = "test-platform-stale-pel-both-arch"
+        amd_stream = get_arch_specific_stream_name("amd64")
+        arm_stream = get_arch_specific_stream_name("arm64")
+        group_name = get_runners_consumer_group_name(platform)
+        _reset_runner_group(conn, amd_stream, group_name)
+        _reset_runner_group(conn, arm_stream, group_name)
+
+        amd_msg_id = None
+        arm_msg_id = None
+        try:
+            amd_msg_id = conn.xadd(amd_stream, {"f": "v"})
+            conn.xreadgroup(group_name, "consumer-1", {amd_stream: ">"}, count=1)
+            conn.xclaim(
+                amd_stream,
+                group_name,
+                "consumer-1",
+                min_idle_time=0,
+                message_ids=[amd_msg_id],
+                idle=STALE_PEL_IDLE_MS + 1000,
+            )
+
+            arm_msg_id = conn.xadd(arm_stream, {"f": "v"})
+            conn.xreadgroup(group_name, "consumer-1", {arm_stream: ">"}, count=1)
+            conn.xclaim(
+                arm_stream,
+                group_name,
+                "consumer-1",
+                min_idle_time=0,
+                message_ids=[arm_msg_id],
+                idle=2 * STALE_PEL_IDLE_MS + 1000,  # older than the amd64 one
+            )
+
+            summary = _get_stale_pel_summary(conn, platform, "waiting")
+            assert "2 msgs" in summary
+        finally:
+            conn.xgroup_destroy(amd_stream, group_name)
+            conn.xgroup_destroy(arm_stream, group_name)
+            if amd_msg_id is not None:
+                conn.xdel(amd_stream, amd_msg_id)
+            if arm_msg_id is not None:
+                conn.xdel(arm_stream, arm_msg_id)
+
+    except redis.exceptions.ConnectionError:
+        pass
+
+
+def test_get_stale_pel_summary_clean_when_no_group():
+    """No consumer group at all for this platform must not raise -- e.g. a
+    freshly-onboarded runner that has never claimed a message yet."""
+    try:
+        conn = redis.StrictRedis(decode_responses=False)
+        conn.ping()
+        assert _get_stale_pel_summary(conn, "test-platform-never-seen", "waiting") == ""
     except redis.exceptions.ConnectionError:
         pass
 


### PR DESCRIPTION
## Problem

`admin health` only reads each runner's heartbeat hash (written by the
process itself every 30s) -- it never queries the runner's own consumer
group PEL. So a runner can report a perfectly healthy `waiting`/`idle`
status while its own consumer group has messages that were delivered and
never acknowledged, and nothing in any existing admin command surfaces it.

#519 found exactly this: `x86-aws-m8a.metal-24xl` sat on 62 abandoned
messages (oldest 16.9 days) while every liveness view showed it
idle-and-available. Checking again just now against the live fleet with
this same runner shows the backlog is still growing: **80 messages, oldest
19.3 days** -- the underlying cause remains open and active (#523 hardened
the ack path but didn't explain the live mechanism), and it was completely
invisible through any existing tooling until manually eyeballing `admin
work`'s idle times.

## What this does

Read-only visibility, nothing more: `_get_stale_pel_summary()` cross-
references each platform's own runner consumer group (both arch streams)
via `XPENDING`, and surfaces a `STALE:N msgs, oldest=Xm/h/d` flag in a new
`PEL` column in `admin health`'s table -- the same table already polled by
the internal fleet-health-watch cron, so this becomes an alerted state
transition instead of something a human has to notice by hand.

Deliberately gated on heartbeat status, not idle time alone: a single
legitimate message stays pending in the PEL for the entire duration of its
work, and a full test suite can run many hours. A flat idle-time cutoff
would false-positive on every long-running legitimate benchmark. The
actual #519 fingerprint is narrower: heartbeat status is idle/waiting
(never "running") while the PEL still has a pending message -- a healthy
runner always acks before flipping back to waiting, so that specific
combination can only mean an abandoned message. (Caught and fixed during
review -- the first draft used a flat threshold.)

Nothing here writes or reclaims anything (no XACK/XCLAIM) -- it's pure
detection, matching the "harden for visibility first" scope; auto-
remediation is a separate, riskier follow-up if this proves out.

## Testing

Four new tests in `test_admin.py` against a real local Redis (no
live/docker infra needed): idle status + an old pending message is
flagged; the identical old pending message is *not* flagged while status
is "running"; simultaneous staleness on both arch streams combines
correctly; a platform with no consumer group yet doesn't raise. Full
`test_admin.py` suite (23 tests) passes; `black --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI observability: extra XPENDING queries and a new table column. No stream mutation, auth, or runner-control changes.
> 
> **Overview**
> Makes `admin health` detect runners that look idle/waiting while their consumer-group PEL still holds unacked messages (the #519 fingerprint). Heartbeats never inspect the PEL, so this mismatch was previously invisible.
> 
> Adds `_get_stale_pel_summary()`, which `XPENDING`s both arch streams for the platform’s runner group and, only when status is `waiting`/`idle` and idle time exceeds 1 minute, prints a parseable `STALE:Nmsgs,oldest=…` token in a new **PEL** column. Busy (`running`) and down runners are skipped so long legitimate runs and existing heartbeat-down alerts are not duplicated. Detection is read-only (no XACK/XCLAIM).
> 
> Covered by tests for idle+stale, running+pending, both-arch aggregation, and missing groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c120114a9e313d396f8fb008caa6576c2199609a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->