### PR TITLE
fix(test-suites): correct preload key-maximum in the 100-field HMGET

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1-template.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1-template.yml
@@ -29,7 +29,7 @@ dbconfig:
       __data__ field83 __data__ field84 __data__ field85 __data__ field86 __data__ field87 __data__ field88 __data__ field89
       __data__ field90 __data__ field91 __data__ field92 __data__ field93 __data__ field94 __data__ field95 __data__ field96
       __data__ field97 __data__ field98 __data__ field99 __data__ field100 __data__" --command-key-pattern="P" --key-minimum=1
-      --key-maximum 10000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50
+      --key-maximum 1000000 -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50
 
       '
   resources:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1.yml
@@ -41,7 +41,7 @@ dbconfig:
       field89 __data__ field90 __data__ field91 __data__ field92 __data__
       field93 __data__ field94 __data__ field95 __data__ field96 __data__
       field97 __data__ field98 __data__ field99 __data__ field100 __data__"
-      --command-key-pattern="P" --key-minimum=1 --key-maximum 10000000
+      --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000
       -n 5000 -c 50 -t 4 --hide-histogram --pipeline 50
   resources:
     requests:


### PR DESCRIPTION
Follow-up to #489, which fixed seven hash read specs but not these two: the preload_tool --key-maximum is 10x the measured phase's, so with --command-key-pattern=P each client's block is 10x too large and -n fills only its first 10%. ~90% of the measured HMGETs then hit keys that were never written, reply with 100 nulls, and never touch a hash at all. The keyspacelen check still passes because the other 90% of the written keys land above the measured range.

  1Mkeys-hash-hmget-100of100-fields-with-32B-values-pipeline-1[-template]
    preload  --key-maximum 10000000, 200 clients -> block 50000, -n 5000 = 10%
    measured --key-maximum 1000000 -> 20 blocks x 5000 = 100k of 1M keys exist

Verified twice on redis unstable, client and server co-located on one host (server pinned to NUMA node 0, native memtier to node 1), before -> after:

  @ ead4b4e4b, spec 0.3.31, 180s measured phase
    hits / misses per sec  772,841 / 7,034,332 (9.9% hits) -> 2,301,374 / 0
    ops/sec                78,072 -> 23,014
    server usec_per_call   4.56 -> 34.34

  @ 065d39703, spec 0.3.38 (this rebase), 30s measured phase
    hits / misses per sec  776,435 / 7,112,527 (9.9% hits) -> 2,309,868 / 0
    ops/sec                78,890 -> 23,099
    server usec_per_call   4.33 -> 34.49

dbsize is 1,000,000 in both arms, which is exactly why this hid: the preload writes the same number of keys either way, they just land outside the measured range.

The 8x rise in usec_per_call is the point: a miss costs a fraction of a hit, so before the fix this spec mostly measured lookups of absent keys. ~34.4 us/call is the real cost of resolving 100 fields of a 100-field listpack hash.

Note that a broken P-pattern preload is only visible with native memtier: the Docker memtier image reports Hits/sec and Misses/sec as 0.000 for --command-style specs, which is why this went unnoticed.

-n is left untouched, so the preload issues the same number of writes as before and its runtime is unchanged, and the block size now matches -n exactly - the same convention the other 200-client preloads in this folder use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-spec YAML only; no runtime product code, but HMGET results and comparisons will change materially because the measured workload is corrected.
> 
> **Overview**
> Corrects a **preload vs. measured keyspace mismatch** in the two **1M-key, 100-field HMGET** memtier specs (base and template). Preload `--key-maximum` drops from **10,000,000** to **1,000,000** so it matches `keyspacelen`, the client HMGET range, and the “1M keys” dataset.
> 
> With `--command-key-pattern=P`, the old 10× larger preload block meant most measured HMGETs targeted keys that were never written (~90% misses, null replies) while `keyspacelen` still passed. Benchmark throughput and latency were dominated by misses, not real listpack hash reads; after the fix, hits cover the measured range and reported cost reflects actual 100-field HMGET work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fccac67e7b1316591c437c5e83c5731d500748a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->