### PR TITLE
pubsub: add low-channel-count and uneven-publish-rate suites

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers.yml
@@ -1,0 +1,58 @@
+version: 0.4
+name: memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers
+description: Publish/subscribe where publish rate is deliberately uneven across client
+  connections. Every other pubsub suite drives all publisher connections at the same rate,
+  which spreads load evenly over server/proxy worker threads and makes per-worker imbalance
+  unmeasurable by construction. Real deployments are not uniform - a small number of busy
+  producers alongside many quiet ones is the common shape, and because a connection is
+  handled by one worker for its lifetime, a single high-rate connection loads its worker far
+  harder than the rest. This suite pairs one heavily pipelined publisher with a pool of
+  lightly loaded ones so that per-worker distribution, not just aggregate throughput,
+  becomes an observable property.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- pubsub
+tested-commands:
+- publish
+- subscribe
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfigs:
+# Hot publisher: a single connection carrying a large share of the publishes.
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 --key-prefix "channel-" --pipeline 30 -d 128 --key-maximum
+    10 --command "PUBLISH __key__ __data__" --command-key-pattern="R" -c 1 -t 1
+    --hide-histogram
+  resources:
+    requests:
+      cpus: '2'
+      memory: 1g
+# Background publishers: many connections, each at a low per-connection rate.
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 --key-prefix "channel-" --pipeline 1 -d 128 --key-maximum
+    10 --command "PUBLISH __key__ __data__" --command-key-pattern="R" -c 12 -t 4
+    --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+- run_image: filipe958/pubsub-sub-bench:latest
+  tool: pubsub-sub-bench
+  arguments: -clients 170 -channel-minimum 1 -channel-maximum 10 -subscriber-prefix
+    "channel-" -mode subscribe -test-time 120 -subscribers-per-channel 17
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 23

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers.yml
@@ -1,14 +1,15 @@
 version: 0.4
 name: memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers
-description: Publish/subscribe where publish rate is deliberately uneven across client
-  connections. Every other pubsub suite drives all publisher connections at the same rate,
-  which spreads load evenly over server/proxy worker threads and makes per-worker imbalance
-  unmeasurable by construction. Real deployments are not uniform - a small number of busy
-  producers alongside many quiet ones is the common shape, and because a connection is
-  handled by one worker for its lifetime, a single high-rate connection loads its worker far
-  harder than the rest. This suite pairs one heavily pipelined publisher with a pool of
-  lightly loaded ones so that per-worker distribution, not just aggregate throughput,
-  becomes an observable property.
+description: Publish/subscribe with deliberately few publisher connections, so that publish
+  load concentrates on a small number of server or proxy worker threads. Where connections are
+  assigned to workers round-robin at accept and then handled by that worker for their lifetime,
+  per-worker load is governed by how many publisher connections landed on each worker, not by
+  pipeline depth or per-connection rate. Suites that open many publisher connections therefore
+  place publish work on every worker and average the imbalance away by construction - 200
+  connections spread over 8 workers is 25 apiece, and the hottest worker sees exactly its even
+  share. This suite opens 3 publisher connections against the same 10 channels and 170
+  subscribers as the sibling suite, so only a few workers carry publish traffic at all and
+  per-worker distribution becomes an observable property rather than an assumption.
 dbconfig:
   configuration-parameters:
     save: '""'
@@ -27,25 +28,16 @@ build-variants:
 - gcc:15.2.0-arm64-debian-bookworm-default
 - dockerhub
 clientconfigs:
-# Hot publisher: a single connection carrying a large share of the publishes.
+# Few publisher connections. With round-robin accept, 3 connections occupy 3 workers and the
+# rest carry no publish traffic; pipeline supplies the rate, not the concentration.
 - run_image: redislabs/memtier_benchmark:edge
   tool: memtier_benchmark
-  arguments: --test-time 120 --key-prefix "channel-" --pipeline 30 -d 128 --key-maximum
-    10 --command "PUBLISH __key__ __data__" --command-key-pattern="R" -c 1 -t 1
+  arguments: --test-time 120 --key-prefix "channel-" --pipeline 10 -d 128 --key-maximum
+    10 --command "PUBLISH __key__ __data__" --command-key-pattern="R" -c 3 -t 1
     --hide-histogram
   resources:
     requests:
       cpus: '2'
