### PR TITLE
Add ZMSCORE member-count coverage at 1/16/32/33 (prefetch batch boundaries)

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-1-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-1-members.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zmscore-1-members
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1,000,000 elements (integer members 1..1,000,000, all with a constant score of 1) and
+  we query it using ZMSCORE with 1 independent random members per call. Sibling of the existing
+  memtier_benchmark-1key-zset-1M-elements-zmscore-100-members suite (same dataset, same preload,
+  same query shape) -- this family sweeps the member-count axis at 1/16/17/100 to cover the
+  intra-command dict-prefetch batching thresholds that the 100-member-only suite left unmeasured.
+  This width sits below the intra-command dict-prefetch batching threshold (batching only engages when more than 1 member is requested), so it exercises the plain, unbatched ZMSCORE lookup loop -- the baseline every wider call is compared against. Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  interest: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb 1 __key__" --command-key-pattern=P
+      --key-minimum 1 --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-const-score
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements
+    (integer members 1..1,000,000, verified via live ZCARD), each with a constant score of 1.
+tested-groups:
+- sorted-set
+tested-commands:
+- zmscore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZMSCORE lb __key__"
+    --key-minimum 1 --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-16-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-16-members.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zmscore-16-members
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1,000,000 elements (integer members 1..1,000,000, all with a constant score of 1) and
+  we query it using ZMSCORE with 16 independent random members per call. Sibling of the existing
+  memtier_benchmark-1key-zset-1M-elements-zmscore-100-members suite (same dataset, same preload,
+  same query shape) -- this family sweeps the member-count axis at 1/16/17/100 to cover the
+  intra-command dict-prefetch batching thresholds that the 100-member-only suite left unmeasured.
+  This width lands on exactly one full intra-command dict-prefetch batch boundary. Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  interest: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb 1 __key__" --command-key-pattern=P
+      --key-minimum 1 --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-const-score
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements
+    (integer members 1..1,000,000, verified via live ZCARD), each with a constant score of 1.
+tested-groups:
+- sorted-set
+tested-commands:
+- zmscore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
+    --key-minimum 1 --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-17-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-17-members.yml
@@ -1,0 +1,47 @@
+version: 0.4
+name: memtier_benchmark-1key-zset-1M-elements-zmscore-17-members
+description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
+  contains 1,000,000 elements (integer members 1..1,000,000, all with a constant score of 1) and
+  we query it using ZMSCORE with 17 independent random members per call. Sibling of the existing
+  memtier_benchmark-1key-zset-1M-elements-zmscore-100-members suite (same dataset, same preload,
+  same query shape) -- this family sweeps the member-count axis at 1/16/17/100 to cover the
+  intra-command dict-prefetch batching thresholds that the 100-member-only suite left unmeasured.
+  This width is one member past a full intra-command dict-prefetch batch -- the shape where a naive fixed-size chunking implementation would leave a trailing batch of exactly 1 member with no prefetch benefit; adaptive batch sizing folds it into the prior batch instead. Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  interest: Ops/sec.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --pipeline 50 --command="ZADD lb 1 __key__" --command-key-pattern=P
+      --key-minimum 1 --key-maximum 1000000 --key-prefix "" -n 100000 --hide-histogram -t 10 -c 1
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1key-zset-1M-elements-const-score
+  dataset_description: This dataset contains 1 sorted set key with 1,000,000 elements
+    (integer members 1..1,000,000, verified via live ZCARD), each with a constant score of 1.
+tested-groups:
+- sorted-set
+tested-commands:
+- zmscore
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
+    --key-minimum 1 --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '4'
+      memory: 2g
+priority: 73

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-32-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-32-members.yml
@@ -1,16 +1,13 @@
 version: 0.4
-name: memtier_benchmark-1key-zset-1M-elements-zmscore-16-members
+name: memtier_benchmark-1key-zset-1M-elements-zmscore-32-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
   contains 1,000,000 elements (integer members 1..1,000,000, all with a constant score of 1) and
-  we query it using ZMSCORE with 16 independent random members per call. Sibling of the existing
+  we query it using ZMSCORE with 32 independent random members per call. Sibling of the existing
   memtier_benchmark-1key-zset-1M-elements-zmscore-100-members suite (same dataset, same preload,
   same query shape) -- this family sweeps the member-count axis to cover the intra-command
-  dict-prefetch batching thresholds that the 100-member-only suite left unmeasured. 16 is the
-  server-side batch-size constant (ZMSCORE_PREFETCH_BATCH) itself: at this width the whole call
-  is handled as a single undivided dict-prefetch batch (the adaptive-shrink rule only splits a
-  call into multiple batches once at least twice the batch size, 32, remains -- see the 32- and
-  33-member sibling suites for that boundary). Encoding: skiplist (1,000,000 elements, exceeds
-  zset-max-listpack-entries 128). Metric of interest: Ops/sec.'
+  dict-prefetch batching thresholds that the 100-member-only suite left unmeasured. 32 is the smallest width where the dict-prefetch batching actually splits into multiple dictPrefetchKeys calls: the adaptive-shrink rule only takes a full ZMSCORE_PREFETCH_BATCH-sized (16) chunk when at least twice that many members remain, so 32 is handled as two clean, evenly-sized batches of 16 -- the first point at which the multi-batch loop path is exercised at all.
+  Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -40,7 +37,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
+  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
     --key-minimum 1 --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
     --test-time 180 --pipeline 1 -c 1 -t 1
   resources:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-33-members.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-zset-1M-elements-zmscore-33-members.yml
