### PR TITLE
Add ZINTER, ZDIFF and SINTERCARD coverage at numkeys=8

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-set-500-elements-sintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-set-500-elements-sintercard.yml
@@ -1,0 +1,41 @@
+version: 0.4
+name: memtier_benchmark-8keys-set-500-elements-sintercard
+description: 'Runs memtier_benchmark issuing SINTERCARD over 8 sets of 500 elements each. SINTERCARD has no coverage today and is a separate implementation from the sorted-set numkeys commands. All 8 keys hold the identical member set so the cardinality is a constant 500.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 8
+  resources:
+    requests:
+      memory: 1g
+  init_lua: |
+    -- 8 sets all holding the identical 500-member set, so the intersection cardinality
+    -- is a constant 500.
+    for k = 1, 8 do
+      for m = 1, 500 do
+        redis.call('SADD', 'st:' .. k, 'm:' .. m)
+      end
+    end
+    return 1
+  dataset_name: 8keys-set-500-elements-identical-members
+  dataset_description: 8 sets, each containing the identical 500 members m:1..m:500.
+tested-commands:
+- sintercard
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="SINTERCARD 8 st:1 st:2 st:3 st:4 st:5 st:6 st:7 st:8 LIMIT 0"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- set
+priority: 131

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-set-500-elements-sintercard.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-set-500-elements-sintercard.yml
@@ -1,6 +1,6 @@
 version: 0.4
 name: memtier_benchmark-8keys-set-500-elements-sintercard
-description: 'Runs memtier_benchmark issuing SINTERCARD over 8 sets of 500 elements each. SINTERCARD has no coverage today and is a separate implementation from the sorted-set numkeys commands. All 8 keys hold the identical member set so the cardinality is a constant 500.'
+description: 'Runs memtier_benchmark issuing SINTERCARD over 8 sets of 500 elements each. SINTERCARD has no coverage today and is a separate implementation from the sorted-set numkeys commands. All 8 keys hold the identical member set so the cardinality is a constant 500. Encoding: hashtable (500 non-integer members, exceeds set-max-listpack-entries 128). Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zdiff.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zdiff.yml
@@ -1,0 +1,41 @@
+version: 0.4
+name: memtier_benchmark-8keys-zset-500-elements-zdiff
+description: 'Runs memtier_benchmark issuing ZDIFF over 8 sorted sets of 500 elements each. ZDIFF has no coverage today. The 8 member sets are pairwise disjoint, so the reply is the full first set (500 members) rather than the empty reply a naive overlapping dataset would produce. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 8
+  resources:
+    requests:
+      memory: 1g
+  init_lua: |
+    -- 8 sorted sets with pairwise-disjoint member sets, so ZDIFF over all 8 returns the
+    -- full first set (500 members) rather than an empty reply.
+    for k = 1, 8 do
+      for m = 1, 500 do
+        redis.call('ZADD', 'zs:' .. k, m, 'k' .. k .. ':m:' .. m)
+      end
+    end
+    return 1
+  dataset_name: 8keys-sorted-set-500-elements-disjoint-members
+  dataset_description: 8 sorted sets with pairwise-disjoint 500-member sets.
+tested-commands:
+- zdiff
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZDIFF 8 zs:1 zs:2 zs:3 zs:4 zs:5 zs:6 zs:7 zs:8"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- sorted-set
+priority: 131

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zdiff.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zdiff.yml
@@ -1,6 +1,6 @@
 version: 0.4
 name: memtier_benchmark-8keys-zset-500-elements-zdiff
-description: 'Runs memtier_benchmark issuing ZDIFF over 8 sorted sets of 500 elements each. ZDIFF has no coverage today. The 8 member sets are pairwise disjoint, so the reply is the full first set (500 members) rather than the empty reply a naive overlapping dataset would produce. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+description: 'Runs memtier_benchmark issuing ZDIFF over 8 sorted sets of 500 elements each. ZDIFF has no coverage today. The 8 member sets are pairwise disjoint, so the reply is the full first set (500 members) rather than the empty reply a naive overlapping dataset would produce. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zinter.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zinter.yml
@@ -5,21 +5,21 @@ dbconfig:
   configuration-parameters:
     save: '""'
   check:
-    keyspacelen: 64
+    keyspacelen: 8
   resources:
     requests:
       memory: 1g
   init_lua: |
-    -- 64 sorted sets all holding the identical 500-member set, so an intersection over
+    -- 8 sorted sets all holding the identical 500-member set, so an intersection over
     -- any subset returns a constant 500 and width is the only variable.
-    for k = 1, 64 do
+    for k = 1, 8 do
       for m = 1, 500 do
         redis.call('ZADD', 'ov:' .. k, m, 'm:' .. m)
       end
     end
     return 1
