### PR TITLE
Add ZINTERCARD numkeys width sweep (2/8/64)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-2keys-zset-500-elements-zintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-2keys-zset-500-elements-zintercard.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-2keys-zset-500-elements-zintercard
+description: 'Runs memtier_benchmark against 2 sorted sets of 500 elements each, issuing
+  ZINTERCARD with numkeys=2. All 2 keys hold the identical member set, so the reply is always
+  500 and the intersection result does not vary with width - the only thing that changes across
+  the width-2/8/64 suites in this family is the numkeys argument, isolating the cost of collecting
+  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 64
+  resources:
+    requests:
+      memory: 1g
+  init_lua: |
+    -- Seed 64 sorted sets that all contain the identical 500-member set. Keeping the
+    -- member sets identical across every key holds the intersection result constant at
+    -- 500, so the only variable between the width-2, width-8 and width-64 suites is the
+    -- numkeys argument itself rather than the size of the answer.
+    for k = 1, 64 do
+      for m = 1, 500 do
+        redis.call('ZADD', 'ov:' .. k, m, 'm:' .. m)
+      end
+    end
+    return 1
+  dataset_name: 64keys-sorted-set-500-elements-identical-members
+  dataset_description: 64 sorted sets, each containing the identical 500 members m:1..m:500.
+tested-commands:
+- zintercard
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZINTERCARD 2 ov:1 ov:2 LIMIT 0"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- sorted-set
+priority: 131

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-2keys-zset-500-elements-zintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-2keys-zset-500-elements-zintercard.yml
@@ -4,7 +4,8 @@ description: 'Runs memtier_benchmark against 2 sorted sets of 500 elements each,
   ZINTERCARD with numkeys=2. All 2 keys hold the identical member set, so the reply is always
   500 and the intersection result does not vary with width - the only thing that changes across
   the width-2/8/64 suites in this family is the numkeys argument, isolating the cost of collecting
-  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).
+  Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-64keys-zset-500-elements-zintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-64keys-zset-500-elements-zintercard.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-64keys-zset-500-elements-zintercard
+description: 'Runs memtier_benchmark against 64 sorted sets of 500 elements each, issuing
+  ZINTERCARD with numkeys=64. All 64 keys hold the identical member set, so the reply is always
+  500 and the intersection result does not vary with width - the only thing that changes across
+  the width-2/8/64 suites in this family is the numkeys argument, isolating the cost of collecting
+  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 64
+  resources:
+    requests:
+      memory: 1g
+  init_lua: |
+    -- Seed 64 sorted sets that all contain the identical 500-member set. Keeping the
+    -- member sets identical across every key holds the intersection result constant at
+    -- 500, so the only variable between the width-2, width-8 and width-64 suites is the
+    -- numkeys argument itself rather than the size of the answer.
+    for k = 1, 64 do
+      for m = 1, 500 do
+        redis.call('ZADD', 'ov:' .. k, m, 'm:' .. m)
+      end
+    end
+    return 1
+  dataset_name: 64keys-sorted-set-500-elements-identical-members
+  dataset_description: 64 sorted sets, each containing the identical 500 members m:1..m:500.
+tested-commands:
+- zintercard
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZINTERCARD 64 ov:1 ov:2 ov:3 ov:4 ov:5 ov:6 ov:7 ov:8 ov:9 ov:10 ov:11 ov:12 ov:13 ov:14 ov:15 ov:16 ov:17 ov:18 ov:19 ov:20 ov:21 ov:22 ov:23 ov:24 ov:25 ov:26 ov:27 ov:28 ov:29 ov:30 ov:31 ov:32 ov:33 ov:34 ov:35 ov:36 ov:37 ov:38 ov:39 ov:40 ov:41 ov:42 ov:43 ov:44 ov:45 ov:46 ov:47 ov:48 ov:49 ov:50 ov:51 ov:52 ov:53 ov:54 ov:55 ov:56 ov:57 ov:58 ov:59 ov:60 ov:61 ov:62 ov:63 ov:64 LIMIT 0"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- sorted-set
+priority: 131

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-64keys-zset-500-elements-zintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-64keys-zset-500-elements-zintercard.yml
@@ -4,7 +4,8 @@ description: 'Runs memtier_benchmark against 64 sorted sets of 500 elements each
   ZINTERCARD with numkeys=64. All 64 keys hold the identical member set, so the reply is always
   500 and the intersection result does not vary with width - the only thing that changes across
   the width-2/8/64 suites in this family is the numkeys argument, isolating the cost of collecting
