### PR TITLE
feat: add benchmark coverage for eviction under maxmemory pressure

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-eviction-allkeys-lru.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-eviction-allkeys-lru.yml
@@ -1,0 +1,75 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-set-eviction-allkeys-lru
+description: |
+  Steady-state SET throughput (Ops/sec) under continuous maxmemory eviction,
+  allkeys-lru policy, RAW-encoded strings (100B random values, >44B ⇒ RAW,
+  not EMBSTR). Closes a real coverage gap: no spec in the suite sets a
+  maxmemory limit, so performEvictions() (called from processCommand()
+  before every command's dispatch) and evictionPoolPopulate() (the
+  approximate-LRU sampling loop, maxmemory-samples=5 per cycle) have zero
+  benchmark coverage today, despite sitting directly in the write path for
+  any capped/cache-style deployment.
+
+  Design: maxmemory is set to 256MB, well below what the preload writes (3M
+  keys × ~154B/key resident cost ⇒ ~460MB uncapped) — eviction is therefore
+  already running continuously by the time preload finishes (empirically
+  verified: DBSIZE stabilizes around ~1.7M keys, used_memory pinned at the
+  256MB cap, evicted_keys climbing into the millions during preload alone).
+  This means the measured phase starts from an already-warm steady state,
+  not a cold fill — the number reflects the eviction cycle, not the fill
+  phase. The measured phase continues writing brand-new keys (a disjoint,
+  far larger id range than the preload used) at saturating throughput, so
+  every SET is a genuine new-key insert that must evict something to make
+  room, sustaining the same steady state for the full --test-time window.
+
+  dbconfig.check.keyspacelen is intentionally omitted: the resident key
+  count is not a fixed, asserted invariant here (unlike a plain preloaded
+  dataset) — it's whatever allkeys-lru's approximate-LRU sampling converges
+  to under the configured cap, which varies slightly run-to-run by design.
+  See memtier_benchmark-3Mkeys-string-set-eviction-allkeys-random.yml for
+  the allkeys-random sibling, which isolates evictionPoolPopulate's
+  sampling cost from allkeys-lru's additional pool-sort/recency bookkeeping
+  by changing only maxmemory-policy — everything else is identical.
+dbconfig:
+  configuration-parameters:
+    maxmemory: 268435456
+    maxmemory-policy: allkeys-lru
+    maxmemory-samples: 5
+    save: '""'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 100 -R --command "SET __key__ __data__" --command-key-pattern
+      P --key-minimum 1 --key-maximum 3000001 -n allkeys --pipeline 10 --hide-histogram
+      -c 25 -t 8
+  resources:
+    requests:
+      memory: 512mb
+  dataset_name: 3Mkeys-string-100B-eviction-allkeys-lru
+  dataset_description: |
+    Preload attempts 3,000,001 keys of 100-byte random RAW-encoded string
+    values into a server capped at 256MB maxmemory with allkeys-lru active
+    — eviction runs throughout preload itself, so the dataset never
+    actually reaches 3M resident keys. Empirically observed to stabilize
+    around ~1.7M resident keys with used_memory pinned at the 256MB cap.
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "100" -R --command "SET __key__ __data__" --command-key-pattern
+    P --key-minimum 3000002 --key-maximum 5003000002 --pipeline 10 -c 25 -t 8 --test-time
+    600 --hide-histogram'
+  resources:
+    requests:
+      cpus: '8'
+      memory: 1g
+tested-groups:
+- string
+priority: 61

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-eviction-allkeys-random.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-eviction-allkeys-random.yml
@@ -1,0 +1,73 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-set-eviction-allkeys-random
+description: |
+  Steady-state SET throughput (Ops/sec) under continuous maxmemory eviction,
+  allkeys-random policy, RAW-encoded strings (100B random values, >44B ⇒
+  RAW). Sibling of memtier_benchmark-3Mkeys-string-set-eviction-allkeys-lru.yml
+  with only maxmemory-policy changed. allkeys-random still runs
+  evictionPoolPopulate()'s maxmemory-samples candidate sampling on every
+  eviction cycle, but picks the victim uniformly at random from the sampled
+  set instead of allkeys-lru's approximate-LRU pool-sort/recency
+  bookkeeping. Comparing this spec against its allkeys-lru sibling isolates
+  the sampling cost (shared by both policies) from the LRU-specific
+  bookkeeping cost (present only in *-lru policies) — a regression that
+  only shows up on the lru sibling and not here localizes to the recency
+  tracking, not the sampling loop itself.
+
+  Design identical to the allkeys-lru sibling: maxmemory=256MB, well below
+  the ~460MB an uncapped 3M-key preload would resident (eviction is
+  therefore already running continuously by the time preload finishes —
+  steady state begins before the measured phase starts, not a cold fill).
+  The measured phase writes brand-new keys (a disjoint, far larger id range
+  than preload used) at saturating throughput, so every SET is a genuine
+  new-key insert that must evict something to make room.
+
+  dbconfig.check.keyspacelen is intentionally omitted for the same reason
+  as the allkeys-lru sibling: the resident key count is whatever the
+  eviction policy converges to under the cap, not a fixed invariant.
+dbconfig:
+  configuration-parameters:
+    maxmemory: 268435456
+    maxmemory-policy: allkeys-random
+    maxmemory-samples: 5
+    save: '""'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 100 -R --command "SET __key__ __data__" --command-key-pattern
+      P --key-minimum 1 --key-maximum 3000001 -n allkeys --pipeline 10 --hide-histogram
+      -c 25 -t 8
+  resources:
+    requests:
+      memory: 512mb
+  dataset_name: 3Mkeys-string-100B-eviction-allkeys-random
+  dataset_description: |
+    Preload attempts 3,000,001 keys of 100-byte random RAW-encoded string
+    values into a server capped at 256MB maxmemory with allkeys-random
+    active — eviction runs throughout preload itself, so the dataset never
+    actually reaches 3M resident keys. Resident count converges under
+    random victim selection rather than LRU-ordered selection, so it is
+    not expected to numerically match the allkeys-lru sibling's ~1.7M —
+    both stabilize at the same used_memory ceiling (256MB), not the same
+    key count.
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "100" -R --command "SET __key__ __data__" --command-key-pattern
+    P --key-minimum 3000002 --key-maximum 5003000002 --pipeline 10 -c 25 -t 8 --test-time
+    600 --hide-histogram'
+  resources:
+    requests:
+      cpus: '8'
+      memory: 1g
+tested-groups:
+- string
+priority: 62

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-eviction-volatile-lru.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-3Mkeys-string-set-eviction-volatile-lru.yml
@@ -1,0 +1,89 @@
+version: 0.4
+name: memtier_benchmark-3Mkeys-string-set-eviction-volatile-lru
+description: |
+  Steady-state SET throughput (Ops/sec) under continuous maxmemory
+  eviction, volatile-lru policy, RAW-encoded strings (100B random values,
+  >44B ⇒ RAW). Every key carries a 24h TTL (SET __key__ __data__ EX 86400)
+  — long enough that no key ever expires naturally within the 600s
+  measured window, so every eviction observed is driven purely by memory
+  pressure, not the active-expire cycle. volatile-lru samples its eviction
+  candidates from Redis's separate `expires` dict rather than the main
+  keyspace dict that allkeys-lru/allkeys-random walk, so this exercises a
+  genuinely different sampling population, not just a different victim-
+  selection rule on the same structure.
+
+  Scope note / simplification vs. a fully mixed dataset: the originating
+  issue's suggested design has only *some* keys carrying a TTL, so the
+  sampler has to skip non-candidates while scanning. That would need two
+  disjoint key-id pools (TTL-bearing vs. permanent) sized independently —
+  not practical to build reliably in a single spec, since memtier's
+  --key-minimum/--key-maximum are global to the whole invocation, not
+  settable per --command, and dbconfig only supports one preload_tool
+  phase (a second phase via init_commands runs *after* preload_tool here,
+  not before, so it can't lay down a disjoint baseline pool first either).
+  This spec instead makes every key volatile, which still isolates the
+  expires-dict sampling machinery as new coverage, just without the
+  candidate/non-candidate skip-scanning nuance. A follow-up spec adding a
+  genuinely mixed pool is possible but needs new plumbing (e.g. a
+  multi-stage preload), not just a YAML change.
+
+  Design otherwise identical to the allkeys-lru/allkeys-random siblings:
+  maxmemory=256MB (well below the ~530MB an uncapped 3M-key TTL-bearing
+  preload would resident — TTL tracking adds a per-key `expires` dict
+  entry on top of the plain-string ~154B/key cost), so eviction is already
+  running continuously by the time preload finishes. The measured phase
+  writes brand-new keys (each also carrying EX 86400, a disjoint far
+  larger id range than preload used) at saturating throughput, so every
+  SET both grows the volatile pool and is itself immediately eviction-
+  eligible, sustaining the same steady state for the full --test-time
+  window without ever exhausting the evictable population.
+
+  dbconfig.check.keyspacelen is intentionally omitted, as with the
+  allkeys-lru/allkeys-random siblings: the resident key count is whatever
+  volatile-lru's sampling converges to under the cap (empirically observed
+  around ~1.45M, lower than allkeys-lru's ~1.7M due to the extra
+  per-key expires-dict overhead), not a fixed invariant.
+dbconfig:
+  configuration-parameters:
+    maxmemory: 268435456
+    maxmemory-policy: volatile-lru
+    maxmemory-samples: 5
+    save: '""'
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --data-size 100 -R --command "SET __key__ __data__ EX 86400" --command-key-pattern
+      P --key-minimum 1 --key-maximum 3000001 -n allkeys --pipeline 10 --hide-histogram
+      -c 25 -t 8
+  resources:
+    requests:
+      memory: 512mb
+  dataset_name: 3Mkeys-string-100B-eviction-volatile-lru-ttl
+  dataset_description: |
+    Preload attempts 3,000,001 keys of 100-byte random RAW-encoded string
+    values, every key carrying a 24h TTL, into a server capped at 256MB
+    maxmemory with volatile-lru active — eviction runs throughout preload
+    itself, so the dataset never actually reaches 3M resident keys.
+    Empirically observed to stabilize around ~1.45M resident keys with
+    used_memory pinned at the 256MB cap.
+tested-commands:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: '"--data-size" "100" -R --command "SET __key__ __data__ EX 86400" --command-key-pattern
+    P --key-minimum 3000002 --key-maximum 5003000002 --pipeline 10 -c 25 -t 8 --test-time
+    600 --hide-histogram'
+  resources:
+    requests:
+      cpus: '8'
+      memory: 1g
+tested-groups:
+- string
+priority: 63