@@ -1,12 +1,12 @@
 version: 0.4
-name: memtier_benchmark-1key-zset-1M-elements-zmscore-17-members
+name: memtier_benchmark-1key-zset-1M-elements-zmscore-33-members
 description: 'Runs memtier_benchmark, for a keyspace length of 1 SORTED SET key. The SORTED SET
   contains 1,000,000 elements (integer members 1..1,000,000, all with a constant score of 1) and
-  we query it using ZMSCORE with 17 independent random members per call. Sibling of the existing
+  we query it using ZMSCORE with 33 independent random members per call. Sibling of the existing
   memtier_benchmark-1key-zset-1M-elements-zmscore-100-members suite (same dataset, same preload,
-  same query shape) -- this family sweeps the member-count axis at 1/16/17/100 to cover the
-  intra-command dict-prefetch batching thresholds that the 100-member-only suite left unmeasured.
-  This width is one member past a full intra-command dict-prefetch batch -- the shape where a naive fixed-size chunking implementation would leave a trailing batch of exactly 1 member with no prefetch benefit; adaptive batch sizing folds it into the prior batch instead. Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
+  same query shape) -- this family sweeps the member-count axis to cover the intra-command
+  dict-prefetch batching thresholds that the 100-member-only suite left unmeasured. 33 is one member past the clean 32-member split: it is handled as a 16-member batch followed by a 17-member batch, not as 16+16+1. This is the shape a naive fixed-size chunking implementation (no adaptive shrink) would instead split into a trailing batch of exactly 1 member -- which the underlying dict-prefetch primitive silently gives no prefetch benefit to -- so this suite is the direct proof that the adaptive-shrink rule folds that remainder away rather than stranding it.
+  Encoding: skiplist (1,000,000 elements, exceeds zset-max-listpack-entries 128). Metric of
   interest: Ops/sec.'
 dbconfig:
   configuration-parameters:
@@ -37,7 +37,7 @@ build-variants:
 clientconfig:
   run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
+  arguments: --command="ZMSCORE lb __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__ __key__"
     --key-minimum 1 --key-maximum 1000000 --command-key-pattern=R --key-prefix "" --hide-histogram
     --test-time 180 --pipeline 1 -c 1 -t 1
   resources:


### PR DESCRIPTION
The existing `memtier_benchmark-1key-zset-1M-elements-zmscore-100-members` suite only
exercises a wide member count (100), deep into multi-batch prefetch territory. It never
measures:
- **1 member** — below the batching threshold, the plain unbatched lookup loop.
- **16 members** — exactly the server-side batch-size constant (`ZMSCORE_PREFETCH_BATCH`),
  handled as a single undivided `dictPrefetchKeys()` call.
- **32 members** — the first width where batching actually splits into multiple calls: a
  clean, even 16+16.
- **33 members** — one past that split: 16+17, not 16+16+1. This is the direct proof that
  the adaptive-shrink rule folds a would-be trailing remainder into the previous batch
  rather than stranding it as a batch of 1 (which the underlying prefetch primitive
  silently gives no benefit to) — the exact shape a naive fixed-size chunker would get
  wrong.

All 4 new suites are siblings of the existing 100-member one: same 1M-element
constant-score dataset, same preload, same query shape — only the ZMSCORE member count
differs, isolating the member-count axis cleanly.

Reviewed against the memtier design/review checklist: encoding + metric stated in each
description (skiplist, Ops/sec), `keyspacelen`/preload identical to the already-verified
sibling, single-letter `--command-key-pattern`, no drain risk (read-only), no newer-build-only
flags on the `:edge` image.

(Original PR used 1/16/17 — Cursor Bugbot correctly caught that 16/17 don't actually exercise
any batch-splitting at all with the current `ZMSCORE_PREFETCH_BATCH=16` constant; replaced
with the real 32/33 boundary. See PR comments.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds YAML benchmark specs only; no runtime, auth, or data-handling code. Extra CI load from four new standalone suites.
> 
> **Overview**
> Adds four sibling `ZMSCORE` memtier suites on the same 1M-element constant-score skiplist dataset as the existing 100-member suite, isolating member count at **1 / 16 / 32 / 33**.
> 
> Those widths map to the intra-command dict-prefetch path: unbatched lookup (1), a single `ZMSCORE_PREFETCH_BATCH` of 16, the first multi-batch split (32 = 16+16), and the adaptive-shrink remainder (33 = 16+17 instead of a stranded 1). Metric remains Ops/sec; preload, topology, and build variants match the 100-member sibling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9822ba7a8d3f1a3e1d1216c6f716c031742d7601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->