-  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).
+  Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zintercard.yml
@@ -4,7 +4,8 @@ description: 'Runs memtier_benchmark against 8 sorted sets of 500 elements each,
   ZINTERCARD with numkeys=8. All 8 keys hold the identical member set, so the reply is always
   500 and the intersection result does not vary with width - the only thing that changes across
   the width-2/8/64 suites in this family is the numkeys argument, isolating the cost of collecting
-  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).
+  Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zintercard.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-8keys-zset-500-elements-zintercard
+description: 'Runs memtier_benchmark against 8 sorted sets of 500 elements each, issuing
+  ZINTERCARD with numkeys=8. All 8 keys hold the identical member set, so the reply is always
+  500 and the intersection result does not vary with width - the only thing that changes across
+  the width-2/8/64 suites in this family is the numkeys argument, isolating the cost of collecting
+  and looking up N keys. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 64
+  resources:
+    requests:
+      memory: 1g
+  init_lua: |
+    -- Seed 64 sorted sets that all contain the identical 500-member set. Keeping the
+    -- member sets identical across every key holds the intersection result constant at
+    -- 500, so the only variable between the width-2, width-8 and width-64 suites is the
+    -- numkeys argument itself rather than the size of the answer.
+    for k = 1, 64 do
+      for m = 1, 500 do
+        redis.call('ZADD', 'ov:' .. k, m, 'm:' .. m)
+      end
+    end
+    return 1
+  dataset_name: 64keys-sorted-set-500-elements-identical-members
+  dataset_description: 64 sorted sets, each containing the identical 500 members m:1..m:500.
+tested-commands:
+- zintercard
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZINTERCARD 8 ov:1 ov:2 ov:3 ov:4 ov:5 ov:6 ov:7 ov:8 LIMIT 0"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- sorted-set
+priority: 131


### PR DESCRIPTION
## Summary

Adds three `ZINTERCARD` suites at numkeys **2 / 8 / 64**.

The `numkeys` family takes its key count from a runtime integer argument. Every suite that currently touches the family pins that argument to **2** — the minimum legal value, and the one width at which the key-collection loop is indistinguishable from a fixed 2-arity command. So the property that makes these commands distinct is not measured anywhere.

Measured locally on identical 500-element sorted sets (`-c 1 -t 1 --pipeline 1 --test-time 3`):

| numkeys | ops/sec |
|---:|---:|
| 2 | 9,892 |
| 8 | 2,208 |
| 64 | 356 |

**~28x** across the axis nothing varies today.

### Design note

All 64 seeded keys hold the **identical** 500-member set, so the reply is a constant 500 regardless of width. That keeps the intersection result fixed and leaves the `numkeys` argument as the only variable between the three suites — otherwise a wider suite would also be doing a different amount of intersection work and the two effects would be confounded.

Seeding uses `init_lua` rather than literal `ZADD` lists. The two existing suites in this family carry ~80KB of inline `ZADD` in `init_commands`; one Lua loop produces the same 64x500 dataset in a few lines. All three suites share one `dataset_name`, so the preload is done once for the set.

Refs #525.

## Verification

```
poetry run redis-benchmarks-spec-cli --tool stats --fail-on-required-diff
  EXIT=0
  no warnings referencing the new suites (12 pre-existing warnings unchanged)

poetry run pytest utils/tests/test_scope.py utils/tests/test_spec.py \
    utils/tests/test_topologies.py utils/tests/test_schema.py \
    utils/tests/test_admin.py::test_dry_run_topology_breakdown -q -ra
  40 passed in 25.19s

poetry run black --check redis_benchmarks_specification
  55 files unchanged  (no .py touched by this PR)
```

`tested-groups` was taken from the validator's derived list rather than hand-written.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New YAML benchmark specs only; no runtime, auth, or data-handling code. Extra CI load from three standalone suites is the main operational impact.
> 
> **Overview**
> Adds three memtier `ZINTERCARD` suites that vary only `numkeys` (2, 8, 64) so the spec measures key-collection cost, not just the minimum-arity case.
> 
> All three seed the same 64 skiplist zsets with identical 500-member sets via `init_lua`, so the intersection reply stays 500 and width is the only variable. They share one `dataset_name` for a single preload. Standalone-only, 120s runs, `LIMIT 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d165338d4d691780133be5ca6cbeab6a0b598220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->