### PR TITLE
Add 100-key variadic coverage for EXISTS, TOUCH and MSET

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-exists-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-exists-100keys.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-generic-exists-100keys
+description: Runs memtier_benchmark issuing EXISTS with 100 keys per call against a 1M-key dataset. EXISTS is variadic
+  but every existing suite calls it with a single key, where only the fixed per-command cost is visible; at 100
+  keys the per-key lookup loop dominates. --key-maximum is twice the preloaded keyspace, so each call mixes hits
+  and misses rather than measuring an all-hit best case.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "SET __key__ __data__" --command-key-pattern="P" -n 5000 --key-minimum=1
+      --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-100B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 100 bytes.
+tested-commands:
+- exists
+tested-groups:
+- generic
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --key-minimum=1 --key-maximum 2000000 --command "EXISTS __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__" --pipeline 10 --command-key-pattern="R"
+    -c 50 -t 2 --hide-histogram --test-time 180
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 25

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-exists-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-exists-100keys.yml
@@ -1,9 +1,10 @@
 version: 0.4
 name: memtier_benchmark-1Mkeys-generic-exists-100keys
-description: Runs memtier_benchmark issuing EXISTS with 100 keys per call against a 1M-key dataset. EXISTS is variadic
+description: 'Runs memtier_benchmark issuing EXISTS with 100 keys per call against a 1M-key dataset. EXISTS is variadic
   but every existing suite calls it with a single key, where only the fixed per-command cost is visible; at 100
   keys the per-key lookup loop dominates. --key-maximum is twice the preloaded keyspace, so each call mixes hits
-  and misses rather than measuring an all-hit best case.
+  and misses rather than measuring an all-hit best case. Encoding: RAW (100B values, exceeds the 44B EMBSTR threshold).
+  Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-touch-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-touch-100keys.yml
@@ -1,0 +1,48 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-generic-touch-100keys
+description: 'Runs memtier_benchmark issuing TOUCH with 100 keys per call against a 1M-key dataset. Paired with
+  the EXISTS 100-key suite at identical width and keyspace: both perform N lookups, but TOUCH additionally updates
+  LRU/LFU metadata per key, so the difference between the two isolates that maintenance cost at a width where it
+  resolves.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "100" --command "SET __key__ __data__" --command-key-pattern="P" -n 5000 --key-minimum=1
+      --key-maximum 1000000 -c 50 -t 4 --hide-histogram --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-100B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 100 bytes.
+tested-commands:
+- touch
+tested-groups:
+- generic
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --key-minimum=1 --key-maximum 2000000 --command "TOUCH __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__
+    __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__" --pipeline 10 --command-key-pattern="R"
+    -c 50 -t 2 --hide-histogram --test-time 180
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 41

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-touch-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-touch-100keys.yml
@@ -3,7 +3,7 @@ name: memtier_benchmark-1Mkeys-generic-touch-100keys
 description: 'Runs memtier_benchmark issuing TOUCH with 100 keys per call against a 1M-key dataset. Paired with
   the EXISTS 100-key suite at identical width and keyspace: both perform N lookups, but TOUCH additionally updates
   LRU/LFU metadata per key, so the difference between the two isolates that maintenance cost at a width where it
-  resolves.'
+  resolves. Encoding: RAW (100B values, exceeds the 44B EMBSTR threshold). Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mset-100B-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mset-100B-100keys.yml
@@ -27,7 +27,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --key-minimum 1 --key-maximum 5000000 --command "MSET __key__ __data__ __key__ __data__ __key__ __data__
+  arguments: --key-minimum 1 --key-maximum 5000000 --data-size 100 --command "MSET __key__ __data__ __key__ __data__
     __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
     __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
     __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
@@ -42,8 +42,8 @@ clientconfig:
     __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
     __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
     __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
-    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__" -c 50
-    -t 8 --hide-histogram --test-time 120
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__" -c 50 -t 8 --hide-histogram --test-time 120
   resources:
     requests:
       cpus: '8'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mset-100B-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mset-100B-100keys.yml
@@ -1,0 +1,53 @@
+version: 0.4
+name: memtier_benchmark-5Mkeys-string-mset-100B-100keys
+description: Runs memtier_benchmark issuing MSET with 100 key/value pairs per call against a 5M-key dataset of 100B
+  values. Existing MSET suites top out at 50 pairs while MGET already runs at 100, so this completes the write side
+  at the read side's widest point and makes the two directly comparable.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 5000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --key-minimum 1 --data-size 100 --key-maximum 5000000 --ratio 1:0 -n allkeys --random-data --key-pattern
+      P:P --hide-histogram -t 4 -c 50 --pipeline 50
+  resources:
+    requests:
+      memory: 2g
+tested-commands:
+- mset
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --key-minimum 1 --key-maximum 5000000 --command "MSET __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__
+    __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__
+    __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__ __key__ __data__" -c 50
+    -t 8 --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '8'
+      memory: 2g
+tested-groups:
+- string
+priority: 1

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mset-100B-100keys.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-5Mkeys-string-mset-100B-100keys.yml
@@ -1,8 +1,12 @@
 version: 0.4
 name: memtier_benchmark-5Mkeys-string-mset-100B-100keys