-  dataset_name: 64keys-sorted-set-500-elements-identical-members
-  dataset_description: 64 sorted sets, each containing the identical 500 members m:1..m:500.
+  dataset_name: 8keys-sorted-set-500-elements-identical-members
+  dataset_description: 8 sorted sets, each containing the identical 500 members m:1..m:500.
 tested-commands:
 - zinter
 redis-topologies:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zinter.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zinter.yml
@@ -1,6 +1,6 @@
 version: 0.4
 name: memtier_benchmark-8keys-zset-500-elements-zinter
-description: 'Runs memtier_benchmark issuing ZINTER over 8 sorted sets of 500 elements each. ZINTER has no coverage today. All 8 keys hold the identical member set so the reply is a constant 500 elements, making this the reply-producing counterpart to ZINTERCARD at the same width. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+description: 'Runs memtier_benchmark issuing ZINTER over 8 sorted sets of 500 elements each. ZINTER has no coverage today. All 8 keys hold the identical member set so the reply is a constant 500 elements, making this the reply-producing counterpart to ZINTERCARD at the same width. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128). Metric of interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zinter.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-8keys-zset-500-elements-zinter.yml
@@ -1,0 +1,41 @@
+version: 0.4
+name: memtier_benchmark-8keys-zset-500-elements-zinter
+description: 'Runs memtier_benchmark issuing ZINTER over 8 sorted sets of 500 elements each. ZINTER has no coverage today. All 8 keys hold the identical member set so the reply is a constant 500 elements, making this the reply-producing counterpart to ZINTERCARD at the same width. Encoding: skiplist (500 elements, exceeds zset-max-listpack-entries 128).'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 64
+  resources:
+    requests:
+      memory: 1g
+  init_lua: |
+    -- 64 sorted sets all holding the identical 500-member set, so an intersection over
+    -- any subset returns a constant 500 and width is the only variable.
+    for k = 1, 64 do
+      for m = 1, 500 do
+        redis.call('ZADD', 'ov:' .. k, m, 'm:' .. m)
+      end
+    end
+    return 1
+  dataset_name: 64keys-sorted-set-500-elements-identical-members
+  dataset_description: 64 sorted sets, each containing the identical 500 members m:1..m:500.
+tested-commands:
+- zinter
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZINTER 8 ov:1 ov:2 ov:3 ov:4 ov:5 ov:6 ov:7 ov:8"  --hide-histogram --test-time 120
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+tested-groups:
+- sorted-set
+priority: 131


### PR DESCRIPTION
## Summary

`ZINTER`, `ZDIFF` and `SINTERCARD` have **no suite at all** today. This adds one each at `numkeys=8`.

| Suite | Command | Reply |
|---|---|---|
| `memtier_benchmark-8keys-zset-500-elements-zinter` | `ZINTER 8 …` | 500 elements |
| `memtier_benchmark-8keys-zset-500-elements-zdiff` | `ZDIFF 8 …` | 500 elements |
| `memtier_benchmark-8keys-set-500-elements-sintercard` | `SINTERCARD 8 … LIMIT 0` | 500 |

### Seeding is the part that matters

Each dataset is chosen so the reply is **non-empty and constant**, which is less obvious than it sounds:

- **ZDIFF over an overlapping dataset returns nothing.** A suite seeded the same way as the ZINTER one would benchmark the empty-reply path rather than the diff. Its 8 member sets are therefore pairwise disjoint, so the reply is the full first set.
- **ZINTER and SINTERCARD** use identical member sets across all 8 keys, so the reply is a constant 500 regardless of width — leaving `numkeys` as the only variable if width sweeps are added later.

`SINTERCARD` is a separate implementation from the sorted-set numkeys commands, so it does not inherit coverage from them.

Seeding uses `init_lua` rather than inline `ZADD`/`SADD` literals — the two pre-existing suites in this family carry ~80KB of literals each.

Refs #525.

## Verification

```
poetry run redis-benchmarks-spec-cli --tool stats --fail-on-required-diff
  EXIT=0
  12 warnings — unchanged baseline, none referencing the new suites

poetry run pytest utils/tests/test_scope.py utils/tests/test_spec.py \
    utils/tests/test_topologies.py utils/tests/test_schema.py \
    utils/tests/test_admin.py::test_dry_run_topology_breakdown -q
  40 passed in 22.84s
```

`tested-groups` cross-checked programmatically against each command's `group` in `commands.json`: ZINTER/ZDIFF → `sorted-set`, SINTERCARD → `set`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds standalone benchmark YAML only; no runtime, auth, or data-path code changes.
> 
> **Overview**
> Adds first-time memtier coverage for `ZINTER`, `ZDIFF`, and `SINTERCARD` at `numkeys=8` (500 elements per key, skiplist/hashtable encodings).
> 
> Datasets are seeded via `init_lua` so replies stay non-empty and constant: identical members for `ZINTER`/`SINTERCARD` (cardinality 500), pairwise-disjoint members for `ZDIFF` so the reply is the full first set rather than empty. Suites run 120s on oss-standalone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0ca2e15000e41974b4cc5e465c09ac8deef7db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->