### PR TITLE
fix: catch transient event-stream connection errors in the main polling loop, and drain preserved PEL backlog on startup

### DIFF
--- a/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
+++ b/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py
@@ -952,35 +952,125 @@ def main():
 
     logging.info("Entering blocking read waiting for work.")
     if stream_id is None:
-        stream_id = args.consumer_start_id
+        stream_id = _initial_stream_id(args)
+    consecutive_connection_errors = 0
     while True:
-        _, stream_id, _, _ = self_contained_coordinator_blocking_read(
-            gh_event_conn,
-            datasink_push_results_redistimeseries,
-            docker_client,
-            home,
-            stream_id,
-            datasink_conn,
-            testsuite_spec_files,
-            topologies_map,
-            running_platform,
-            profilers_enabled,
-            profilers_list,
-            grafana_profile_dashboard,
-            cpuset_start_pos,
-            redis_proc_start_port,
-            consumer_pos,
-            docker_air_gap,
-            override_memtier_test_time,
-            default_metrics,
-            arch,
-            github_token,
-            priority_lower_limit,
-            priority_upper_limit,
-            default_baseline_branch,
-            default_metrics_str,
+        stream_id, consecutive_connection_errors = _poll_for_work_with_retry(
+            consecutive_connection_errors,
+            github_event_conn=gh_event_conn,
+            datasink_push_results_redistimeseries=datasink_push_results_redistimeseries,
+            docker_client=docker_client,
+            home=home,
+            stream_id=stream_id,
+            datasink_conn=datasink_conn,
+            testsuite_spec_files=testsuite_spec_files,
+            topologies_map=topologies_map,
+            platform_name=running_platform,
+            profilers_enabled=profilers_enabled,
+            profilers_list=profilers_list,
+            grafana_profile_dashboard=grafana_profile_dashboard,
+            cpuset_start_pos=cpuset_start_pos,
+            redis_proc_start_port=redis_proc_start_port,
+            consumer_pos=consumer_pos,
+            docker_air_gap=docker_air_gap,
+            override_test_time=override_memtier_test_time,
+            default_metrics=default_metrics,
+            arch=arch,
+            github_token=github_token,
+            priority_lower_limit=priority_lower_limit,
+            priority_upper_limit=priority_upper_limit,
+            default_baseline_branch=default_baseline_branch,
+            default_metrics_str=default_metrics_str,
             explicit_only=explicit_only,
         )
+
+
+def _initial_stream_id(args):
+    """Pick the starting XREADGROUP id for main()'s polling loop.
+
+    When --skip-clear-pending-on-startup is set, the PEL cleanup a few lines
+    above this call is skipped, so this consumer may have pending (delivered,
+    never-acked) messages left over from a prior crashed incarnation.
+    Draining that history before falling through to new work is exactly what
+    XREADGROUP's "0" id does: it walks every not-yet-acked message previously
+    delivered to this consumer name, oldest first, and
+    self_contained_coordinator_blocking_read's existing empty-response branch
+    already falls through to the normal args.consumer_start_id (">" by
+    default) once that history is exhausted. Without this,
+    --skip-clear-pending-on-startup preserves old work across a restart but
+    nothing ever goes back to actually finish it
+    (redis/redis-benchmarks-specification#519): it just accumulates forever
+    instead.
+    """
+    if args.skip_clear_pending_on_startup:
+        return "0"
+    return args.consumer_start_id
+
+
+# A transient blip (the actual #519 bug -- a proxy/idle-timeout socket drop
+# every ~8126s) should be absorbed silently. A PERSISTENT outage (revoked
+# credentials, the endpoint genuinely gone) should NOT retry forever: the
+# background heartbeat thread keeps writing "waiting" the whole time this
+# loop is stuck retrying, so a silent infinite retry would make `admin
+# health` report a runner as healthy while it can no longer do any work at
+# all -- a worse, quieter version of the exact blind spot #519 is about.
+# Re-raising past this cap restores the old crash+respawn behavior (visible
+# in supervisor logs, and eventually in heartbeat staleness once restarts
+# can no longer keep up), which is a real, if crude, alerting signal for a
+# failure this fix was never meant to paper over.
+MAX_CONSECUTIVE_CONNECTION_ERRORS = 20
+
+
+def _poll_for_work_with_retry(consecutive_connection_errors, **blocking_read_kwargs):
+    """One iteration of the main polling loop, resilient to transient event-stream
+    connection errors (redis/redis-benchmarks-specification#519).
+
+    self_contained_coordinator_blocking_read() is blocked indefinitely on
+    XREADGROUP (BLOCK 0) waiting for new work. Any intermediate proxy/load-
+    balancer/NAT with an idle-connection timeout can sever that socket out from
+    under redis-py -- observed in production as a ~8126s-periodic crash on one
+    runner. Uncaught, this kills the whole process; supervisor respawns it, but
+    the fresh process has no memory of whether the in-flight XREADGROUP had
+    *already* been fulfilled server-side (a message delivered into this
+    consumer's PEL) before the client gave up waiting for the reply -- that
+    message is then never acked and never retried, since a brand-new process
+    starts back at "read only new work", not "check my own pending backlog
+    first". Catching the error here keeps the process (and therefore this
+    consumer identity) alive so the *same* alternating own-PEL-then-new-work
+    logic that already exists in self_contained_coordinator_blocking_read gets
+    a chance to pick that message back up on a later iteration, instead of
+    orphaning it and burning through a fresh restart+reconnect on every single
+    occurrence.
+
+    Bounded by MAX_CONSECUTIVE_CONNECTION_ERRORS: a PERSISTENT failure
+    (as opposed to the transient blip this is meant to absorb) re-raises
+    instead of retrying forever, see module comment above.
+
+    Returns (next_stream_id, next_consecutive_connection_errors).
+    """
+    try:
+        _, stream_id, _, _ = self_contained_coordinator_blocking_read(
+            **blocking_read_kwargs
+        )
+        return stream_id, 0
+    except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError) as e:
+        consecutive_connection_errors += 1
+        if consecutive_connection_errors > MAX_CONSECUTIVE_CONNECTION_ERRORS:
+            logging.critical(
+                "Event stream connection error persisted for {} consecutive "
+                "attempts: {}. Giving up and letting the process exit so it "
+                "can be restarted/alerted on, rather than retrying a "
+                "seemingly-permanent outage forever.".format(
+                    consecutive_connection_errors, e
+                )
+            )
+            raise
+        logging.warning(
+            "Event stream connection error on iteration (attempt {}): {}. "
+            "Retrying after a short backoff.".format(consecutive_connection_errors, e)
+        )
+        time.sleep(min(consecutive_connection_errors * 2, 30))
+        return blocking_read_kwargs["stream_id"], consecutive_connection_errors
 
 
 def check_health(container):