-      memory: 1g
-# Background publishers: many connections, each at a low per-connection rate.
-- run_image: redislabs/memtier_benchmark:edge
-  tool: memtier_benchmark
-  arguments: --test-time 120 --key-prefix "channel-" --pipeline 1 -d 128 --key-maximum
-    10 --command "PUBLISH __key__ __data__" --command-key-pattern="R" -c 12 -t 4
-    --hide-histogram
-  resources:
-    requests:
-      cpus: '4'
       memory: 1g
 - run_image: filipe958/pubsub-sub-bench:latest
   tool: pubsub-sub-bench

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-mixed-10-channels-128B-publishers-170-subscribers.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-nokeys-pubsub-mixed-10-channels-128B-publishers-170-subscribers.yml
@@ -1,0 +1,45 @@
+version: 0.4
+name: memtier_benchmark-nokeys-pubsub-mixed-10-channels-128B-publishers-170-subscribers
+description: Publish/subscribe over a deliberately small channel set. The existing pubsub
+  suites use 100 or 1000 channels with uniform-random channel selection, which spreads
+  delivery evenly across proxy workers by construction. Real deployments frequently run
+  a handful of channels with many subscribers each, and that concentration is what loads
+  individual workers unevenly. This suite fixes the channel count at 10 with ~17
+  subscribers per channel so the per-worker distribution, not just aggregate throughput,
+  becomes observable.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  resources:
+    requests:
+      memory: 2g
+tested-groups:
+- pubsub
+tested-commands:
+- publish
+- subscribe
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfigs:
+- run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --test-time 120 --key-prefix "channel-" --pipeline 1 -d 128 --key-maximum
+    10 --command "PUBLISH __key__ __data__" --command-key-pattern="R" -c 50 -t 4
+    --hide-histogram
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+- run_image: filipe958/pubsub-sub-bench:latest
+  tool: pubsub-sub-bench
+  arguments: -clients 170 -channel-minimum 1 -channel-maximum 10 -subscriber-prefix
+    "channel-" -mode subscribe -test-time 120 -subscribers-per-channel 17
+  resources:
+    requests:
+      cpus: '4'
+      memory: 1g
+priority: 23


### PR DESCRIPTION
The existing pubsub suites use 100 or 1000 channels, select the channel uniformly at random (`--command-key-pattern="R"`), and drive every publisher connection at the same rate. That is a good throughput benchmark, but it makes two properties invisible by construction.

### 1. Channel concentration — `mixed-10-channels-128B-publishers-170-subscribers`

Spreading publishes uniformly over 100+ channels averages away any concentration. Deployments commonly run a handful of channels with many subscribers each, which is a different regime for delivery. This suite pins 10 channels with ~17 subscribers each (170 total), keeping the 128B payload and mixed publish/subscribe structure of the existing 100-channel suites so results stay comparable across the family.

### 2. Uneven publish rate — `10-channels-128B-skewed-publishers-170-subscribers`

Where a connection is handled by one worker thread for its lifetime, worker load is determined by the *per-connection* command rate of whatever landed there. Driving every connection at the same rate therefore produces near-perfect balance regardless of the workload, and aggregate ops/sec cannot tell an evenly loaded set of workers from a badly skewed one.

Real traffic is rarely uniform — a few busy producers among many quiet ones is the common shape. This suite pairs one heavily pipelined publisher (1 connection, pipeline 30) with a pool of lightly loaded ones (48 connections, pipeline 1), over the same channels and subscribers as the suite above, so the two differ *only* in how publish rate is distributed.

With 8 workers this predicts ~3.7x max/mean worker skew against ~1.0x measured for the uniform suites — enough separation to make per-worker distribution a measurable property rather than an assumption. Pipeline depth on the hot client is the knob for dialling the ratio.

### Notes

- Both suites validate against the repo's suite tests (23 passed, 0 failed).
- The second suite needs a runner with multi-client support, since it declares three `clientconfigs`.
- The metric of interest for the second suite is the distribution of work across workers, not only aggregate ops/sec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only new benchmark specification YAML; no application or infrastructure code changes.
> 
> **Overview**
> Adds **two** new memtier/pubsub-sub-bench suites under `redis_benchmarks_specification/test-suites`, both using **10 channels**, **128B** payloads, **170** subscribers (~17 per channel), **oss-standalone**, and **priority 23**.
> 
> The **mixed** suite (`memtier_benchmark-nokeys-pubsub-mixed-10-channels-128B-publishers-170-subscribers.yml`) mirrors the existing 100-channel mixed pub/sub shape but caps `--key-maximum` at 10 so channel concentration is visible instead of averaged across many channels.
> 
> The **skewed** suite (`memtier_benchmark-nokeys-pubsub-10-channels-128B-skewed-publishers-170-subscribers.yml`) keeps the same subscriber setup and drives publish with **only 3** memtier connections (`-c 3`, `--pipeline 10`) so publish work can land on a small subset of workers when connections are pinned per accept, making per-worker load distribution measurable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c70939e04f44a54740de27de1bb3dae84469aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->