### PR TITLE
ci: raise claude review max-turns 35 -> 99

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -118,7 +118,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr list:*)"
-            --max-turns 35
+            --max-turns 99
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if the issue is already clear/actionable and needs no comment"},"comment_body":{"type":"string","description":"The triage comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -172,7 +172,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*)"
-            --max-turns 35
+            --max-turns 99
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if this routine/out-of-scope PR should get no comment at all"},"comment_body":{"type":"string","description":"The review comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)


### PR DESCRIPTION
Matches the same bump applied to sibling repos (redisbench-admin, go-ycsb, memtier_benchmark) after redisbench-admin's live push/review/iterate loop hit `error_max_turns` again at 35.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only configuration tweak with no application, auth, or data-path changes; main effect is slightly higher API usage on complex runs.
> 
> **Overview**
> Raises the Claude Code action **`--max-turns`** limit from **35** to **99** in the automated **issue triage** and **PR review** workflows so longer read-only `gh` lookup loops can finish instead of failing with **`error_max_turns`**.
> 
> No other workflow behavior, prompts, tool allowlists, or posting gates change—only the turn budget for the model step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd6174db955d213eec1429391648f3a72b1ce271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->