--- a/utils/tests/test_self_contained_coordinator_ack.py
+++ b/utils/tests/test_self_contained_coordinator_ack.py
@@ -5,8 +5,13 @@
 # mock-based unit tests -- no live redis/docker required.
 from unittest.mock import MagicMock, patch
 
+import redis.exceptions
+
 from redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator import (
     self_contained_coordinator_blocking_read,
+    _poll_for_work_with_retry,
+    _initial_stream_id,
+    MAX_CONSECUTIVE_CONNECTION_ERRORS,
 )
 
 
@@ -121,3 +126,124 @@ def test_blocking_read_acks_delivered_id_on_normal_success():
     assert acked_id == msg_id
     assert overall_result is True
     assert num_streams == 1
+
+
+# Regression tests for the crash-loop half of #519: a ~8126s-periodic
+# redis.exceptions.TimeoutError from the blocking XREADGROUP call, observed
+# live on x86-aws-m8a.metal-24xl, crashed the whole coordinator process on
+# every occurrence because main()'s while loop had no try/except around it.
+
+
+def test_poll_for_work_with_retry_survives_timeout_error():
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.self_contained_coordinator_blocking_read",
+        side_effect=redis.exceptions.TimeoutError("Timeout reading from socket"),
+    ), patch("time.sleep") as mock_sleep:
+        stream_id, errors = _poll_for_work_with_retry(
+            0, stream_id=">", some_other_kwarg="x"
+        )
+
+    # Must not raise (that's the whole point -- this used to kill the
+    # process), must preserve the stream_id for the next attempt, and must
+    # count the failure so a persistent outage backs off instead of
+    # busy-looping.
+    assert stream_id == ">"
+    assert errors == 1
+    mock_sleep.assert_called_once_with(2)
+
+
+def test_poll_for_work_with_retry_survives_connection_error_and_backs_off():
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.self_contained_coordinator_blocking_read",
+        side_effect=redis.exceptions.ConnectionError("Connection reset by peer"),
+    ), patch("time.sleep") as mock_sleep:
+        stream_id, errors = _poll_for_work_with_retry(3, stream_id="12345-0")
+
+    assert stream_id == "12345-0"
+    assert errors == 4
+    # backoff is min(errors * 2, 30) computed on the POST-increment count
+    mock_sleep.assert_called_once_with(8)
+
+
+def test_poll_for_work_with_retry_resets_error_count_on_success():
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.self_contained_coordinator_blocking_read",
+        return_value=(True, ">", 1, 1),
+    ):
+        stream_id, errors = _poll_for_work_with_retry(5, stream_id="9999-0")
+
+    assert stream_id == ">"
+    assert errors == 0
+
+
+def test_poll_for_work_with_retry_does_not_swallow_other_exceptions():
+    # Only the two transient-connection exception types are caught -- a
+    # genuine bug (e.g. TypeError from a bad call site) must still surface
+    # loudly rather than be silently retried forever.
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.self_contained_coordinator_blocking_read",
+        side_effect=TypeError("unrelated bug"),
+    ):
+        try:
+            _poll_for_work_with_retry(0, stream_id=">")
+            assert False, "expected TypeError to propagate"
+        except TypeError:
+            pass
+
+
+def test_poll_for_work_with_retry_gives_up_after_persistent_outage():
+    # A transient blip should retry silently, but a PERSISTENT connection
+    # failure (revoked credentials, endpoint genuinely gone) must eventually
+    # re-raise rather than retry forever -- the heartbeat thread keeps
+    # reporting "waiting" the whole time this loop is stuck, so an infinite
+    # silent retry would be a quieter version of the exact blind spot #519
+    # is about. Re-raising restores the old crash+respawn alerting signal.
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.self_contained_coordinator_blocking_read",
+        side_effect=redis.exceptions.TimeoutError("Timeout reading from socket"),
+    ), patch("time.sleep"):
+        try:
+            _poll_for_work_with_retry(MAX_CONSECUTIVE_CONNECTION_ERRORS, stream_id=">")
+            assert False, "expected the persistent outage to re-raise"
+        except redis.exceptions.TimeoutError:
+            pass
+
+
+def test_poll_for_work_with_retry_stays_silent_below_the_giveup_threshold():
+    with patch(
+        "redis_benchmarks_specification.__self_contained_coordinator__.self_contained_coordinator.self_contained_coordinator_blocking_read",
+        side_effect=redis.exceptions.TimeoutError("Timeout reading from socket"),
+    ), patch("time.sleep") as mock_sleep:
+        stream_id, errors = _poll_for_work_with_retry(
+            MAX_CONSECUTIVE_CONNECTION_ERRORS - 1, stream_id=">"
+        )
+
+    assert stream_id == ">"
+    assert errors == MAX_CONSECUTIVE_CONNECTION_ERRORS
+    mock_sleep.assert_called_once()
+
+
+# Regression tests for the other half of #519: --skip-clear-pending-on-startup
+# preserves this consumer's PEL across a restart, but a fresh process
+# previously always started at ">" (new work only) regardless, so that
+# preserved backlog was never actually retried -- just an inert liability
+# that grows across every crash-restart cycle.
+
+
+def test_initial_stream_id_drains_own_history_when_skip_clear_pending():
+    args = MagicMock(skip_clear_pending_on_startup=True, consumer_start_id=">")
+    assert _initial_stream_id(args) == "0"
+
+
+def test_initial_stream_id_uses_consumer_start_id_by_default():
+    args = MagicMock(skip_clear_pending_on_startup=False, consumer_start_id=">")
+    assert _initial_stream_id(args) == ">"
+
+
+def test_initial_stream_id_respects_explicit_consumer_start_id_override():
+    # An operator who explicitly overrides --consumer-start-id (e.g. to
+    # replay from a specific point) should still get that value when
+    # --skip-clear-pending-on-startup is NOT set -- only the skip-clear path
+    # forces "0".
+    args = MagicMock(skip_clear_pending_on_startup=False, consumer_start_id="12345-0")
+    assert _initial_stream_id(args) == "12345-0"