### PR DESCRIPTION
## Problem

No spec in the suite ever sets a `maxmemory` limit -- 8 specs pin
`maxmemory-policy: noeviction`, one issues `CONFIG GET maxmemory` as a
client command, and nothing else touches it. With no limit set,
`performEvictions()` never enters its eviction loop and
`evictionPoolPopulate()` never runs, so a hot loop sitting directly in
the write command path (`processCommand()` calls `performEvictions()`
before dispatch; `evictionTimeProc()` calls it again to keep evicting)
has zero benchmark coverage today, despite affecting ordinary GET/SET
latency on any capped, cache-style deployment.

## What this adds

Three SET throughput (Ops/sec) specs against RAW-encoded 100B string
values, `maxmemory` capped at 256MB so the working set overflows it by
design:

- **allkeys-lru** -- full approximate-LRU sampling + pool-sort/recency
  bookkeeping.
- **allkeys-random** -- same sampling loop, uniform-random victim
  selection instead of LRU bookkeeping. Comparing the two isolates
  sampling cost (shared by both) from LRU-specific bookkeeping cost
  (lru-only) -- a regression on only one sibling localizes the cause.
- **volatile-lru** -- every key carries a 24h TTL (long enough not to
  expire naturally within the 600s window), so eviction samples from
  Redis's separate `expires` dict rather than the main keyspace dict
  the other two walk -- a genuinely different sampling population.