-description: Runs memtier_benchmark issuing MSET with 100 key/value pairs per call against a 5M-key dataset of 100B
+description: 'Runs memtier_benchmark issuing MSET with 100 key/value pairs per call against a 5M-key dataset of 100B
   values. Existing MSET suites top out at 50 pairs while MGET already runs at 100, so this completes the write side
-  at the read side's widest point and makes the two directly comparable.
+  at the read side''s widest point and makes the two directly comparable. Encoding: RAW (100B values, exceeds the
+  44B EMBSTR threshold). Metric of interest: Ops/sec. Note: the preload uses --random-data but the measured MSET
+  calls send the default constant filler -- deliberate, since the objective here is dispatch/argument-vector
+  overhead (100 key/value pairs per call), not payload compressibility or memcpy cost, which the preload''s
+  encoding check already covers.'
 dbconfig:
   configuration-parameters:
     save: '""'


### PR DESCRIPTION
## Summary

`EXISTS`, `TOUCH`, `DEL` and `UNLINK` are variadic, but every suite that exercises them passes exactly **one** key:

```
--command "EXISTS __key__"
--command "TOUCH __key__"
```

At width 1 only the fixed per-command cost is observable. The per-key lookup loop, argument-vector growth, and the tail-latency cost of a single command occupying the event loop are all invisible. `MGET` already spans widths 1-100 and is in good shape; the generic commands are not.

This PR adds three suites at 100 keys per call:

| Suite | Width |
|---|---|
| `memtier_benchmark-1Mkeys-generic-exists-100keys` | 100 |
| `memtier_benchmark-1Mkeys-generic-touch-100keys` | 100 |
| `memtier_benchmark-5Mkeys-string-mset-100B-100keys` | 100 pairs |

### EXISTS and TOUCH are a matched pair

Both perform N lookups; `TOUCH` additionally updates LRU/LFU metadata per key. The difference between the two isolates that maintenance cost at a width where it resolves — so they are deliberately identical in every respect except the verb: same dataset (`1Mkeys-string-100B-size`), same `--key-maximum`, same connection counts, same pipeline depth, byte-identical argument strings otherwise.

Worth noting they would **not** have been comparable if derived naively from the two existing single-key suites — those use different datasets (hash vs string-with-expiration) and different key ranges, so the difference would have conflated data type, TTL presence, and hit ratio with the LRU cost.

`--key-maximum` is twice the preloaded keyspace, so each call mixes hits and misses within a single command rather than measuring an all-hit best case.

### Not included

`DEL` and `UNLINK` at width belong in a separate PR: a width-100 delete consumes keys ~100x faster than a single-key suite, so those need the replenishing-writer pattern from `memtier_benchmark-1Mkeys-string-key-churn-rehash-32B` and a validity criterion on the miss ratio. Worth reviewing on its own.

`MSETNX` is also held back. Against a populated keyspace it always returns 0 and writes nothing — it still performs all N existence checks, but a suite whose command never succeeds needs a deliberate design rather than being folded in here.

Refs #526.

## Verification

```
poetry run redis-benchmarks-spec-cli --tool stats --fail-on-required-diff
  EXIT=0
  12 warnings — unchanged from the pre-existing baseline, none referencing the new suites

poetry run pytest utils/tests/test_scope.py utils/tests/test_spec.py \
    utils/tests/test_topologies.py utils/tests/test_schema.py \
    utils/tests/test_admin.py::test_dry_run_topology_breakdown -q
  40 passed in 23.15s

placeholder counts asserted programmatically: exists 100 __key__, touch 100 __key__,
mset 100 __key__ + 100 __data__
```

`tested-groups` taken from the validator's derived list, not hand-written.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds YAML benchmark specs only; no runtime, auth, or data-handling code. New suites will increase CI/benchmark load.
> 
> **Overview**
> Adds three memtier test suites that run **100 keys per command**, filling a gap where existing `EXISTS`/`TOUCH` suites used a single key and `MSET` topped out at 50 pairs.
> 
> `EXISTS` and `TOUCH` share the same 1M-key RAW string dataset, key range (hits mixed with misses via `--key-maximum` 2M), pipeline, and client shape so the delta isolates LRU/LFU maintenance. `MSET` uses a 5M-key 100B dataset to match existing 100-key `MGET` width; measured values use constant filler to focus on dispatch/arg-vector overhead.
> 
> Standalone-only, gcc amd64/arm64 plus dockerhub. `DEL`/`UNLINK`/`MSETNX` at this width are intentionally omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7ee64c29700c8a7a6bdc5d0a338226c48769ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->