### PR DESCRIPTION
## Root cause

SSHed into the actual affected host (`x86-aws-m8a.metal-24xl`) and read the
coordinator's stderr log. The process crashes (exit status 1, uncaught
exception) with:

```
redis.exceptions.TimeoutError: Timeout reading from socket
```

raised from the blocking `XREADGROUP` call in
`self_contained_coordinator_blocking_read()`, called from `main()`'s bare
`while True:` loop with no `try/except`. This has been happening on a
strikingly consistent **~8126-8127 second cadence** (supervisor log,
2026-08-21 through 2026-08-22) — almost certainly an idle-connection reap
somewhere between this host and `benchmarks.redislabs.com:12010`, since
`XREADGROUP BLOCK 0` holds that socket open indefinitely with no traffic
while waiting for new work.

On the original issue's own "uptime rules this out" claim: the reproduction
there sampled for ~4 minutes against a process already 19+ minutes into its
uptime — far shorter than the ~8126s crash period, so it correctly ruled out
a restart *during that sample* without ruling out a crash on a much longer
cycle than was ever observed live. The supervisor log (spanning 2+ days)
shows exactly that longer cycle.

Two things compound this into #519's specific symptom (a runner silently
abandoning messages while its heartbeat looks healthy):

1. **The crash can race a real delivery.** `XREADGROUP`'s blocking wait is
   fulfilled server-side (message written into this consumer's PEL) as part
   of the same atomic operation that sends the reply. If the client's socket
   times out while that reply is in flight, the message is already pending
   in Redis but the client never learns its id. Uncaught, this kills the
   process before anything can ack it.
2. **`--skip-clear-pending-on-startup` preserves but never retries.** m8a's
   supervisor config passes this flag (added 2026-07-27, presumably to stop
   a plain restart from silently discarding legitimately-queued work). But
   nothing ever reads that preserved backlog back out: a fresh process
   always started at `">"` (new work only), never checking its own
   consumer's pending history first. So the flag succeeds at not being
   destructive, but nothing picks up what it preserves — it just
   accumulates forever instead of either being cleanly dropped (the default
   behavior) or retried.

## Fix

- Wrap the polling call in `try/except` for `(ConnectionError,
  TimeoutError)`, log, back off (2s × consecutive failures, capped at 30s),
  and retry — **bounded**: gives up and re-raises past
  `MAX_CONSECUTIVE_CONNECTION_ERRORS=20` so a genuinely permanent outage
  (revoked credentials) still surfaces as a crash+restart instead of
  retrying forever behind a heartbeat thread that keeps reporting "waiting"
  regardless. Extracted into `_poll_for_work_with_retry()` so it's
  unit-testable without invoking the rest of `main()`'s giant setup
  sequence.
- When `--skip-clear-pending-on-startup` is set, start the first
  `XREADGROUP` at id `"0"` instead of `">"` — extracted into
  `_initial_stream_id()`. `"0"` walks this consumer's own pending history
  (oldest first), reusing the exact alternating own-PEL-then-new-work logic
  `self_contained_coordinator_blocking_read` already has for every
  subsequent iteration; once drained it falls through to normal `">"`
  behavior on its own. No new `XPENDING`/`XCLAIM` code needed.

## Operational note for deploying this to m8a

The next process restart (the deploy itself) **is** what triggers the
backlog drain — not a separate step. It's also **unconditional**: no
age/staleness filter on what `"0"` walks, so all ~80 pending messages (some
19+ days old, possibly referencing since-merged/closed branches) get run
through the normal pipeline one at a time. A stale one that fails to
build/run is caught by `process_self_contained_coordinator_stream`'s
existing catch-all and acked as a failure rather than crashing anything —
wasted compute/time, not a correctness risk — but budget for up to ~80
sequential job attempts rather than being surprised by it. There's no
existing way to selectively drop old-but-pending entries for a single
consumer before restarting (the HTTP `/flush` endpoint's timestamp filter is
in-memory and only takes effect once the new process's HTTP server is up,
i.e. after this startup drain has already begun) — discarding rather than
replaying would need a manual PEL clear for this consumer first.

## Testing

10 new tests in `test_self_contained_coordinator_ack.py` (real assertions
against the extracted, mockable helpers — no live redis/docker needed):
survives `TimeoutError`/`ConnectionError`, resets the failure counter on
success, doesn't swallow unrelated exceptions, gives up past the bounded
retry threshold (and correctly stays silent right at the boundary), and all
three branches of `_initial_stream_id`. Full existing suite (37 tests
including `test_self_contained_coordinator.py`) still passes; `black
--check` clean.

Fixes #519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the coordinator’s work-consumption loop (retry vs crash, and PEL replay on restart). Bounded retries and existing job-failure handling limit blast radius, but a skip-clear deploy will replay all pending messages including stale ones.
> 
> **Overview**
> Stops the coordinator from crashing on idle-timeout `TimeoutError`/`ConnectionError` during blocking `XREADGROUP`, which was orphaning delivered-but-unacked work and looking healthy via heartbeat (#519).
> 
> The main poll loop now goes through `_poll_for_work_with_retry`: catch those two redis-py errors, exponential backoff (2s × consecutive, cap 30s), reset the counter on success, and re-raise after `MAX_CONSECUTIVE_CONNECTION_ERRORS` (20) so a real outage still crash-restarts instead of retrying forever behind a live heartbeat.
> 
> When `--skip-clear-pending-on-startup` is set, `_initial_stream_id` starts at `"0"` so the existing own-PEL-then-`>` path actually drains preserved pending messages instead of leaving them to accumulate. Unit tests cover retry, give-up, exception filtering, and the three start-id branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb80bd36596ec6bdb0c4779f94bad25e45562b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->