## Design (verified empirically, not just reasoned about)

Preload deliberately writes far more data than the 256MB cap holds (a
plain 3M-key/100B-value preload would resident ~460MB uncapped), so
eviction is already running continuously by the time preload finishes
-- the measured phase starts from an already-warm steady state, not a
cold fill. Verified live against a local build: `used_memory` pins
almost exactly at the 256MB cap for all three policies (`evicted_keys`
climbing continuously), with resident key count settling around ~1.7M
for allkeys-lru/random and ~1.45M for volatile-lru (extra per-key
`expires` dict overhead). The measured phase then writes brand-new
keys over a disjoint id range (`3,000,002`-`5,003,000,002`, ~5 billion
ids of headroom -- would need >8.3M sustained ops/sec to exhaust,
comfortably beyond any realistic single-instance throughput for this
workload), so every SET is a genuine new-key insert that must evict
something to make room.

`dbconfig.check.keyspacelen` is intentionally omitted on all three:
the resident count isn't a fixed invariant, it's whatever the eviction
policy converges to under the cap -- asserting an exact value would be
flaky by construction. Matches existing precedent in this repo's own
memtier-benchmark-design skill (the SADD intset→hashtable worked
example explicitly documents this same "keyspacelen is run-created,
not asserted" pattern).

## Explicitly out of scope

- The issue's optional maxmemory-samples (5 vs 10) sweep -- marked
  "Optionally" in the original request, a natural low-cost follow-up.
- Reporting `evicted_keys` from `INFO` alongside throughput -- the
  `exporter.metrics` mechanism (`defaults.yml`) is JSONPath into
  memtier's own client-side JSON only; there's no existing path to
  export a server-side `INFO` field as a spec metric. Would need new
  plumbing beyond a spec-only PR.
- volatile-lru's partial-TTL-coverage nuance (some keys non-candidate,
  so the sampler has to skip them) -- building two independently-sized
  disjoint key-id pools isn't practical in a single spec today:
  memtier's `--key-minimum`/`--key-maximum` are global to the whole
  invocation (not settable per `--command`), and `dbconfig` supports
  exactly one `preload_tool` phase (a second phase via `init_commands`
  runs *after* `preload_tool`, not before, so it can't lay down a
  disjoint baseline pool first either). This spec makes every key
  volatile instead -- still new, previously-zero coverage of the
  separate expires-dict sampling machinery, just without the
  skip-scanning nuance.

## Testing

`redis-benchmarks-spec-cli --tool stats --fail-on-required-diff`
passes clean on all three new specs. Adversarial review independently
reproduced the core eviction-steady-state behavior at both 1/30 scale
and full scale against a local build, confirmed the `-n allkeys`/
`--command-key-pattern P` preload form creates exactly `key-maximum`
keys with no off-by-one, and confirmed `SET ... EX 86400` is reported
by memtier as a plain `Sets` command with a real TTL applied. Review
also caught and fixed a real gap: the client key range was initially
too narrow (memtier silently wraps and overwrites rather than erroring
on range exhaustion, which would have quietly degraded eviction
pressure on fast-enough hardware) -- widened 10x to close it with a
large safety margin.

Addresses #497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only benchmark specs; no runtime, auth, or data-path code. Risk is mainly extra CI time and possible flakiness from non-asserted resident key counts.
> 
> **Overview**
> Adds the first suite coverage of **continuous maxmemory eviction** on the SET write path (`performEvictions` / `evictionPoolPopulate`), which previously never ran because no spec set a memory cap.
> 
> Three sibling standalone SET (Ops/sec) specs preload ~3M 100B RAW strings against `maxmemory=256MB` so eviction is already at steady state before the 600s measured phase. The measured phase writes new keys on a disjoint id range so every SET must evict. Policies: **allkeys-lru**, **allkeys-random** (same sampling, no LRU bookkeeping), and **volatile-lru** (all keys get a 24h TTL so sampling walks the `expires` dict). `keyspacelen` is omitted because resident count is policy-dependent, not a fixed invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621151129305ff0a9f57bbbdfcb91653d0565c2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->