### PR TITLE
Refresh commands.json against the Redis 8.10.1 command table

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -7,7 +7,10 @@
     "acl_categories": [
       "@slow"
     ],
-    "arity": -2
+    "arity": -2,
+    "command_flags": [
+      "sentinel"
+    ]
   },
   "ACL CAT": {
     "summary": "Lists the ACL categories, or the commands inside a category.",
@@ -22,14 +25,14 @@
       {
         "name": "category",
         "type": "string",
-        "display_text": "category",
         "optional": true
       }
     ],
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "ACL DELUSER": {
@@ -47,7 +50,6 @@
       {
         "name": "username",
         "type": "string",
-        "display_text": "username",
         "multiple": true
       }
     ],
@@ -55,7 +57,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "request_policy:all_nodes",
@@ -76,18 +79,15 @@
     "arguments": [
       {
         "name": "username",
-        "type": "string",
-        "display_text": "username"
+        "type": "string"
       },
       {
         "name": "command",
-        "type": "string",
-        "display_text": "command"
+        "type": "string"
       },
       {
         "name": "arg",
         "type": "string",
-        "display_text": "arg",
         "optional": true,
         "multiple": true
       }
@@ -96,8 +96,10 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
-    ]
+      "stale",
+      "sentinel"
+    ],
+    "history": []
   },
   "ACL GENPASS": {
     "summary": "Generates a pseudorandom, secure password that can be used to identify ACL users.",
@@ -112,14 +114,14 @@
       {
         "name": "bits",
         "type": "integer",
-        "display_text": "bits",
         "optional": true
       }
     ],
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "ACL GETUSER": {
@@ -127,16 +129,6 @@
     "since": "6.0.0",
     "group": "server",
     "complexity": "O(N). Where N is the number of password, command and pattern rules that the user has.",
-    "history": [
-      [
-        "6.2.0",
-        "Added Pub/Sub channel patterns."
-      ],
-      [
-        "7.0.0",
-        "Added selectors and changed the format of key and channel patterns from a list to their rule representation."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -146,15 +138,25 @@
     "arguments": [
       {
         "name": "username",
-        "type": "string",
-        "display_text": "username"
+        "type": "string"
       }
     ],
     "command_flags": [
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added Pub/Sub channel patterns."
+      ],
+      [
+        "7.0.0",
+        "Added selectors and changed the format of key and channel patterns from a list to their rule representation."
+      ]
     ]
   },
   "ACL HELP": {
@@ -168,7 +170,8 @@
     "arity": 2,
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "ACL LIST": {
@@ -186,7 +189,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "ACL LOAD": {
@@ -204,7 +208,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "ACL LOG": {
@@ -212,12 +217,6 @@
     "since": "6.0.0",
     "group": "server",
     "complexity": "O(N) with N being the number of entries shown.",
-    "history": [
-      [
-        "7.2.0",
-        "Added entry ID, timestamp created, and timestamp last updated."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -232,13 +231,11 @@
         "arguments": [
           {
             "name": "count",
-            "type": "integer",
-            "display_text": "count"
+            "type": "integer"
           },
           {
             "name": "reset",
             "type": "pure-token",
-            "display_text": "reset",
             "token": "RESET"
           }
         ]
@@ -248,7 +245,14 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
+    ],
+    "history": [
+      [
+        "7.2.0",
+        "Added entry ID, timestamp created, and timestamp last updated."
+      ]
     ]
   },
   "ACL SAVE": {
@@ -266,7 +270,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "request_policy:all_nodes",
@@ -278,16 +283,6 @@
     "since": "6.0.0",
     "group": "server",
     "complexity": "O(N). Where N is the number of rules provided.",
-    "history": [
-      [
-        "6.2.0",
-        "Added Pub/Sub channel patterns."
-      ],
-      [
-        "7.0.0",
-        "Added selectors and key based permissions."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -297,13 +292,11 @@
     "arguments": [
       {
         "name": "username",
-        "type": "string",
-        "display_text": "username"
+        "type": "string"
       },
       {
         "name": "rule",
         "type": "string",
-        "display_text": "rule",
         "optional": true,
         "multiple": true
       }
@@ -312,11 +305,22 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "request_policy:all_nodes",
       "response_policy:all_succeeded"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added Pub/Sub channel patterns."
+      ],
+      [
+        "7.0.0",
+        "Added selectors and key based permissions."
+      ]
     ]
   },
   "ACL USERS": {
@@ -334,7 +338,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "ACL WHOAMI": {
@@ -349,7 +354,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "APPEND": {
@@ -363,6 +369,22 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -382,24 +404,1057 @@
         "RW": true,
         "insert": true
       }
+    ]
+  },
+  "ARCOUNT": {
+    "summary": "Returns the number of non-empty elements in an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@fast"
     ],
+    "arity": 2,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARDEL": {
+    "summary": "Deletes elements at the specified indices in an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the number of indices to delete",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@fast"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "delete": true
+      }
+    ]
+  },
+  "ARDELRANGE": {
+    "summary": "Deletes elements in one or more ranges.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@slow"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "range",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "start",
+            "type": "integer"
+          },
+          {
+            "name": "end",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "delete": true
+      }
+    ]
+  },
+  "ARGET": {
+    "summary": "Gets the value at an index in an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@fast"
+    ],
+    "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARGETRANGE": {
+    "summary": "Gets values in a range of indices.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the range length",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@slow"
+    ],
+    "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "end",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARGREP": {
+    "summary": "Searches array elements in a range using textual predicates.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(P * C) where P is the number of visited positions in touched slices and C is the cost of evaluating the predicates on one existing element.",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@slow"
+    ],
+    "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "string"
+      },
+      {
+        "name": "end",
+        "type": "string"
+      },
+      {
+        "name": "predicate",
+        "type": "oneof",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "exact",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "exact",
+                "type": "pure-token",
+                "token": "EXACT"
+              },
+              {
+                "name": "string",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "match",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "match",
+                "type": "pure-token",
+                "token": "MATCH"
+              },
+              {
+                "name": "string",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "glob",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "glob",
+                "type": "pure-token",
+                "token": "GLOB"
+              },
+              {
+                "name": "pattern",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "re",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "re",
+                "type": "pure-token",
+                "token": "RE"
+              },
+              {
+                "name": "pattern",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "options",
+        "type": "oneof",
+        "optional": true,
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "and",
+            "type": "pure-token",
+            "token": "AND"
+          },
+          {
+            "name": "or",
+            "type": "pure-token",
+            "token": "OR"
+          },
+          {
+            "name": "limit",
+            "type": "integer",
+            "token": "LIMIT"
+          },
+          {
+            "name": "withvalues",
+            "type": "pure-token",
+            "token": "WITHVALUES"
+          },
+          {
+            "name": "nocase",
+            "type": "pure-token",
+            "token": "NOCASE"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARINFO": {
+    "summary": "Returns metadata about an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(1), or O(N) with FULL option where N is the number of slices.",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@slow"
+    ],
+    "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "full",
+        "type": "pure-token",
+        "token": "FULL",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARINSERT": {
+    "summary": "Inserts one or more values at consecutive indices.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the number of values",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@fast"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
         "key_spec_index": 0
       },
       {
         "name": "value",
         "type": "string",
-        "display_text": "value"
+        "multiple": true
       }
     ],
     "command_flags": [
       "write",
       "denyoom",
       "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
+    ]
+  },
+  "ARLASTITEMS": {
+    "summary": "Returns the most recently inserted elements.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the count",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@slow"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer"
+      },
+      {
+        "name": "rev",
+        "type": "pure-token",
+        "token": "REV",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARLEN": {
+    "summary": "Returns the length of an array (max index + 1).",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@fast"
+    ],
+    "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARMGET": {
+    "summary": "Gets values at multiple indices in an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the number of indices",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@fast"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARMSET": {
+    "summary": "Sets multiple index-value pairs in an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the number of pairs",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@fast"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "index",
+            "type": "integer"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
+    ]
+  },
+  "ARNEXT": {
+    "summary": "Returns the next index ARINSERT would use.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@fast"
+    ],
+    "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "AROP": {
+    "summary": "Performs aggregate operations on array elements in a range.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@slow"
+    ],
+    "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "end",
+        "type": "integer"
+      },
+      {
+        "name": "operation",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "sum",
+            "type": "pure-token",
+            "token": "SUM"
+          },
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          },
+          {
+            "name": "and",
+            "type": "pure-token",
+            "token": "AND"
+          },
+          {
+            "name": "or",
+            "type": "pure-token",
+            "token": "OR"
+          },
+          {
+            "name": "xor",
+            "type": "pure-token",
+            "token": "XOR"
+          },
+          {
+            "name": "match",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "match",
+                "type": "pure-token",
+                "token": "MATCH"
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "used",
+            "type": "pure-token",
+            "token": "USED"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARRING": {
+    "summary": "Inserts values into a ring buffer of specified size, wrapping and truncating as needed.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(M) normally, O(N+M) on ring resize, where N is the maximum of the old and new ring size and M is the number of inserted values",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@slow"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "size",
+        "type": "integer"
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
+    ]
+  },
+  "ARSCAN": {
+    "summary": "Iterates existing elements in a range, returning index-value pairs.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+    "acl_categories": [
+      "@read",
+      "@array",
+      "@slow"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "end",
+        "type": "integer"
+      },
+      {
+        "name": "limit",
+        "token": "LIMIT",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
+    ]
+  },
+  "ARSEEK": {
+    "summary": "Sets the ARINSERT / ARRING cursor to a specific index.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@fast"
+    ],
+    "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
+    ]
+  },
+  "ARSET": {
+    "summary": "Sets one or more contiguous values starting at an index in an array.",
+    "since": "8.8.0",
+    "group": "array",
+    "complexity": "O(N) where N is the number of values",
+    "acl_categories": [
+      "@write",
+      "@array",
+      "@fast"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer"
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
     ]
   },
   "ASKING": {
@@ -421,12 +1476,6 @@
     "since": "1.0.0",
     "group": "connection",
     "complexity": "O(N) where N is the number of passwords defined for the user",
-    "history": [
-      [
-        "6.0.0",
-        "Added ACL style (username and password)."
-      ]
-    ],
     "acl_categories": [
       "@fast",
       "@connection"
@@ -436,14 +1485,12 @@
       {
         "name": "username",
         "type": "string",
-        "display_text": "username",
-        "since": "6.0.0",
-        "optional": true
+        "optional": true,
+        "since": "6.0.0"
       },
       {
         "name": "password",
-        "type": "string",
-        "display_text": "password"
+        "type": "string"
       }
     ],
     "command_flags": [
@@ -452,7 +1499,134 @@
       "stale",
       "fast",
       "no_auth",
+      "sentinel",
       "allow_busy"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "Added ACL style (username and password)."
+      ]
+    ]
+  },
+  "BACKUP": {
+    "summary": "A container for backup management commands.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "Depends on subcommand.",
+    "acl_categories": [
+      "@slow"
+    ],
+    "arity": 2
+  },
+  "BACKUP ABORT": {
+    "summary": "Cancel a backup that has not been sealed yet.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ]
+  },
+  "BACKUP CLEANUP": {
+    "summary": "Remove a sealed backup's files and return to idle.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ]
+  },
+  "BACKUP HELP": {
+    "summary": "Return helpful text about BACKUP command parameters.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@slow"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "loading",
+      "stale"
+    ]
+  },
+  "BACKUP LIST": {
+    "summary": "List the immutable backup file paths pinned so far.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "stale"
+    ]
+  },
+  "BACKUP SEAL": {
+    "summary": "Freeze the current backup (BASE + INCR + manifest).",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ]
+  },
+  "BACKUP START": {
+    "summary": "Start a new backup into the configured 'backupdirname'.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ]
+  },
+  "BACKUP STATUS": {
+    "summary": "Report the current backup state.",
+    "since": "8.10.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "stale"
     ]
   },
   "BGREWRITEAOF": {
@@ -467,9 +1641,9 @@
     ],
     "arity": 1,
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "noscript",
-      "no_async_loading"
+      "noscript"
     ]
   },
   "BGSAVE": {
@@ -477,12 +1651,6 @@
     "since": "1.0.0",
     "group": "server",
     "complexity": "O(1)",
-    "history": [
-      [
-        "3.2.2",
-        "Added the `SCHEDULE` option."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -492,17 +1660,22 @@
     "arguments": [
       {
         "name": "schedule",
-        "type": "pure-token",
-        "display_text": "schedule",
         "token": "SCHEDULE",
-        "since": "3.2.2",
-        "optional": true
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.2.2"
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "noscript",
-      "no_async_loading"
+      "noscript"
+    ],
+    "history": [
+      [
+        "3.2.2",
+        "Added the `SCHEDULE` option."
+      ]
     ]
   },
   "BITCOUNT": {
@@ -510,18 +1683,61 @@
     "since": "2.6.0",
     "group": "bitmap",
     "complexity": "O(N)",
-    "history": [
-      [
-        "7.0.0",
-        "Added the `BYTE|BIT` option."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@bitmap",
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "range",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "start",
+            "type": "integer"
+          },
+          {
+            "name": "end",
+            "type": "integer"
+          },
+          {
+            "name": "unit",
+            "type": "oneof",
+            "optional": true,
+            "since": "7.0.0",
+            "arguments": [
+              {
+                "name": "byte",
+                "type": "pure-token",
+                "token": "BYTE"
+              },
+              {
+                "name": "bit",
+                "type": "pure-token",
+                "token": "BIT"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the `BYTE|BIT` option."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -541,54 +1757,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "range",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "start",
-            "type": "integer",
-            "display_text": "start"
-          },
-          {
-            "name": "end",
-            "type": "integer",
-            "display_text": "end"
-          },
-          {
-            "name": "unit",
-            "type": "oneof",
-            "since": "7.0.0",
-            "optional": true,
-            "arguments": [
-              {
-                "name": "byte",
-                "type": "pure-token",
-                "display_text": "byte",
-                "token": "BYTE"
-              },
-              {
-                "name": "bit",
-                "type": "pure-token",
-                "display_text": "bit",
-                "token": "BIT"
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "BITFIELD": {
@@ -602,6 +1770,113 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "operation",
+        "type": "oneof",
+        "multiple": true,
+        "optional": true,
+        "arguments": [
+          {
+            "token": "GET",
+            "name": "get-block",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "encoding",
+                "type": "string"
+              },
+              {
+                "name": "offset",
+                "type": "integer"
+              }
+            ]
+          },
+          {
+            "name": "write",
+            "type": "block",
+            "arguments": [
+              {
+                "token": "OVERFLOW",
+                "name": "overflow-block",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                  {
+                    "name": "wrap",
+                    "type": "pure-token",
+                    "token": "WRAP"
+                  },
+                  {
+                    "name": "sat",
+                    "type": "pure-token",
+                    "token": "SAT"
+                  },
+                  {
+                    "name": "fail",
+                    "type": "pure-token",
+                    "token": "FAIL"
+                  }
+                ]
+              },
+              {
+                "name": "write-operation",
+                "type": "oneof",
+                "arguments": [
+                  {
+                    "token": "SET",
+                    "name": "set-block",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "encoding",
+                        "type": "string"
+                      },
+                      {
+                        "name": "offset",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "value",
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  {
+                    "token": "INCRBY",
+                    "name": "incrby-block",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "encoding",
+                        "type": "string"
+                      },
+                      {
+                        "name": "offset",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "increment",
+                        "type": "integer"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "notes": "This command allows both access and modification of the key",
@@ -620,129 +1895,10 @@
           }
         },
         "RW": true,
-        "access": true,
         "update": true,
+        "access": true,
         "variable_flags": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "operation",
-        "type": "oneof",
-        "optional": true,
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "get-block",
-            "type": "block",
-            "token": "GET",
-            "arguments": [
-              {
-                "name": "encoding",
-                "type": "string",
-                "display_text": "encoding"
-              },
-              {
-                "name": "offset",
-                "type": "integer",
-                "display_text": "offset"
-              }
-            ]
-          },
-          {
-            "name": "write",
-            "type": "block",
-            "arguments": [
-              {
-                "name": "overflow-block",
-                "type": "oneof",
-                "token": "OVERFLOW",
-                "optional": true,
-                "arguments": [
-                  {
-                    "name": "wrap",
-                    "type": "pure-token",
-                    "display_text": "wrap",
-                    "token": "WRAP"
-                  },
-                  {
-                    "name": "sat",
-                    "type": "pure-token",
-                    "display_text": "sat",
-                    "token": "SAT"
-                  },
-                  {
-                    "name": "fail",
-                    "type": "pure-token",
-                    "display_text": "fail",
-                    "token": "FAIL"
-                  }
-                ]
-              },
-              {
-                "name": "write-operation",
-                "type": "oneof",
-                "arguments": [
-                  {
-                    "name": "set-block",
-                    "type": "block",
-                    "token": "SET",
-                    "arguments": [
-                      {
-                        "name": "encoding",
-                        "type": "string",
-                        "display_text": "encoding"
-                      },
-                      {
-                        "name": "offset",
-                        "type": "integer",
-                        "display_text": "offset"
-                      },
-                      {
-                        "name": "value",
-                        "type": "integer",
-                        "display_text": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "incrby-block",
-                    "type": "block",
-                    "token": "INCRBY",
-                    "arguments": [
-                      {
-                        "name": "encoding",
-                        "type": "string",
-                        "display_text": "encoding"
-                      },
-                      {
-                        "name": "offset",
-                        "type": "integer",
-                        "display_text": "offset"
-                      },
-                      {
-                        "name": "increment",
-                        "type": "integer",
-                        "display_text": "increment"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "BITFIELD_RO": {
@@ -756,6 +1912,35 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "token": "GET",
+        "name": "get-block",
+        "type": "block",
+        "optional": true,
+        "multiple": true,
+        "multiple_token": true,
+        "arguments": [
+          {
+            "name": "encoding",
+            "type": "string"
+          },
+          {
+            "name": "offset",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -775,38 +1960,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "get-block",
-        "type": "block",
-        "token": "GET",
-        "optional": true,
-        "multiple": true,
-        "multiple_token": true,
-        "arguments": [
-          {
-            "name": "encoding",
-            "type": "string",
-            "display_text": "encoding"
-          },
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "BITOP": {
@@ -820,6 +1973,69 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "operation",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "and",
+            "type": "pure-token",
+            "token": "AND"
+          },
+          {
+            "name": "or",
+            "type": "pure-token",
+            "token": "OR"
+          },
+          {
+            "name": "xor",
+            "type": "pure-token",
+            "token": "XOR"
+          },
+          {
+            "name": "not",
+            "type": "pure-token",
+            "token": "NOT"
+          },
+          {
+            "name": "diff",
+            "type": "pure-token",
+            "token": "DIFF"
+          },
+          {
+            "name": "diff1",
+            "type": "pure-token",
+            "token": "DIFF1"
+          },
+          {
+            "name": "andor",
+            "type": "pure-token",
+            "token": "ANDOR"
+          },
+          {
+            "name": "one",
+            "type": "pure-token",
+            "token": "ONE"
+          }
+        ]
+      },
+      {
+        "name": "destkey",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -857,55 +2073,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "operation",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "and",
-            "type": "pure-token",
-            "display_text": "and",
-            "token": "AND"
-          },
-          {
-            "name": "or",
-            "type": "pure-token",
-            "display_text": "or",
-            "token": "OR"
-          },
-          {
-            "name": "xor",
-            "type": "pure-token",
-            "display_text": "xor",
-            "token": "XOR"
-          },
-          {
-            "name": "not",
-            "type": "pure-token",
-            "display_text": "not",
-            "token": "NOT"
-          }
-        ]
-      },
-      {
-        "name": "destkey",
-        "type": "key",
-        "display_text": "destkey",
-        "key_spec_index": 0
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "BITPOS": {
@@ -913,18 +2080,72 @@
     "since": "2.8.7",
     "group": "bitmap",
     "complexity": "O(N)",
-    "history": [
-      [
-        "7.0.0",
-        "Added the `BYTE|BIT` option."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@bitmap",
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "bit",
+        "type": "integer"
+      },
+      {
+        "name": "range",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "start",
+            "type": "integer"
+          },
+          {
+            "name": "end-unit-block",
+            "type": "block",
+            "optional": true,
+            "arguments": [
+              {
+                "name": "end",
+                "type": "integer"
+              },
+              {
+                "name": "unit",
+                "type": "oneof",
+                "optional": true,
+                "since": "7.0.0",
+                "arguments": [
+                  {
+                    "name": "byte",
+                    "type": "pure-token",
+                    "token": "BYTE"
+                  },
+                  {
+                    "name": "bit",
+                    "type": "pure-token",
+                    "token": "BIT"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the `BYTE|BIT` option."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -944,66 +2165,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "bit",
-        "type": "integer",
-        "display_text": "bit"
-      },
-      {
-        "name": "range",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "start",
-            "type": "integer",
-            "display_text": "start"
-          },
-          {
-            "name": "end-unit-block",
-            "type": "block",
-            "optional": true,
-            "arguments": [
-              {
-                "name": "end",
-                "type": "integer",
-                "display_text": "end"
-              },
-              {
-                "name": "unit",
-                "type": "oneof",
-                "since": "7.0.0",
-                "optional": true,
-                "arguments": [
-                  {
-                    "name": "byte",
-                    "type": "pure-token",
-                    "display_text": "byte",
-                    "token": "BYTE"
-                  },
-                  {
-                    "name": "bit",
-                    "type": "pure-token",
-                    "display_text": "bit",
-                    "token": "BIT"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "BLMOVE": {
@@ -1018,6 +2179,59 @@
       "@blocking"
     ],
     "arity": 6,
+    "arguments": [
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "name": "wherefrom",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "left",
+            "type": "pure-token",
+            "token": "LEFT"
+          },
+          {
+            "name": "right",
+            "type": "pure-token",
+            "token": "RIGHT"
+          }
+        ]
+      },
+      {
+        "name": "whereto",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "left",
+            "type": "pure-token",
+            "token": "LEFT"
+          },
+          {
+            "name": "right",
+            "type": "pure-token",
+            "token": "RIGHT"
+          }
+        ]
+      },
+      {
+        "name": "timeout",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "blocking"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1056,18 +2270,29 @@
         "RW": true,
         "insert": true
       }
+    ]
+  },
+  "BLMOVEM": {
+    "summary": "Moves up to (or exactly) a number of elements from one list to another and returns them. Blocks until the elements are available otherwise. Deletes the source list if it becomes empty.",
+    "since": "8.10.0",
+    "group": "list",
+    "complexity": "O(N) where N is the number of elements moved.",
+    "acl_categories": [
+      "@write",
+      "@list",
+      "@slow",
+      "@blocking"
     ],
+    "arity": -6,
     "arguments": [
       {
         "name": "source",
         "type": "key",
-        "display_text": "source",
         "key_spec_index": 0
       },
       {
         "name": "destination",
         "type": "key",
-        "display_text": "destination",
         "key_spec_index": 1
       },
       {
@@ -1077,13 +2302,11 @@
           {
             "name": "left",
             "type": "pure-token",
-            "display_text": "left",
             "token": "LEFT"
           },
           {
             "name": "right",
             "type": "pure-token",
-            "display_text": "right",
             "token": "RIGHT"
           }
         ]
@@ -1095,27 +2318,102 @@
           {
             "name": "left",
             "type": "pure-token",
-            "display_text": "left",
             "token": "LEFT"
           },
           {
             "name": "right",
             "type": "pure-token",
-            "display_text": "right",
             "token": "RIGHT"
           }
         ]
       },
       {
         "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
+        "type": "double"
+      },
+      {
+        "name": "how-many",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "selector",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "count",
+                "type": "integer",
+                "token": "COUNT"
+              },
+              {
+                "name": "exactly",
+                "type": "integer",
+                "token": "EXACTLY"
+              }
+            ]
+          },
+          {
+            "name": "ordering",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "obo",
+                "type": "pure-token",
+                "token": "OBO"
+              },
+              {
+                "name": "bulk",
+                "type": "pure-token",
+                "token": "BULK"
+              }
+            ]
+          }
+        ]
       }
     ],
     "command_flags": [
       "write",
       "denyoom",
       "blocking"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "access": true,
+        "delete": true
+      },
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 2
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "insert": true
+      }
     ]
   },
   "BLMPOP": {
@@ -1130,6 +2428,48 @@
       "@blocking"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "timeout",
+        "type": "double"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "where",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "left",
+            "type": "pure-token",
+            "token": "LEFT"
+          },
+          {
+            "name": "right",
+            "type": "pure-token",
+            "token": "RIGHT"
+          }
+        ]
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "blocking"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1150,55 +2490,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "where",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "left",
-            "type": "pure-token",
-            "display_text": "left",
-            "token": "LEFT"
-          },
-          {
-            "name": "right",
-            "type": "pure-token",
-            "display_text": "right",
-            "token": "RIGHT"
-          }
-        ]
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking",
-      "movablekeys"
     ]
   },
   "BLPOP": {
@@ -1206,12 +2497,6 @@
     "since": "2.0.0",
     "group": "list",
     "complexity": "O(N) where N is the number of provided keys.",
-    "history": [
-      [
-        "6.0.0",
-        "`timeout` is interpreted as a double instead of an integer."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
@@ -1219,6 +2504,28 @@
       "@blocking"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "timeout",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "blocking"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "`timeout` is interpreted as a double instead of an integer."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1239,24 +2546,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking"
     ]
   },
   "BRPOP": {
@@ -1264,12 +2553,6 @@
     "since": "2.0.0",
     "group": "list",
     "complexity": "O(N) where N is the number of provided keys.",
-    "history": [
-      [
-        "6.0.0",
-        "`timeout` is interpreted as a double instead of an integer."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
@@ -1277,6 +2560,28 @@
       "@blocking"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "timeout",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "blocking"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "`timeout` is interpreted as a double instead of an integer."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1297,24 +2602,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking"
     ]
   },
   "BRPOPLPUSH": {
@@ -1322,14 +2609,6 @@
     "since": "2.2.0",
     "group": "list",
     "complexity": "O(1)",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`BLMOVE` with the `RIGHT` and `LEFT` arguments",
-    "history": [
-      [
-        "6.0.0",
-        "`timeout` is interpreted as a double instead of an integer."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
@@ -1337,6 +2616,33 @@
       "@blocking"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "name": "timeout",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "blocking"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "`timeout` is interpreted as a double instead of an integer."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1376,30 +2682,8 @@
         "insert": true
       }
     ],
-    "arguments": [
-      {
-        "name": "source",
-        "type": "key",
-        "display_text": "source",
-        "key_spec_index": 0
-      },
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 1
-      },
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "blocking"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`BLMOVE` with the `RIGHT` and `LEFT` arguments",
     "doc_flags": [
       "deprecated"
     ]
@@ -1416,6 +2700,48 @@
       "@blocking"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "timeout",
+        "type": "double"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "where",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          }
+        ]
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "blocking"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1436,55 +2762,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "where",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "min",
-            "type": "pure-token",
-            "display_text": "min",
-            "token": "MIN"
-          },
-          {
-            "name": "max",
-            "type": "pure-token",
-            "display_text": "max",
-            "token": "MAX"
-          }
-        ]
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking",
-      "movablekeys"
     ]
   },
   "BZPOPMAX": {
@@ -1492,12 +2769,6 @@
     "since": "5.0.0",
     "group": "sorted-set",
     "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
-    "history": [
-      [
-        "6.0.0",
-        "`timeout` is interpreted as a double instead of an integer."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@sortedset",
@@ -1505,6 +2776,29 @@
       "@blocking"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "timeout",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast",
+      "blocking"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "`timeout` is interpreted as a double instead of an integer."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1525,25 +2819,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking",
-      "fast"
     ]
   },
   "BZPOPMIN": {
@@ -1551,12 +2826,6 @@
     "since": "5.0.0",
     "group": "sorted-set",
     "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
-    "history": [
-      [
-        "6.0.0",
-        "`timeout` is interpreted as a double instead of an integer."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@sortedset",
@@ -1564,6 +2833,29 @@
       "@blocking"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "timeout",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast",
+      "blocking"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "`timeout` is interpreted as a double instead of an integer."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -1584,25 +2876,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "timeout",
-        "type": "double",
-        "display_text": "timeout"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking",
-      "fast"
     ]
   },
   "CLIENT": {
@@ -1613,7 +2886,10 @@
     "acl_categories": [
       "@slow"
     ],
-    "arity": -2
+    "arity": -2,
+    "command_flags": [
+      "sentinel"
+    ]
   },
   "CLIENT CACHING": {
     "summary": "Instructs the server whether to track the keys in the next request.",
@@ -1633,13 +2909,11 @@
           {
             "name": "yes",
             "type": "pure-token",
-            "display_text": "yes",
             "token": "YES"
           },
           {
             "name": "no",
             "type": "pure-token",
-            "display_text": "no",
             "token": "NO"
           }
         ]
@@ -1648,7 +2922,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT GETNAME": {
@@ -1664,7 +2939,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT GETREDIR": {
@@ -1680,7 +2956,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT HELP": {
@@ -1695,7 +2972,8 @@
     "arity": 2,
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT ID": {
@@ -1711,7 +2989,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT INFO": {
@@ -1727,7 +3006,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "nondeterministic_output"
@@ -1738,6 +3018,130 @@
     "since": "2.4.0",
     "group": "connection",
     "complexity": "O(N) where N is the number of client connections",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous",
+      "@connection"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "filter",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "old-format",
+            "display": "ip:port",
+            "type": "string",
+            "deprecated_since": "2.8.12"
+          },
+          {
+            "name": "new-format",
+            "type": "oneof",
+            "multiple": true,
+            "arguments": [
+              {
+                "token": "ID",
+                "name": "client-id",
+                "type": "integer",
+                "optional": true,
+                "since": "2.8.12"
+              },
+              {
+                "token": "TYPE",
+                "name": "client-type",
+                "type": "oneof",
+                "optional": true,
+                "since": "2.8.12",
+                "arguments": [
+                  {
+                    "name": "normal",
+                    "type": "pure-token",
+                    "token": "normal"
+                  },
+                  {
+                    "name": "master",
+                    "type": "pure-token",
+                    "token": "master",
+                    "since": "3.2.0"
+                  },
+                  {
+                    "name": "slave",
+                    "type": "pure-token",
+                    "token": "slave"
+                  },
+                  {
+                    "name": "replica",
+                    "type": "pure-token",
+                    "token": "replica",
+                    "since": "5.0.0"
+                  },
+                  {
+                    "name": "pubsub",
+                    "type": "pure-token",
+                    "token": "pubsub"
+                  }
+                ]
+              },
+              {
+                "token": "USER",
+                "name": "username",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "token": "ADDR",
+                "name": "addr",
+                "display": "ip:port",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "token": "LADDR",
+                "name": "laddr",
+                "display": "ip:port",
+                "type": "string",
+                "optional": true,
+                "since": "6.2.0"
+              },
+              {
+                "token": "SKIPME",
+                "name": "skipme",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                  {
+                    "name": "yes",
+                    "type": "pure-token",
+                    "token": "YES"
+                  },
+                  {
+                    "name": "no",
+                    "type": "pure-token",
+                    "token": "NO"
+                  }
+                ]
+              },
+              {
+                "token": "MAXAGE",
+                "name": "maxage",
+                "type": "integer",
+                "optional": true,
+                "since": "7.4.0"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "admin",
+      "noscript",
+      "loading",
+      "stale",
+      "sentinel"
+    ],
     "history": [
       [
         "2.8.12",
@@ -1763,139 +3167,6 @@
         "7.4.0",
         "`MAXAGE` option."
       ]
-    ],
-    "acl_categories": [
-      "@admin",
-      "@slow",
-      "@dangerous",
-      "@connection"
-    ],
-    "arity": -3,
-    "arguments": [
-      {
-        "name": "filter",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "old-format",
-            "type": "string",
-            "display_text": "ip:port",
-            "deprecated_since": "2.8.12"
-          },
-          {
-            "name": "new-format",
-            "type": "oneof",
-            "multiple": true,
-            "arguments": [
-              {
-                "name": "client-id",
-                "type": "integer",
-                "display_text": "client-id",
-                "token": "ID",
-                "since": "2.8.12",
-                "optional": true
-              },
-              {
-                "name": "client-type",
-                "type": "oneof",
-                "token": "TYPE",
-                "since": "2.8.12",
-                "optional": true,
-                "arguments": [
-                  {
-                    "name": "normal",
-                    "type": "pure-token",
-                    "display_text": "normal",
-                    "token": "NORMAL"
-                  },
-                  {
-                    "name": "master",
-                    "type": "pure-token",
-                    "display_text": "master",
-                    "token": "MASTER",
-                    "since": "3.2.0"
-                  },
-                  {
-                    "name": "slave",
-                    "type": "pure-token",
-                    "display_text": "slave",
-                    "token": "SLAVE"
-                  },
-                  {
-                    "name": "replica",
-                    "type": "pure-token",
-                    "display_text": "replica",
-                    "token": "REPLICA",
-                    "since": "5.0.0"
-                  },
-                  {
-                    "name": "pubsub",
-                    "type": "pure-token",
-                    "display_text": "pubsub",
-                    "token": "PUBSUB"
-                  }
-                ]
-              },
-              {
-                "name": "username",
-                "type": "string",
-                "display_text": "username",
-                "token": "USER",
-                "optional": true
-              },
-              {
-                "name": "addr",
-                "type": "string",
-                "display_text": "ip:port",
-                "token": "ADDR",
-                "optional": true
-              },
-              {
-                "name": "laddr",
-                "type": "string",
-                "display_text": "ip:port",
-                "token": "LADDR",
-                "since": "6.2.0",
-                "optional": true
-              },
-              {
-                "name": "skipme",
-                "type": "oneof",
-                "token": "SKIPME",
-                "optional": true,
-                "arguments": [
-                  {
-                    "name": "yes",
-                    "type": "pure-token",
-                    "display_text": "yes",
-                    "token": "YES"
-                  },
-                  {
-                    "name": "no",
-                    "type": "pure-token",
-                    "display_text": "no",
-                    "token": "NO"
-                  }
-                ]
-              },
-              {
-                "name": "maxage",
-                "type": "integer",
-                "display_text": "maxage",
-                "token": "MAXAGE",
-                "since": "7.4.0",
-                "optional": true
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "admin",
-      "noscript",
-      "loading",
-      "stale"
     ]
   },
   "CLIENT LIST": {
@@ -1903,6 +3174,62 @@
     "since": "2.4.0",
     "group": "connection",
     "complexity": "O(N) where N is the number of client connections",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous",
+      "@connection"
+    ],
+    "arity": -2,
+    "arguments": [
+      {
+        "token": "TYPE",
+        "name": "client-type",
+        "type": "oneof",
+        "optional": true,
+        "since": "5.0.0",
+        "arguments": [
+          {
+            "name": "normal",
+            "type": "pure-token",
+            "token": "normal"
+          },
+          {
+            "name": "master",
+            "type": "pure-token",
+            "token": "master"
+          },
+          {
+            "name": "replica",
+            "type": "pure-token",
+            "token": "replica"
+          },
+          {
+            "name": "pubsub",
+            "type": "pure-token",
+            "token": "pubsub"
+          }
+        ]
+      },
+      {
+        "name": "client-id",
+        "token": "ID",
+        "type": "integer",
+        "optional": true,
+        "multiple": true,
+        "since": "6.2.0"
+      }
+    ],
+    "command_flags": [
+      "admin",
+      "noscript",
+      "loading",
+      "stale",
+      "sentinel"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "history": [
       [
         "2.8.12",
@@ -1940,66 +3267,6 @@
         "8.0.0",
         "Added `io-thread` field."
       ]
-    ],
-    "acl_categories": [
-      "@admin",
-      "@slow",
-      "@dangerous",
-      "@connection"
-    ],
-    "arity": -2,
-    "arguments": [
-      {
-        "name": "client-type",
-        "type": "oneof",
-        "token": "TYPE",
-        "since": "5.0.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "normal",
-            "type": "pure-token",
-            "display_text": "normal",
-            "token": "NORMAL"
-          },
-          {
-            "name": "master",
-            "type": "pure-token",
-            "display_text": "master",
-            "token": "MASTER"
-          },
-          {
-            "name": "replica",
-            "type": "pure-token",
-            "display_text": "replica",
-            "token": "REPLICA"
-          },
-          {
-            "name": "pubsub",
-            "type": "pure-token",
-            "display_text": "pubsub",
-            "token": "PUBSUB"
-          }
-        ]
-      },
-      {
-        "name": "client-id",
-        "type": "integer",
-        "display_text": "client-id",
-        "token": "ID",
-        "since": "6.2.0",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "admin",
-      "noscript",
-      "loading",
-      "stale"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "CLIENT NO-EVICT": {
@@ -2022,13 +3289,11 @@
           {
             "name": "on",
             "type": "pure-token",
-            "display_text": "on",
             "token": "ON"
           },
           {
             "name": "off",
             "type": "pure-token",
-            "display_text": "off",
             "token": "OFF"
           }
         ]
@@ -2038,7 +3303,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT NO-TOUCH": {
@@ -2059,13 +3325,11 @@
           {
             "name": "on",
             "type": "pure-token",
-            "display_text": "on",
             "token": "ON"
           },
           {
             "name": "off",
             "type": "pure-token",
-            "display_text": "off",
             "token": "OFF"
           }
         ]
@@ -2082,12 +3346,6 @@
     "since": "3.0.0",
     "group": "connection",
     "complexity": "O(1)",
-    "history": [
-      [
-        "6.2.0",
-        "`CLIENT PAUSE WRITE` mode added along with the `mode` option."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -2098,25 +3356,22 @@
     "arguments": [
       {
         "name": "timeout",
-        "type": "integer",
-        "display_text": "timeout"
+        "type": "integer"
       },
       {
         "name": "mode",
         "type": "oneof",
-        "since": "6.2.0",
         "optional": true,
+        "since": "6.2.0",
         "arguments": [
           {
             "name": "write",
             "type": "pure-token",
-            "display_text": "write",
             "token": "WRITE"
           },
           {
             "name": "all",
             "type": "pure-token",
-            "display_text": "all",
             "token": "ALL"
           }
         ]
@@ -2126,7 +3381,14 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "`CLIENT PAUSE WRITE` mode added along with the `mode` option."
+      ]
     ]
   },
   "CLIENT REPLY": {
@@ -2147,19 +3409,16 @@
           {
             "name": "on",
             "type": "pure-token",
-            "display_text": "on",
             "token": "ON"
           },
           {
             "name": "off",
             "type": "pure-token",
-            "display_text": "off",
             "token": "OFF"
           },
           {
             "name": "skip",
             "type": "pure-token",
-            "display_text": "skip",
             "token": "SKIP"
           }
         ]
@@ -2168,7 +3427,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT SETINFO": {
@@ -2187,16 +3447,14 @@
         "type": "oneof",
         "arguments": [
           {
+            "token": "lib-name",
             "name": "libname",
-            "type": "string",
-            "display_text": "libname",
-            "token": "LIB-NAME"
+            "type": "string"
           },
           {
+            "token": "lib-ver",
             "name": "libver",
-            "type": "string",
-            "display_text": "libver",
-            "token": "LIB-VER"
+            "type": "string"
           }
         ]
       }
@@ -2204,7 +3462,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "request_policy:all_nodes",
@@ -2224,14 +3483,14 @@
     "arguments": [
       {
         "name": "connection-name",
-        "type": "string",
-        "display_text": "connection-name"
+        "type": "string"
       }
     ],
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "request_policy:all_nodes",
@@ -2256,66 +3515,59 @@
           {
             "name": "on",
             "type": "pure-token",
-            "display_text": "on",
             "token": "ON"
           },
           {
             "name": "off",
             "type": "pure-token",
-            "display_text": "off",
             "token": "OFF"
           }
         ]
       },
       {
+        "token": "REDIRECT",
         "name": "client-id",
         "type": "integer",
-        "display_text": "client-id",
-        "token": "REDIRECT",
         "optional": true
       },
       {
+        "token": "PREFIX",
         "name": "prefix",
         "type": "string",
-        "display_text": "prefix",
-        "token": "PREFIX",
         "optional": true,
         "multiple": true,
         "multiple_token": true
       },
       {
-        "name": "bcast",
-        "type": "pure-token",
-        "display_text": "bcast",
+        "name": "BCAST",
         "token": "BCAST",
+        "type": "pure-token",
         "optional": true
       },
       {
-        "name": "optin",
-        "type": "pure-token",
-        "display_text": "optin",
+        "name": "OPTIN",
         "token": "OPTIN",
+        "type": "pure-token",
         "optional": true
       },
       {
-        "name": "optout",
-        "type": "pure-token",
-        "display_text": "optout",
+        "name": "OPTOUT",
         "token": "OPTOUT",
+        "type": "pure-token",
         "optional": true
       },
       {
-        "name": "noloop",
-        "type": "pure-token",
-        "display_text": "noloop",
+        "name": "NOLOOP",
         "token": "NOLOOP",
+        "type": "pure-token",
         "optional": true
       }
     ],
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT TRACKINGINFO": {
@@ -2331,7 +3583,8 @@
     "command_flags": [
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT UNBLOCK": {
@@ -2349,8 +3602,7 @@
     "arguments": [
       {
         "name": "client-id",
-        "type": "integer",
-        "display_text": "client-id"
+        "type": "integer"
       },
       {
         "name": "unblock-type",
@@ -2360,13 +3612,11 @@
           {
             "name": "timeout",
             "type": "pure-token",
-            "display_text": "timeout",
             "token": "TIMEOUT"
           },
           {
             "name": "error",
             "type": "pure-token",
-            "display_text": "error",
             "token": "ERROR"
           }
         ]
@@ -2376,7 +3626,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLIENT UNPAUSE": {
@@ -2395,7 +3646,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "CLUSTER": {
@@ -2423,14 +3675,13 @@
       {
         "name": "slot",
         "type": "integer",
-        "display_text": "slot",
         "multiple": true
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER ADDSLOTSRANGE": {
@@ -2452,21 +3703,19 @@
         "arguments": [
           {
             "name": "start-slot",
-            "type": "integer",
-            "display_text": "start-slot"
+            "type": "integer"
           },
           {
             "name": "end-slot",
-            "type": "integer",
-            "display_text": "end-slot"
+            "type": "integer"
           }
         ]
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER BUMPEPOCH": {
@@ -2481,9 +3730,9 @@
     ],
     "arity": 2,
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ],
     "hints": [
       "nondeterministic_output"
@@ -2503,12 +3752,12 @@
     "arguments": [
       {
         "name": "node-id",
-        "type": "string",
-        "display_text": "node-id"
+        "type": "string"
       }
     ],
     "command_flags": [
       "admin",
+      "loading",
       "stale"
     ],
     "hints": [
@@ -2527,8 +3776,7 @@
     "arguments": [
       {
         "name": "slot",
-        "type": "integer",
-        "display_text": "slot"
+        "type": "integer"
       }
     ],
     "command_flags": [
@@ -2550,14 +3798,13 @@
       {
         "name": "slot",
         "type": "integer",
-        "display_text": "slot",
         "multiple": true
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER DELSLOTSRANGE": {
@@ -2579,21 +3826,19 @@
         "arguments": [
           {
             "name": "start-slot",
-            "type": "integer",
-            "display_text": "start-slot"
+            "type": "integer"
           },
           {
             "name": "end-slot",
-            "type": "integer",
-            "display_text": "end-slot"
+            "type": "integer"
           }
         ]
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER FAILOVER": {
@@ -2616,22 +3861,20 @@
           {
             "name": "force",
             "type": "pure-token",
-            "display_text": "force",
             "token": "FORCE"
           },
           {
             "name": "takeover",
             "type": "pure-token",
-            "display_text": "takeover",
             "token": "TAKEOVER"
           }
         ]
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER FLUSHSLOTS": {
@@ -2646,9 +3889,9 @@
     ],
     "arity": 2,
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER FORGET": {
@@ -2665,14 +3908,13 @@
     "arguments": [
       {
         "name": "node-id",
-        "type": "string",
-        "display_text": "node-id"
+        "type": "string"
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER GETKEYSINSLOT": {
@@ -2687,13 +3929,11 @@
     "arguments": [
       {
         "name": "slot",
-        "type": "integer",
-        "display_text": "slot"
+        "type": "integer"
       },
       {
         "name": "count",
-        "type": "integer",
-        "display_text": "count"
+        "type": "integer"
       }
     ],
     "command_flags": [
@@ -2727,6 +3967,7 @@
     ],
     "arity": 2,
     "command_flags": [
+      "loading",
       "stale"
     ],
     "hints": [
@@ -2745,11 +3986,11 @@
     "arguments": [
       {
         "name": "key",
-        "type": "string",
-        "display_text": "key"
+        "type": "string"
       }
     ],
     "command_flags": [
+      "loading",
       "stale"
     ]
   },
@@ -2763,6 +4004,7 @@
     ],
     "arity": 2,
     "command_flags": [
+      "loading",
       "stale"
     ],
     "hints": [
@@ -2774,12 +4016,6 @@
     "since": "3.0.0",
     "group": "cluster",
     "complexity": "O(1)",
-    "history": [
-      [
-        "4.0.0",
-        "Added the optional `cluster_bus_port` argument."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -2789,26 +4025,106 @@
     "arguments": [
       {
         "name": "ip",
-        "type": "string",
-        "display_text": "ip"
+        "type": "string"
       },
       {
         "name": "port",
-        "type": "integer",
-        "display_text": "port"
+        "type": "integer"
       },
       {
         "name": "cluster-bus-port",
         "type": "integer",
-        "display_text": "cluster-bus-port",
-        "since": "4.0.0",
-        "optional": true
+        "optional": true,
+        "since": "4.0.0"
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Added the optional `cluster_bus_port` argument."
+      ]
+    ]
+  },
+  "CLUSTER MIGRATION": {
+    "summary": "Start, monitor and cancel slot migration.",
+    "since": "8.4.0",
+    "group": "cluster",
+    "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "subcommand",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "import",
+            "token": "IMPORT",
+            "type": "block",
+            "multiple": true,
+            "arguments": [
+              {
+                "name": "start-slot",
+                "type": "integer"
+              },
+              {
+                "name": "end-slot",
+                "type": "integer"
+              }
+            ]
+          },
+          {
+            "name": "cancel",
+            "token": "CANCEL",
+            "type": "oneof",
+            "arguments": [
+              {
+                "token": "ID",
+                "name": "task-id",
+                "type": "string"
+              },
+              {
+                "name": "all",
+                "token": "ALL",
+                "type": "pure-token"
+              }
+            ]
+          },
+          {
+            "name": "status",
+            "token": "STATUS",
+            "type": "oneof",
+            "arguments": [
+              {
+                "token": "ID",
+                "name": "task-id",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "name": "all",
+                "token": "ALL",
+                "type": "pure-token",
+                "optional": true
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "no_async_loading",
+      "admin",
+      "stale"
     ]
   },
   "CLUSTER MYID": {
@@ -2821,6 +4137,7 @@
     ],
     "arity": 2,
     "command_flags": [
+      "loading",
       "stale"
     ]
   },
@@ -2834,11 +4151,13 @@
     ],
     "arity": 2,
     "command_flags": [
+      "loading",
       "stale"
     ],
     "hints": [
       "nondeterministic_output"
-    ]
+    ],
+    "history": []
   },
   "CLUSTER NODES": {
     "summary": "Returns the cluster configuration for a node.",
@@ -2850,6 +4169,7 @@
     ],
     "arity": 2,
     "command_flags": [
+      "loading",
       "stale"
     ],
     "hints": [
@@ -2870,12 +4190,12 @@
     "arguments": [
       {
         "name": "node-id",
-        "type": "string",
-        "display_text": "node-id"
+        "type": "string"
       }
     ],
     "command_flags": [
       "admin",
+      "loading",
       "stale"
     ],
     "hints": [
@@ -2896,14 +4216,13 @@
     "arguments": [
       {
         "name": "node-id",
-        "type": "string",
-        "display_text": "node-id"
+        "type": "string"
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER RESET": {
@@ -2926,13 +4245,11 @@
           {
             "name": "hard",
             "type": "pure-token",
-            "display_text": "hard",
             "token": "HARD"
           },
           {
             "name": "soft",
             "type": "pure-token",
-            "display_text": "soft",
             "token": "SOFT"
           }
         ]
@@ -2940,8 +4257,8 @@
     ],
     "command_flags": [
       "admin",
-      "noscript",
-      "stale"
+      "stale",
+      "noscript"
     ]
   },
   "CLUSTER SAVECONFIG": {
@@ -2956,9 +4273,9 @@
     ],
     "arity": 2,
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER SET-CONFIG-EPOCH": {
@@ -2975,14 +4292,13 @@
     "arguments": [
       {
         "name": "config-epoch",
-        "type": "integer",
-        "display_text": "config-epoch"
+        "type": "integer"
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER SETSLOT": {
@@ -2999,8 +4315,7 @@
     "arguments": [
       {
         "name": "slot",
-        "type": "integer",
-        "display_text": "slot"
+        "type": "integer"
       },
       {
         "name": "subcommand",
@@ -3008,35 +4323,34 @@
         "arguments": [
           {
             "name": "importing",
+            "display": "node-id",
             "type": "string",
-            "display_text": "node-id",
             "token": "IMPORTING"
           },
           {
             "name": "migrating",
+            "display": "node-id",
             "type": "string",
-            "display_text": "node-id",
             "token": "MIGRATING"
           },
           {
             "name": "node",
+            "display": "node-id",
             "type": "string",
-            "display_text": "node-id",
             "token": "NODE"
           },
           {
             "name": "stable",
             "type": "pure-token",
-            "display_text": "stable",
             "token": "STABLE"
           }
         ]
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "CLUSTER SHARDS": {
@@ -3054,15 +4368,14 @@
     ],
     "hints": [
       "nondeterministic_output"
-    ]
+    ],
+    "history": []
   },
   "CLUSTER SLAVES": {
     "summary": "Lists the replica nodes of a master node.",
     "since": "3.0.0",
     "group": "cluster",
     "complexity": "O(N) where N is the number of replicas.",
-    "deprecated_since": "5.0.0",
-    "replaced_by": "`CLUSTER REPLICAS`",
     "acl_categories": [
       "@admin",
       "@slow",
@@ -3072,19 +4385,96 @@
     "arguments": [
       {
         "name": "node-id",
-        "type": "string",
-        "display_text": "node-id"
+        "type": "string"
       }
     ],
     "command_flags": [
       "admin",
+      "loading",
       "stale"
-    ],
-    "doc_flags": [
-      "deprecated"
     ],
     "hints": [
       "nondeterministic_output"
+    ],
+    "deprecated_since": "5.0.0",
+    "replaced_by": "`CLUSTER REPLICAS`",
+    "doc_flags": [
+      "deprecated"
+    ]
+  },
+  "CLUSTER SLOT-STATS": {
+    "summary": "Return an array of slot usage statistics for slots assigned to the current node.",
+    "since": "8.2.0",
+    "group": "cluster",
+    "complexity": "O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.",
+    "acl_categories": [
+      "@slow"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "filter",
+        "type": "oneof",
+        "arguments": [
+          {
+            "token": "SLOTSRANGE",
+            "name": "slotsrange",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "start-slot",
+                "type": "integer"
+              },
+              {
+                "name": "end-slot",
+                "type": "integer"
+              }
+            ]
+          },
+          {
+            "token": "ORDERBY",
+            "name": "orderby",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "metric",
+                "type": "string"
+              },
+              {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "integer",
+                "optional": true
+              },
+              {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                  {
+                    "name": "asc",
+                    "type": "pure-token",
+                    "token": "ASC"
+                  },
+                  {
+                    "name": "desc",
+                    "type": "pure-token",
+                    "token": "DESC"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "stale",
+      "loading"
+    ],
+    "hints": [
+      "nondeterministic_output",
+      "request_policy:all_shards"
     ]
   },
   "CLUSTER SLOTS": {
@@ -3092,8 +4482,17 @@
     "since": "3.0.0",
     "group": "cluster",
     "complexity": "O(N) where N is the total number of Cluster nodes",
-    "deprecated_since": "7.0.0",
-    "replaced_by": "`CLUSTER SHARDS`",
+    "acl_categories": [
+      "@slow"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "loading",
+      "stale"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "history": [
       [
         "4.0.0",
@@ -3104,16 +4503,113 @@
         "Added additional networking metadata field."
       ]
     ],
-    "acl_categories": [
-      "@slow"
-    ],
-    "arity": 2,
-    "command_flags": [
-      "loading",
-      "stale"
-    ],
+    "deprecated_since": "7.0.0",
+    "replaced_by": "`CLUSTER SHARDS`",
     "doc_flags": [
       "deprecated"
+    ]
+  },
+  "CLUSTER SYNCSLOTS": {
+    "summary": "Internal command for atomic slot migration protocol between cluster nodes.",
+    "since": "8.4.0",
+    "group": "cluster",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "subcommand",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "sync",
+            "token": "SYNC",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "task-id",
+                "type": "string"
+              },
+              {
+                "name": "slot-range",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                  {
+                    "name": "start-slot",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "end-slot",
+                    "type": "integer"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "token": "RDBCHANNEL",
+            "name": "task-id",
+            "type": "string"
+          },
+          {
+            "name": "snapshot-eof",
+            "token": "SNAPSHOT-EOF",
+            "type": "pure-token"
+          },
+          {
+            "name": "stream-eof",
+            "token": "STREAM-EOF",
+            "type": "pure-token"
+          },
+          {
+            "name": "ack",
+            "token": "ACK",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "state",
+                "type": "string"
+              },
+              {
+                "name": "offset",
+                "type": "integer"
+              }
+            ]
+          },
+          {
+            "token": "FAIL",
+            "name": "error",
+            "type": "string"
+          },
+          {
+            "name": "conf",
+            "token": "CONF",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "option",
+                "type": "string",
+                "multiple": true
+              },
+              {
+                "name": "value",
+                "type": "string",
+                "multiple": true
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "no_async_loading",
+      "admin",
+      "stale"
     ],
     "hints": [
       "nondeterministic_output"
@@ -3131,7 +4627,8 @@
     "arity": -1,
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "nondeterministic_output_order"
@@ -3149,7 +4646,8 @@
     "arity": 2,
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "COMMAND DOCS": {
@@ -3166,14 +4664,14 @@
       {
         "name": "command-name",
         "type": "string",
-        "display_text": "command-name",
         "optional": true,
         "multiple": true
       }
     ],
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "nondeterministic_output_order"
@@ -3192,20 +4690,19 @@
     "arguments": [
       {
         "name": "command",
-        "type": "string",
-        "display_text": "command"
+        "type": "string"
       },
       {
         "name": "arg",
         "type": "string",
-        "display_text": "arg",
         "optional": true,
         "multiple": true
       }
     ],
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "COMMAND GETKEYSANDFLAGS": {
@@ -3221,20 +4718,19 @@
     "arguments": [
       {
         "name": "command",
-        "type": "string",
-        "display_text": "command"
+        "type": "string"
       },
       {
         "name": "arg",
         "type": "string",
-        "display_text": "arg",
         "optional": true,
         "multiple": true
       }
     ],
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "COMMAND HELP": {
@@ -3249,7 +4745,8 @@
     "arity": 2,
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "COMMAND INFO": {
@@ -3257,12 +4754,6 @@
     "since": "2.8.13",
     "group": "server",
     "complexity": "O(N) where N is the number of commands to look up",
-    "history": [
-      [
-        "7.0.0",
-        "Allowed to be called with no argument to get info on all commands."
-      ]
-    ],
     "acl_categories": [
       "@slow",
       "@connection"
@@ -3272,17 +4763,23 @@
       {
         "name": "command-name",
         "type": "string",
-        "display_text": "command-name",
         "optional": true,
         "multiple": true
       }
     ],
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "nondeterministic_output_order"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Allowed to be called with no argument to get info on all commands."
+      ]
     ]
   },
   "COMMAND LIST": {
@@ -3298,26 +4795,23 @@
     "arguments": [
       {
         "name": "filterby",
-        "type": "oneof",
         "token": "FILTERBY",
+        "type": "oneof",
         "optional": true,
         "arguments": [
           {
             "name": "module-name",
             "type": "string",
-            "display_text": "module-name",
             "token": "MODULE"
           },
           {
             "name": "category",
             "type": "string",
-            "display_text": "category",
             "token": "ACLCAT"
           },
           {
             "name": "pattern",
             "type": "pattern",
-            "display_text": "pattern",
             "token": "PATTERN"
           }
         ]
@@ -3325,7 +4819,8 @@
     ],
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "nondeterministic_output_order"
@@ -3346,12 +4841,6 @@
     "since": "2.0.0",
     "group": "server",
     "complexity": "O(N) when N is the number of configuration parameters provided",
-    "history": [
-      [
-        "7.0.0",
-        "Added the ability to pass multiple pattern parameters in one call"
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -3362,7 +4851,6 @@
       {
         "name": "parameter",
         "type": "string",
-        "display_text": "parameter",
         "multiple": true
       }
     ],
@@ -3371,6 +4859,12 @@
       "noscript",
       "loading",
       "stale"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the ability to pass multiple pattern parameters in one call"
+      ]
     ]
   },
   "CONFIG HELP": {
@@ -3436,12 +4930,6 @@
     "since": "2.0.0",
     "group": "server",
     "complexity": "O(N) when N is the number of configuration parameters provided",
-    "history": [
-      [
-        "7.0.0",
-        "Added the ability to set multiple parameters in one call."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -3456,13 +4944,11 @@
         "arguments": [
           {
             "name": "parameter",
-            "type": "string",
-            "display_text": "parameter"
+            "type": "string"
           },
           {
             "name": "value",
-            "type": "string",
-            "display_text": "value"
+            "type": "string"
           }
         ]
       }
@@ -3476,6 +4962,12 @@
     "hints": [
       "request_policy:all_nodes",
       "response_policy:all_succeeded"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the ability to set multiple parameters in one call."
+      ]
     ]
   },
   "COPY": {
@@ -3489,6 +4981,34 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "token": "DB",
+        "name": "destination-db",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "name": "replace",
+        "token": "REPLACE",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3526,38 +5046,6 @@
         "OW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "source",
-        "type": "key",
-        "display_text": "source",
-        "key_spec_index": 0
-      },
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 1
-      },
-      {
-        "name": "destination-db",
-        "type": "integer",
-        "display_text": "destination-db",
-        "token": "DB",
-        "optional": true
-      },
-      {
-        "name": "replace",
-        "type": "pure-token",
-        "display_text": "replace",
-        "token": "REPLACE",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "DBSIZE": {
@@ -3595,7 +5083,8 @@
       "admin",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "protected"
     ],
     "doc_flags": [
       "syscmd"
@@ -3612,6 +5101,18 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3632,19 +5133,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "DECRBY": {
@@ -3658,6 +5146,22 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "decrement",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3678,24 +5182,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "decrement",
-        "type": "integer",
-        "display_text": "decrement"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "DEL": {
@@ -3709,6 +5195,21 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
+    "hints": [
+      "request_policy:multi_shard",
+      "response_policy:agg_sum"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3728,22 +5229,120 @@
         "RM": true,
         "delete": true
       }
+    ]
+  },
+  "DELEX": {
+    "summary": "Conditionally removes the specified key based on value or digest comparison.",
+    "since": "8.4.0",
+    "group": "string",
+    "complexity": "O(1) for IFEQ/IFNE, O(N) for IFDEQ/IFDNE where N is the length of the string value.",
+    "acl_categories": [
+      "@write",
+      "@string",
+      "@fast"
     ],
+    "arity": -2,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
+        "key_spec_index": 0
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "ifeq-value",
+            "type": "string",
+            "token": "IFEQ"
+          },
+          {
+            "name": "ifne-value",
+            "type": "string",
+            "token": "IFNE"
+          },
+          {
+            "name": "ifdeq-digest",
+            "type": "string",
+            "token": "IFDEQ"
+          },
+          {
+            "name": "ifdne-digest",
+            "type": "string",
+            "token": "IFDNE"
+          }
+        ]
       }
     ],
     "command_flags": [
-      "write"
+      "write",
+      "fast"
     ],
-    "hints": [
-      "request_policy:multi_shard",
-      "response_policy:agg_sum"
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "delete": true,
+        "variable_flags": true
+      }
+    ]
+  },
+  "DIGEST": {
+    "summary": "Returns the XXH3 hash of a string value.",
+    "since": "8.4.0",
+    "group": "string",
+    "complexity": "O(N) where N is the length of the string value.",
+    "acl_categories": [
+      "@read",
+      "@string",
+      "@fast"
+    ],
+    "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "DISCARD": {
@@ -3775,6 +5374,19 @@
       "@slow"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3794,20 +5406,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "ECHO": {
@@ -3823,8 +5421,7 @@
     "arguments": [
       {
         "name": "message",
-        "type": "string",
-        "display_text": "message"
+        "type": "string"
       }
     ],
     "command_flags": [
@@ -3843,6 +5440,37 @@
       "@scripting"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "script",
+        "type": "string"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "name": "arg",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "skip_monitor",
+      "may_replicate",
+      "no_mandatory_keys",
+      "script_runner",
+      "stale"
+    ],
     "key_specs": [
       {
         "notes": "We cannot tell how the keys will be used so we assume the worst, RW and UPDATE",
@@ -3864,40 +5492,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "script",
-        "type": "string",
-        "display_text": "script"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
-        "display_text": "arg",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "noscript",
-      "stale",
-      "skip_monitor",
-      "no_mandatory_keys",
-      "movablekeys"
     ]
   },
   "EVALSHA": {
@@ -3910,6 +5504,37 @@
       "@scripting"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "sha1",
+        "type": "string"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "name": "arg",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "skip_monitor",
+      "may_replicate",
+      "no_mandatory_keys",
+      "script_runner",
+      "stale"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3930,40 +5555,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "sha1",
-        "type": "string",
-        "display_text": "sha1"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
-        "display_text": "arg",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "noscript",
-      "stale",
-      "skip_monitor",
-      "no_mandatory_keys",
-      "movablekeys"
     ]
   },
   "EVALSHA_RO": {
@@ -3976,6 +5567,37 @@
       "@scripting"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "sha1",
+        "type": "string"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "name": "arg",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "skip_monitor",
+      "no_mandatory_keys",
+      "stale",
+      "script_runner",
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -3995,41 +5617,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "sha1",
-        "type": "string",
-        "display_text": "sha1"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
-        "display_text": "arg",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "noscript",
-      "stale",
-      "skip_monitor",
-      "no_mandatory_keys",
-      "movablekeys"
     ]
   },
   "EVAL_RO": {
@@ -4042,6 +5629,37 @@
       "@scripting"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "script",
+        "type": "string"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "name": "arg",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "skip_monitor",
+      "no_mandatory_keys",
+      "stale",
+      "script_runner",
+      "readonly"
+    ],
     "key_specs": [
       {
         "notes": "We cannot tell how the keys will be used so we assume the worst, RO and ACCESS",
@@ -4062,41 +5680,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "script",
-        "type": "string",
-        "display_text": "script"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
-        "display_text": "arg",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "noscript",
-      "stale",
-      "skip_monitor",
-      "no_mandatory_keys",
-      "movablekeys"
     ]
   },
   "EXEC": {
@@ -4121,18 +5704,34 @@
     "since": "1.0.0",
     "group": "generic",
     "complexity": "O(N) where N is the number of keys to check.",
-    "history": [
-      [
-        "3.0.3",
-        "Accepts multiple `key` arguments."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@read",
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "request_policy:multi_shard",
+      "response_policy:agg_sum"
+    ],
+    "history": [
+      [
+        "3.0.3",
+        "Accepts multiple `key` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -4151,23 +5750,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "request_policy:multi_shard",
-      "response_policy:agg_sum"
     ]
   },
   "EXPIRE": {
@@ -4175,18 +5757,61 @@
     "since": "1.0.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added options: `NX`, `XX`, `GT` and `LT`."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "seconds",
+        "type": "integer"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "7.0.0",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added options: `NX`, `XX`, `GT` and `LT`."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -4206,55 +5831,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "seconds",
-        "type": "integer",
-        "display_text": "seconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "7.0.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "EXPIREAT": {
@@ -4262,18 +5838,61 @@
     "since": "1.2.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added options: `NX`, `XX`, `GT` and `LT`."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "unix-time-seconds",
+        "type": "unix-time"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "7.0.0",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added options: `NX`, `XX`, `GT` and `LT`."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -4293,55 +5912,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "unix-time-seconds",
-        "type": "unix-time",
-        "display_text": "unix-time-seconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "7.0.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "EXPIRETIME": {
@@ -4355,6 +5925,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -4374,18 +5955,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "FAILOVER": {
@@ -4402,41 +5971,36 @@
     "arguments": [
       {
         "name": "target",
-        "type": "block",
         "token": "TO",
+        "type": "block",
         "optional": true,
         "arguments": [
           {
             "name": "host",
-            "type": "string",
-            "display_text": "host"
+            "type": "string"
           },
           {
             "name": "port",
-            "type": "integer",
-            "display_text": "port"
+            "type": "integer"
           },
           {
+            "token": "FORCE",
             "name": "force",
             "type": "pure-token",
-            "display_text": "force",
-            "token": "FORCE",
             "optional": true
           }
         ]
       },
       {
+        "token": "ABORT",
         "name": "abort",
         "type": "pure-token",
-        "display_text": "abort",
-        "token": "ABORT",
         "optional": true
       },
       {
+        "token": "TIMEOUT",
         "name": "milliseconds",
         "type": "integer",
-        "display_text": "milliseconds",
-        "token": "TIMEOUT",
         "optional": true
       }
     ],
@@ -4456,6 +6020,37 @@
       "@scripting"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "function",
+        "type": "string"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "name": "arg",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "skip_monitor",
+      "may_replicate",
+      "no_mandatory_keys",
+      "script_runner",
+      "stale"
+    ],
     "key_specs": [
       {
         "notes": "We cannot tell how the keys will be used so we assume the worst, RW and UPDATE",
@@ -4477,40 +6072,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "function",
-        "type": "string",
-        "display_text": "function"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
-        "display_text": "arg",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "noscript",
-      "stale",
-      "skip_monitor",
-      "no_mandatory_keys",
-      "movablekeys"
     ]
   },
   "FCALL_RO": {
@@ -4523,6 +6084,37 @@
       "@scripting"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "function",
+        "type": "string"
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "name": "arg",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "skip_monitor",
+      "no_mandatory_keys",
+      "stale",
+      "script_runner",
+      "readonly"
+    ],
     "key_specs": [
       {
         "notes": "We cannot tell how the keys will be used so we assume the worst, RO and ACCESS",
@@ -4543,41 +6135,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "function",
-        "type": "string",
-        "display_text": "function"
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
-        "display_text": "arg",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "noscript",
-      "stale",
-      "skip_monitor",
-      "no_mandatory_keys",
-      "movablekeys"
     ]
   },
   "FLUSHALL": {
@@ -4585,16 +6142,6 @@
     "since": "1.0.0",
     "group": "server",
     "complexity": "O(N) where N is the total number of keys in all databases",
-    "history": [
-      [
-        "4.0.0",
-        "Added the `ASYNC` flushing mode modifier."
-      ],
-      [
-        "6.2.0",
-        "Added the `SYNC` flushing mode modifier."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
@@ -4611,14 +6158,12 @@
           {
             "name": "async",
             "type": "pure-token",
-            "display_text": "async",
             "token": "ASYNC",
             "since": "4.0.0"
           },
           {
             "name": "sync",
             "type": "pure-token",
-            "display_text": "sync",
             "token": "SYNC",
             "since": "6.2.0"
           }
@@ -4631,6 +6176,16 @@
     "hints": [
       "request_policy:all_shards",
       "response_policy:all_succeeded"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Added the `ASYNC` flushing mode modifier."
+      ],
+      [
+        "6.2.0",
+        "Added the `SYNC` flushing mode modifier."
+      ]
     ]
   },
   "FLUSHDB": {
@@ -4638,16 +6193,6 @@
     "since": "1.0.0",
     "group": "server",
     "complexity": "O(N) where N is the number of keys in the selected database",
-    "history": [
-      [
-        "4.0.0",
-        "Added the `ASYNC` flushing mode modifier."
-      ],
-      [
-        "6.2.0",
-        "Added the `SYNC` flushing mode modifier."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
@@ -4664,14 +6209,12 @@
           {
             "name": "async",
             "type": "pure-token",
-            "display_text": "async",
             "token": "ASYNC",
             "since": "4.0.0"
           },
           {
             "name": "sync",
             "type": "pure-token",
-            "display_text": "sync",
             "token": "SYNC",
             "since": "6.2.0"
           }
@@ -4684,6 +6227,16 @@
     "hints": [
       "request_policy:all_shards",
       "response_policy:all_succeeded"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Added the `ASYNC` flushing mode modifier."
+      ],
+      [
+        "6.2.0",
+        "Added the `SYNC` flushing mode modifier."
+      ]
     ]
   },
   "FUNCTION": {
@@ -4710,13 +6263,12 @@
     "arguments": [
       {
         "name": "library-name",
-        "type": "string",
-        "display_text": "library-name"
+        "type": "string"
       }
     ],
     "command_flags": [
-      "write",
-      "noscript"
+      "noscript",
+      "write"
     ],
     "hints": [
       "request_policy:all_shards",
@@ -4757,21 +6309,19 @@
           {
             "name": "async",
             "type": "pure-token",
-            "display_text": "async",
             "token": "ASYNC"
           },
           {
             "name": "sync",
             "type": "pure-token",
-            "display_text": "sync",
             "token": "SYNC"
           }
         ]
       }
     ],
     "command_flags": [
-      "write",
-      "noscript"
+      "noscript",
+      "write"
     ],
     "hints": [
       "request_policy:all_shards",
@@ -4826,14 +6376,12 @@
       {
         "name": "library-name-pattern",
         "type": "string",
-        "display_text": "library-name-pattern",
         "token": "LIBRARYNAME",
         "optional": true
       },
       {
         "name": "withcode",
         "type": "pure-token",
-        "display_text": "withcode",
         "token": "WITHCODE",
         "optional": true
       }
@@ -4860,20 +6408,18 @@
       {
         "name": "replace",
         "type": "pure-token",
-        "display_text": "replace",
         "token": "REPLACE",
         "optional": true
       },
       {
         "name": "function-code",
-        "type": "string",
-        "display_text": "function-code"
+        "type": "string"
       }
     ],
     "command_flags": [
+      "noscript",
       "write",
-      "denyoom",
-      "noscript"
+      "denyoom"
     ],
     "hints": [
       "request_policy:all_shards",
@@ -4894,8 +6440,7 @@
     "arguments": [
       {
         "name": "serialized-value",
-        "type": "string",
-        "display_text": "serialized-value"
+        "type": "string"
       },
       {
         "name": "policy",
@@ -4905,28 +6450,25 @@
           {
             "name": "flush",
             "type": "pure-token",
-            "display_text": "flush",
             "token": "FLUSH"
           },
           {
             "name": "append",
             "type": "pure-token",
-            "display_text": "append",
             "token": "APPEND"
           },
           {
             "name": "replace",
             "type": "pure-token",
-            "display_text": "replace",
             "token": "REPLACE"
           }
         ]
       }
     ],
     "command_flags": [
+      "noscript",
       "write",
-      "denyoom",
-      "noscript"
+      "denyoom"
     ],
     "hints": [
       "request_policy:all_shards",
@@ -4958,18 +6500,73 @@
     "since": "3.2.0",
     "group": "geo",
     "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `CH`, `NX` and `XX` options."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@geo",
       "@slow"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "6.2.0",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          }
+        ]
+      },
+      {
+        "name": "change",
+        "token": "CH",
+        "type": "pure-token",
+        "optional": true,
+        "since": "6.2.0"
+      },
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "longitude",
+            "type": "double"
+          },
+          {
+            "name": "latitude",
+            "type": "double"
+          },
+          {
+            "name": "member",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added the `CH`, `NX` and `XX` options."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -4989,68 +6586,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "6.2.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          }
-        ]
-      },
-      {
-        "name": "change",
-        "type": "pure-token",
-        "display_text": "change",
-        "token": "CH",
-        "since": "6.2.0",
-        "optional": true
-      },
-      {
-        "name": "data",
-        "type": "block",
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "longitude",
-            "type": "double",
-            "display_text": "longitude"
-          },
-          {
-            "name": "latitude",
-            "type": "double",
-            "display_text": "latitude"
-          },
-          {
-            "name": "member",
-            "type": "string",
-            "display_text": "member"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "GEODIST": {
@@ -5064,6 +6599,51 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member1",
+        "type": "string"
+      },
+      {
+        "name": "member2",
+        "type": "string"
+      },
+      {
+        "name": "unit",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "m",
+            "type": "pure-token",
+            "token": "m"
+          },
+          {
+            "name": "km",
+            "type": "pure-token",
+            "token": "km"
+          },
+          {
+            "name": "ft",
+            "type": "pure-token",
+            "token": "ft"
+          },
+          {
+            "name": "mi",
+            "type": "pure-token",
+            "token": "mi"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -5083,58 +6663,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member1",
-        "type": "string",
-        "display_text": "member1"
-      },
-      {
-        "name": "member2",
-        "type": "string",
-        "display_text": "member2"
-      },
-      {
-        "name": "unit",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "m",
-            "type": "pure-token",
-            "display_text": "m",
-            "token": "M"
-          },
-          {
-            "name": "km",
-            "type": "pure-token",
-            "display_text": "km",
-            "token": "KM"
-          },
-          {
-            "name": "ft",
-            "type": "pure-token",
-            "display_text": "ft",
-            "token": "FT"
-          },
-          {
-            "name": "mi",
-            "type": "pure-token",
-            "display_text": "mi",
-            "token": "MI"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "GEOHASH": {
@@ -5148,6 +6676,22 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true,
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -5167,24 +6711,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "GEOPOS": {
@@ -5198,6 +6724,22 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true,
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -5217,24 +6759,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "GEORADIUS": {
@@ -5242,8 +6766,136 @@
     "since": "3.2.0",
     "group": "geo",
     "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` argument",
+    "acl_categories": [
+      "@write",
+      "@geo",
+      "@slow"
+    ],
+    "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "longitude",
+        "type": "double"
+      },
+      {
+        "name": "latitude",
+        "type": "double"
+      },
+      {
+        "name": "radius",
+        "type": "double"
+      },
+      {
+        "name": "unit",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "m",
+            "type": "pure-token",
+            "token": "m"
+          },
+          {
+            "name": "km",
+            "type": "pure-token",
+            "token": "km"
+          },
+          {
+            "name": "ft",
+            "type": "pure-token",
+            "token": "ft"
+          },
+          {
+            "name": "mi",
+            "type": "pure-token",
+            "token": "mi"
+          }
+        ]
+      },
+      {
+        "name": "withcoord",
+        "token": "WITHCOORD",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "withdist",
+        "token": "WITHDIST",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "withhash",
+        "token": "WITHHASH",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "count-block",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "COUNT",
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "any",
+            "token": "ANY",
+            "type": "pure-token",
+            "optional": true,
+            "since": "6.2.0"
+          }
+        ]
+      },
+      {
+        "name": "order",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "asc",
+            "type": "pure-token",
+            "token": "ASC"
+          },
+          {
+            "name": "desc",
+            "type": "pure-token",
+            "token": "DESC"
+          }
+        ]
+      },
+      {
+        "name": "store",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "STORE",
+            "name": "storekey",
+            "display": "key",
+            "type": "key",
+            "key_spec_index": 1
+          },
+          {
+            "token": "STOREDIST",
+            "name": "storedistkey",
+            "display": "key",
+            "type": "key",
+            "key_spec_index": 2
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "history": [
       [
         "6.2.0",
@@ -5254,12 +6906,6 @@
         "Added support for uppercase unit names."
       ]
     ],
-    "acl_categories": [
-      "@write",
-      "@geo",
-      "@slow"
-    ],
-    "arity": -6,
     "key_specs": [
       {
         "begin_search": {
@@ -5280,6 +6926,7 @@
         "access": true
       },
       {
+        "notes": "Incomplete because duplicate STORE options use last-wins; fall back to georadiusGetKeys",
         "begin_search": {
           "type": "keyword",
           "spec": {
@@ -5296,9 +6943,11 @@
           }
         },
         "OW": true,
-        "update": true
+        "update": true,
+        "incomplete": true
       },
       {
+        "notes": "Incomplete because duplicate STOREDIST options use last-wins; fall back to georadiusGetKeys",
         "begin_search": {
           "type": "keyword",
           "spec": {
@@ -5315,149 +6964,12 @@
           }
         },
         "OW": true,
-        "update": true
+        "update": true,
+        "incomplete": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "longitude",
-        "type": "double",
-        "display_text": "longitude"
-      },
-      {
-        "name": "latitude",
-        "type": "double",
-        "display_text": "latitude"
-      },
-      {
-        "name": "radius",
-        "type": "double",
-        "display_text": "radius"
-      },
-      {
-        "name": "unit",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "m",
-            "type": "pure-token",
-            "display_text": "m",
-            "token": "M"
-          },
-          {
-            "name": "km",
-            "type": "pure-token",
-            "display_text": "km",
-            "token": "KM"
-          },
-          {
-            "name": "ft",
-            "type": "pure-token",
-            "display_text": "ft",
-            "token": "FT"
-          },
-          {
-            "name": "mi",
-            "type": "pure-token",
-            "display_text": "mi",
-            "token": "MI"
-          }
-        ]
-      },
-      {
-        "name": "withcoord",
-        "type": "pure-token",
-        "display_text": "withcoord",
-        "token": "WITHCOORD",
-        "optional": true
-      },
-      {
-        "name": "withdist",
-        "type": "pure-token",
-        "display_text": "withdist",
-        "token": "WITHDIST",
-        "optional": true
-      },
-      {
-        "name": "withhash",
-        "type": "pure-token",
-        "display_text": "withhash",
-        "token": "WITHHASH",
-        "optional": true
-      },
-      {
-        "name": "count-block",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT"
-          },
-          {
-            "name": "any",
-            "type": "pure-token",
-            "display_text": "any",
-            "token": "ANY",
-            "since": "6.2.0",
-            "optional": true
-          }
-        ]
-      },
-      {
-        "name": "order",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "asc",
-            "type": "pure-token",
-            "display_text": "asc",
-            "token": "ASC"
-          },
-          {
-            "name": "desc",
-            "type": "pure-token",
-            "display_text": "desc",
-            "token": "DESC"
-          }
-        ]
-      },
-      {
-        "name": "store",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "storekey",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 1,
-            "token": "STORE"
-          },
-          {
-            "name": "storedistkey",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 2,
-            "token": "STOREDIST"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "movablekeys"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -5467,8 +6979,131 @@
     "since": "3.2.0",
     "group": "geo",
     "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` and `FROMMEMBER` arguments",
+    "acl_categories": [
+      "@write",
+      "@geo",
+      "@slow"
+    ],
+    "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string"
+      },
+      {
+        "name": "radius",
+        "type": "double"
+      },
+      {
+        "name": "unit",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "m",
+            "type": "pure-token",
+            "token": "m"
+          },
+          {
+            "name": "km",
+            "type": "pure-token",
+            "token": "km"
+          },
+          {
+            "name": "ft",
+            "type": "pure-token",
+            "token": "ft"
+          },
+          {
+            "name": "mi",
+            "type": "pure-token",
+            "token": "mi"
+          }
+        ]
+      },
+      {
+        "name": "withcoord",
+        "token": "WITHCOORD",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "withdist",
+        "token": "WITHDIST",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "withhash",
+        "token": "WITHHASH",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "count-block",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "COUNT",
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "any",
+            "token": "ANY",
+            "type": "pure-token",
+            "optional": true
+          }
+        ]
+      },
+      {
+        "name": "order",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "asc",
+            "type": "pure-token",
+            "token": "ASC"
+          },
+          {
+            "name": "desc",
+            "type": "pure-token",
+            "token": "DESC"
+          }
+        ]
+      },
+      {
+        "name": "store",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "STORE",
+            "name": "storekey",
+            "display": "key",
+            "type": "key",
+            "key_spec_index": 1
+          },
+          {
+            "token": "STOREDIST",
+            "name": "storedistkey",
+            "display": "key",
+            "type": "key",
+            "key_spec_index": 2
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "history": [
       [
         "6.2.0",
@@ -5479,12 +7114,6 @@
         "Added support for uppercase unit names."
       ]
     ],
-    "acl_categories": [
-      "@write",
-      "@geo",
-      "@slow"
-    ],
-    "arity": -5,
     "key_specs": [
       {
         "begin_search": {
@@ -5505,6 +7134,7 @@
         "access": true
       },
       {
+        "notes": "Incomplete because duplicate STORE options use last-wins; fall back to georadiusGetKeys",
         "begin_search": {
           "type": "keyword",
           "spec": {
@@ -5521,9 +7151,11 @@
           }
         },
         "OW": true,
-        "update": true
+        "update": true,
+        "incomplete": true
       },
       {
+        "notes": "Incomplete because duplicate STOREDIST options use last-wins; fall back to georadiusGetKeys",
         "begin_search": {
           "type": "keyword",
           "spec": {
@@ -5540,143 +7172,12 @@
           }
         },
         "OW": true,
-        "update": true
+        "update": true,
+        "incomplete": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      },
-      {
-        "name": "radius",
-        "type": "double",
-        "display_text": "radius"
-      },
-      {
-        "name": "unit",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "m",
-            "type": "pure-token",
-            "display_text": "m",
-            "token": "M"
-          },
-          {
-            "name": "km",
-            "type": "pure-token",
-            "display_text": "km",
-            "token": "KM"
-          },
-          {
-            "name": "ft",
-            "type": "pure-token",
-            "display_text": "ft",
-            "token": "FT"
-          },
-          {
-            "name": "mi",
-            "type": "pure-token",
-            "display_text": "mi",
-            "token": "MI"
-          }
-        ]
-      },
-      {
-        "name": "withcoord",
-        "type": "pure-token",
-        "display_text": "withcoord",
-        "token": "WITHCOORD",
-        "optional": true
-      },
-      {
-        "name": "withdist",
-        "type": "pure-token",
-        "display_text": "withdist",
-        "token": "WITHDIST",
-        "optional": true
-      },
-      {
-        "name": "withhash",
-        "type": "pure-token",
-        "display_text": "withhash",
-        "token": "WITHHASH",
-        "optional": true
-      },
-      {
-        "name": "count-block",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT"
-          },
-          {
-            "name": "any",
-            "type": "pure-token",
-            "display_text": "any",
-            "token": "ANY",
-            "optional": true
-          }
-        ]
-      },
-      {
-        "name": "order",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "asc",
-            "type": "pure-token",
-            "display_text": "asc",
-            "token": "ASC"
-          },
-          {
-            "name": "desc",
-            "type": "pure-token",
-            "display_text": "desc",
-            "token": "DESC"
-          }
-        ]
-      },
-      {
-        "name": "store",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "storekey",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 1,
-            "token": "STORE"
-          },
-          {
-            "name": "storedistkey",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 2,
-            "token": "STOREDIST"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "movablekeys"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` and `FROMMEMBER` arguments",
     "doc_flags": [
       "deprecated"
     ]
@@ -5686,8 +7187,109 @@
     "since": "3.2.10",
     "group": "geo",
     "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`GEOSEARCH` with the `BYRADIUS` and `FROMMEMBER` arguments",
+    "acl_categories": [
+      "@read",
+      "@geo",
+      "@slow"
+    ],
+    "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string"
+      },
+      {
+        "name": "radius",
+        "type": "double"
+      },
+      {
+        "name": "unit",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "m",
+            "type": "pure-token",
+            "token": "m"
+          },
+          {
+            "name": "km",
+            "type": "pure-token",
+            "token": "km"
+          },
+          {
+            "name": "ft",
+            "type": "pure-token",
+            "token": "ft"
+          },
+          {
+            "name": "mi",
+            "type": "pure-token",
+            "token": "mi"
+          }
+        ]
+      },
+      {
+        "name": "withcoord",
+        "token": "WITHCOORD",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "withdist",
+        "token": "WITHDIST",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "withhash",
+        "token": "WITHHASH",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "count-block",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "COUNT",
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "any",
+            "token": "ANY",
+            "type": "pure-token",
+            "optional": true
+          }
+        ]
+      },
+      {
+        "name": "order",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "asc",
+            "type": "pure-token",
+            "token": "ASC"
+          },
+          {
+            "name": "desc",
+            "type": "pure-token",
+            "token": "DESC"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "history": [
       [
         "6.2.0",
@@ -5698,12 +7300,6 @@
         "Added support for uppercase unit names."
       ]
     ],
-    "acl_categories": [
-      "@read",
-      "@geo",
-      "@slow"
-    ],
-    "arity": -5,
     "key_specs": [
       {
         "begin_search": {
@@ -5724,117 +7320,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      },
-      {
-        "name": "radius",
-        "type": "double",
-        "display_text": "radius"
-      },
-      {
-        "name": "unit",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "m",
-            "type": "pure-token",
-            "display_text": "m",
-            "token": "M"
-          },
-          {
-            "name": "km",
-            "type": "pure-token",
-            "display_text": "km",
-            "token": "KM"
-          },
-          {
-            "name": "ft",
-            "type": "pure-token",
-            "display_text": "ft",
-            "token": "FT"
-          },
-          {
-            "name": "mi",
-            "type": "pure-token",
-            "display_text": "mi",
-            "token": "MI"
-          }
-        ]
-      },
-      {
-        "name": "withcoord",
-        "type": "pure-token",
-        "display_text": "withcoord",
-        "token": "WITHCOORD",
-        "optional": true
-      },
-      {
-        "name": "withdist",
-        "type": "pure-token",
-        "display_text": "withdist",
-        "token": "WITHDIST",
-        "optional": true
-      },
-      {
-        "name": "withhash",
-        "type": "pure-token",
-        "display_text": "withhash",
-        "token": "WITHHASH",
-        "optional": true
-      },
-      {
-        "name": "count-block",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT"
-          },
-          {
-            "name": "any",
-            "type": "pure-token",
-            "display_text": "any",
-            "token": "ANY",
-            "optional": true
-          }
-        ]
-      },
-      {
-        "name": "order",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "asc",
-            "type": "pure-token",
-            "display_text": "asc",
-            "token": "ASC"
-          },
-          {
-            "name": "desc",
-            "type": "pure-token",
-            "display_text": "desc",
-            "token": "DESC"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`GEOSEARCH` with the `BYRADIUS` and `FROMMEMBER` arguments",
     "doc_flags": [
       "deprecated"
     ]
@@ -5844,65 +7331,29 @@
     "since": "3.2.10",
     "group": "geo",
     "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`GEOSEARCH` with the `BYRADIUS` argument",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `ANY` option for `COUNT`."
-      ],
-      [
-        "7.0.0",
-        "Added support for uppercase unit names."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@geo",
       "@slow"
     ],
     "arity": -6,
-    "key_specs": [
-      {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RO": true,
-        "access": true
-      }
-    ],
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "longitude",
-        "type": "double",
-        "display_text": "longitude"
+        "type": "double"
       },
       {
         "name": "latitude",
-        "type": "double",
-        "display_text": "latitude"
+        "type": "double"
       },
       {
         "name": "radius",
-        "type": "double",
-        "display_text": "radius"
+        "type": "double"
       },
       {
         "name": "unit",
@@ -5911,48 +7362,41 @@
           {
             "name": "m",
             "type": "pure-token",
-            "display_text": "m",
-            "token": "M"
+            "token": "m"
           },
           {
             "name": "km",
             "type": "pure-token",
-            "display_text": "km",
-            "token": "KM"
+            "token": "km"
           },
           {
             "name": "ft",
             "type": "pure-token",
-            "display_text": "ft",
-            "token": "FT"
+            "token": "ft"
           },
           {
             "name": "mi",
             "type": "pure-token",
-            "display_text": "mi",
-            "token": "MI"
+            "token": "mi"
           }
         ]
       },
       {
         "name": "withcoord",
-        "type": "pure-token",
-        "display_text": "withcoord",
         "token": "WITHCOORD",
+        "type": "pure-token",
         "optional": true
       },
       {
         "name": "withdist",
-        "type": "pure-token",
-        "display_text": "withdist",
         "token": "WITHDIST",
+        "type": "pure-token",
         "optional": true
       },
       {
         "name": "withhash",
-        "type": "pure-token",
-        "display_text": "withhash",
         "token": "WITHHASH",
+        "type": "pure-token",
         "optional": true
       },
       {
@@ -5961,18 +7405,16 @@
         "optional": true,
         "arguments": [
           {
+            "token": "COUNT",
             "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT"
+            "type": "integer"
           },
           {
             "name": "any",
-            "type": "pure-token",
-            "display_text": "any",
             "token": "ANY",
-            "since": "6.2.0",
-            "optional": true
+            "type": "pure-token",
+            "optional": true,
+            "since": "6.2.0"
           }
         ]
       },
@@ -5984,13 +7426,11 @@
           {
             "name": "asc",
             "type": "pure-token",
-            "display_text": "asc",
             "token": "ASC"
           },
           {
             "name": "desc",
             "type": "pure-token",
-            "display_text": "desc",
             "token": "DESC"
           }
         ]
@@ -5999,27 +7439,16 @@
     "command_flags": [
       "readonly"
     ],
-    "doc_flags": [
-      "deprecated"
-    ]
-  },
-  "GEOSEARCH": {
-    "summary": "Queries a geospatial index for members inside an area of a box or a circle.",
-    "since": "6.2.0",
-    "group": "geo",
-    "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
     "history": [
+      [
+        "6.2.0",
+        "Added the `ANY` option for `COUNT`."
+      ],
       [
         "7.0.0",
         "Added support for uppercase unit names."
       ]
     ],
-    "acl_categories": [
-      "@read",
-      "@geo",
-      "@slow"
-    ],
-    "arity": -7,
     "key_specs": [
       {
         "begin_search": {
@@ -6040,11 +7469,27 @@
         "access": true
       }
     ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`GEOSEARCH` with the `BYRADIUS` argument",
+    "doc_flags": [
+      "deprecated"
+    ]
+  },
+  "GEOSEARCH": {
+    "summary": "Queries a geospatial index for members inside an area of a box or a circle.",
+    "since": "6.2.0",
+    "group": "geo",
+    "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
+    "acl_categories": [
+      "@read",
+      "@geo",
+      "@slow"
+    ],
+    "arity": -7,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
@@ -6052,25 +7497,22 @@
         "type": "oneof",
         "arguments": [
           {
+            "token": "FROMMEMBER",
             "name": "member",
-            "type": "string",
-            "display_text": "member",
-            "token": "FROMMEMBER"
+            "type": "string"
           },
           {
+            "token": "FROMLONLAT",
             "name": "fromlonlat",
             "type": "block",
-            "token": "FROMLONLAT",
             "arguments": [
               {
                 "name": "longitude",
-                "type": "double",
-                "display_text": "longitude"
+                "type": "double"
               },
               {
                 "name": "latitude",
-                "type": "double",
-                "display_text": "latitude"
+                "type": "double"
               }
             ]
           }
@@ -6085,10 +7527,9 @@
             "type": "block",
             "arguments": [
               {
+                "token": "BYRADIUS",
                 "name": "radius",
-                "type": "double",
-                "display_text": "radius",
-                "token": "BYRADIUS"
+                "type": "double"
               },
               {
                 "name": "unit",
@@ -6097,26 +7538,22 @@
                   {
                     "name": "m",
                     "type": "pure-token",
-                    "display_text": "m",
-                    "token": "M"
+                    "token": "m"
                   },
                   {
                     "name": "km",
                     "type": "pure-token",
-                    "display_text": "km",
-                    "token": "KM"
+                    "token": "km"
                   },
                   {
                     "name": "ft",
                     "type": "pure-token",
-                    "display_text": "ft",
-                    "token": "FT"
+                    "token": "ft"
                   },
                   {
                     "name": "mi",
                     "type": "pure-token",
-                    "display_text": "mi",
-                    "token": "MI"
+                    "token": "mi"
                   }
                 ]
               }
@@ -6127,15 +7564,13 @@
             "type": "block",
             "arguments": [
               {
+                "token": "BYBOX",
                 "name": "width",
-                "type": "double",
-                "display_text": "width",
-                "token": "BYBOX"
+                "type": "double"
               },
               {
                 "name": "height",
-                "type": "double",
-                "display_text": "height"
+                "type": "double"
               },
               {
                 "name": "unit",
@@ -6144,26 +7579,22 @@
                   {
                     "name": "m",
                     "type": "pure-token",
-                    "display_text": "m",
-                    "token": "M"
+                    "token": "m"
                   },
                   {
                     "name": "km",
                     "type": "pure-token",
-                    "display_text": "km",
-                    "token": "KM"
+                    "token": "km"
                   },
                   {
                     "name": "ft",
                     "type": "pure-token",
-                    "display_text": "ft",
-                    "token": "FT"
+                    "token": "ft"
                   },
                   {
                     "name": "mi",
                     "type": "pure-token",
-                    "display_text": "mi",
-                    "token": "MI"
+                    "token": "mi"
                   }
                 ]
               }
@@ -6179,13 +7610,11 @@
           {
             "name": "asc",
             "type": "pure-token",
-            "display_text": "asc",
             "token": "ASC"
           },
           {
             "name": "desc",
             "type": "pure-token",
-            "display_text": "desc",
             "token": "DESC"
           }
         ]
@@ -6196,44 +7625,65 @@
         "optional": true,
         "arguments": [
           {
+            "token": "COUNT",
             "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT"
+            "type": "integer"
           },
           {
             "name": "any",
-            "type": "pure-token",
-            "display_text": "any",
             "token": "ANY",
+            "type": "pure-token",
             "optional": true
           }
         ]
       },
       {
         "name": "withcoord",
-        "type": "pure-token",
-        "display_text": "withcoord",
         "token": "WITHCOORD",
+        "type": "pure-token",
         "optional": true
       },
       {
         "name": "withdist",
-        "type": "pure-token",
-        "display_text": "withdist",
         "token": "WITHDIST",
+        "type": "pure-token",
         "optional": true
       },
       {
         "name": "withhash",
-        "type": "pure-token",
-        "display_text": "withhash",
         "token": "WITHHASH",
+        "type": "pure-token",
         "optional": true
       }
     ],
     "command_flags": [
       "readonly"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added support for uppercase unit names."
+      ]
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "GEOSEARCHSTORE": {
@@ -6241,18 +7691,185 @@
     "since": "6.2.0",
     "group": "geo",
     "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
-    "history": [
-      [
-        "7.0.0",
-        "Added support for uppercase unit names."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@geo",
       "@slow"
     ],
     "arity": -8,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "name": "from",
+        "type": "oneof",
+        "arguments": [
+          {
+            "token": "FROMMEMBER",
+            "name": "member",
+            "type": "string"
+          },
+          {
+            "token": "FROMLONLAT",
+            "name": "fromlonlat",
+            "type": "block",
+            "arguments": [
+              {
+                "name": "longitude",
+                "type": "double"
+              },
+              {
+                "name": "latitude",
+                "type": "double"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "by",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "circle",
+            "type": "block",
+            "arguments": [
+              {
+                "token": "BYRADIUS",
+                "name": "radius",
+                "type": "double"
+              },
+              {
+                "name": "unit",
+                "type": "oneof",
+                "arguments": [
+                  {
+                    "name": "m",
+                    "type": "pure-token",
+                    "token": "m"
+                  },
+                  {
+                    "name": "km",
+                    "type": "pure-token",
+                    "token": "km"
+                  },
+                  {
+                    "name": "ft",
+                    "type": "pure-token",
+                    "token": "ft"
+                  },
+                  {
+                    "name": "mi",
+                    "type": "pure-token",
+                    "token": "mi"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "box",
+            "type": "block",
+            "arguments": [
+              {
+                "token": "BYBOX",
+                "name": "width",
+                "type": "double"
+              },
+              {
+                "name": "height",
+                "type": "double"
+              },
+              {
+                "name": "unit",
+                "type": "oneof",
+                "arguments": [
+                  {
+                    "name": "m",
+                    "type": "pure-token",
+                    "token": "m"
+                  },
+                  {
+                    "name": "km",
+                    "type": "pure-token",
+                    "token": "km"
+                  },
+                  {
+                    "name": "ft",
+                    "type": "pure-token",
+                    "token": "ft"
+                  },
+                  {
+                    "name": "mi",
+                    "type": "pure-token",
+                    "token": "mi"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "order",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "asc",
+            "type": "pure-token",
+            "token": "ASC"
+          },
+          {
+            "name": "desc",
+            "type": "pure-token",
+            "token": "DESC"
+          }
+        ]
+      },
+      {
+        "name": "count-block",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "COUNT",
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "any",
+            "token": "ANY",
+            "type": "pure-token",
+            "optional": true
+          }
+        ]
+      },
+      {
+        "name": "storedist",
+        "token": "STOREDIST",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added support for uppercase unit names."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6290,194 +7907,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "source",
-        "type": "key",
-        "display_text": "source",
-        "key_spec_index": 1
-      },
-      {
-        "name": "from",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "member",
-            "type": "string",
-            "display_text": "member",
-            "token": "FROMMEMBER"
-          },
-          {
-            "name": "fromlonlat",
-            "type": "block",
-            "token": "FROMLONLAT",
-            "arguments": [
-              {
-                "name": "longitude",
-                "type": "double",
-                "display_text": "longitude"
-              },
-              {
-                "name": "latitude",
-                "type": "double",
-                "display_text": "latitude"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "by",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "circle",
-            "type": "block",
-            "arguments": [
-              {
-                "name": "radius",
-                "type": "double",
-                "display_text": "radius",
-                "token": "BYRADIUS"
-              },
-              {
-                "name": "unit",
-                "type": "oneof",
-                "arguments": [
-                  {
-                    "name": "m",
-                    "type": "pure-token",
-                    "display_text": "m",
-                    "token": "M"
-                  },
-                  {
-                    "name": "km",
-                    "type": "pure-token",
-                    "display_text": "km",
-                    "token": "KM"
-                  },
-                  {
-                    "name": "ft",
-                    "type": "pure-token",
-                    "display_text": "ft",
-                    "token": "FT"
-                  },
-                  {
-                    "name": "mi",
-                    "type": "pure-token",
-                    "display_text": "mi",
-                    "token": "MI"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "box",
-            "type": "block",
-            "arguments": [
-              {
-                "name": "width",
-                "type": "double",
-                "display_text": "width",
-                "token": "BYBOX"
-              },
-              {
-                "name": "height",
-                "type": "double",
-                "display_text": "height"
-              },
-              {
-                "name": "unit",
-                "type": "oneof",
-                "arguments": [
-                  {
-                    "name": "m",
-                    "type": "pure-token",
-                    "display_text": "m",
-                    "token": "M"
-                  },
-                  {
-                    "name": "km",
-                    "type": "pure-token",
-                    "display_text": "km",
-                    "token": "KM"
-                  },
-                  {
-                    "name": "ft",
-                    "type": "pure-token",
-                    "display_text": "ft",
-                    "token": "FT"
-                  },
-                  {
-                    "name": "mi",
-                    "type": "pure-token",
-                    "display_text": "mi",
-                    "token": "MI"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "order",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "asc",
-            "type": "pure-token",
-            "display_text": "asc",
-            "token": "ASC"
-          },
-          {
-            "name": "desc",
-            "type": "pure-token",
-            "display_text": "desc",
-            "token": "DESC"
-          }
-        ]
-      },
-      {
-        "name": "count-block",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT"
-          },
-          {
-            "name": "any",
-            "type": "pure-token",
-            "display_text": "any",
-            "token": "ANY",
-            "optional": true
-          }
-        ]
-      },
-      {
-        "name": "storedist",
-        "type": "pure-token",
-        "display_text": "storedist",
-        "token": "STOREDIST",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "GET": {
@@ -6491,6 +7920,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6510,18 +7950,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "GETBIT": {
@@ -6535,6 +7963,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "offset",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6554,23 +7997,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "offset",
-        "type": "integer",
-        "display_text": "offset"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "GETDEL": {
@@ -6584,6 +8010,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6604,18 +8041,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "GETEX": {
@@ -6629,6 +8054,49 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "expiration",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "seconds",
+            "type": "integer",
+            "token": "EX"
+          },
+          {
+            "name": "milliseconds",
+            "type": "integer",
+            "token": "PX"
+          },
+          {
+            "name": "unix-time-seconds",
+            "type": "unix-time",
+            "token": "EXAT"
+          },
+          {
+            "name": "unix-time-milliseconds",
+            "type": "unix-time",
+            "token": "PXAT"
+          },
+          {
+            "name": "persist",
+            "type": "pure-token",
+            "token": "PERSIST"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "notes": "RW and UPDATE because it changes the TTL",
@@ -6650,55 +8118,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "expiration",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "seconds",
-            "type": "integer",
-            "display_text": "seconds",
-            "token": "EX"
-          },
-          {
-            "name": "milliseconds",
-            "type": "integer",
-            "display_text": "milliseconds",
-            "token": "PX"
-          },
-          {
-            "name": "unix-time-seconds",
-            "type": "unix-time",
-            "display_text": "unix-time-seconds",
-            "token": "EXAT"
-          },
-          {
-            "name": "unix-time-milliseconds",
-            "type": "unix-time",
-            "display_text": "unix-time-milliseconds",
-            "token": "PXAT"
-          },
-          {
-            "name": "persist",
-            "type": "pure-token",
-            "display_text": "persist",
-            "token": "PERSIST"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "GETRANGE": {
@@ -6712,6 +8131,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "end",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6731,27 +8168,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "integer",
-        "display_text": "start"
-      },
-      {
-        "name": "end",
-        "type": "integer",
-        "display_text": "end"
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "GETSET": {
@@ -6759,14 +8175,28 @@
     "since": "1.0.0",
     "group": "string",
     "complexity": "O(1)",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`SET` with the `!GET` argument",
     "acl_categories": [
       "@write",
       "@string",
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6788,24 +8218,8 @@
         "update": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`SET` with the `!GET` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -6815,18 +8229,34 @@
     "since": "2.0.0",
     "group": "hash",
     "complexity": "O(N) where N is the number of fields to be removed.",
-    "history": [
-      [
-        "2.4.0",
-        "Accepts multiple `field` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@hash",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "2.4.0",
+        "Accepts multiple `field` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6846,24 +8276,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HELLO": {
@@ -6871,12 +8283,6 @@
     "since": "6.0.0",
     "group": "connection",
     "complexity": "O(1)",
-    "history": [
-      [
-        "6.2.0",
-        "`protover` made optional; when called without arguments the command reports the current connection's context."
-      ]
-    ],
     "acl_categories": [
       "@fast",
       "@connection"
@@ -6890,32 +8296,28 @@
         "arguments": [
           {
             "name": "protover",
-            "type": "integer",
-            "display_text": "protover"
+            "type": "integer"
           },
           {
+            "token": "AUTH",
             "name": "auth",
             "type": "block",
-            "token": "AUTH",
             "optional": true,
             "arguments": [
               {
                 "name": "username",
-                "type": "string",
-                "display_text": "username"
+                "type": "string"
               },
               {
                 "name": "password",
-                "type": "string",
-                "display_text": "password"
+                "type": "string"
               }
             ]
           },
           {
+            "token": "SETNAME",
             "name": "clientname",
             "type": "string",
-            "display_text": "clientname",
-            "token": "SETNAME",
             "optional": true
           }
         ]
@@ -6927,7 +8329,14 @@
       "stale",
       "fast",
       "no_auth",
+      "sentinel",
       "allow_busy"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "`protover` made optional; when called without arguments the command reports the current connection's context."
+      ]
     ]
   },
   "HEXISTS": {
@@ -6941,6 +8350,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -6959,23 +8383,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HEXPIRE": {
@@ -6989,6 +8396,65 @@
       "@fast"
     ],
     "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "seconds",
+        "type": "integer"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -7008,72 +8474,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "seconds",
-        "type": "integer",
-        "display_text": "seconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HEXPIREAT": {
@@ -7087,6 +8487,65 @@
       "@fast"
     ],
     "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "unix-time-seconds",
+        "type": "unix-time"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -7106,72 +8565,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "unix-time-seconds",
-        "type": "unix-time",
-        "display_text": "unix-time-seconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HEXPIRETIME": {
@@ -7185,6 +8578,34 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -7204,36 +8625,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HGET": {
@@ -7247,6 +8638,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7266,23 +8672,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HGETALL": {
@@ -7296,6 +8685,19 @@
       "@slow"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7315,20 +8717,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output_order"
     ]
   },
   "HGETDEL": {
@@ -7342,6 +8730,34 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -7362,36 +8778,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HGETEX": {
@@ -7405,6 +8791,66 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "expiration",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "seconds",
+            "type": "integer",
+            "token": "EX"
+          },
+          {
+            "name": "milliseconds",
+            "type": "integer",
+            "token": "PX"
+          },
+          {
+            "name": "unix-time-seconds",
+            "type": "unix-time",
+            "token": "EXAT"
+          },
+          {
+            "name": "unix-time-milliseconds",
+            "type": "unix-time",
+            "token": "PXAT"
+          },
+          {
+            "name": "persist",
+            "type": "pure-token",
+            "token": "PERSIST"
+          }
+        ]
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "notes": "RW and UPDATE because it changes the TTL",
@@ -7426,73 +8872,131 @@
         "access": true,
         "update": true
       }
+    ]
+  },
+  "HIMPORT": {
+    "summary": "A container for session-based hash import commands using fieldsets.",
+    "since": "8.10.0",
+    "group": "hash",
+    "complexity": "Depends on subcommand.",
+    "acl_categories": [
+      "@hash",
+      "@slow"
     ],
+    "arity": -2
+  },
+  "HIMPORT DISCARD": {
+    "summary": "Removes a single session-local fieldset by name.",
+    "since": "8.10.0",
+    "group": "hash",
+    "complexity": "O(N) where N is the number of session-local fieldsets.",
+    "acl_categories": [
+      "@hash",
+      "@slow"
+    ],
+    "arity": 3,
+    "arguments": [
+      {
+        "name": "fieldset-name",
+        "type": "string"
+      }
+    ],
+    "hints": [
+      "request_policy:all_shards"
+    ]
+  },
+  "HIMPORT DISCARDALL": {
+    "summary": "Removes all session-local fieldsets for the connection.",
+    "since": "8.10.0",
+    "group": "hash",
+    "complexity": "O(N) where N is the number of session-local fieldsets.",
+    "acl_categories": [
+      "@hash",
+      "@slow"
+    ],
+    "arity": 2,
+    "hints": [
+      "request_policy:all_shards"
+    ]
+  },
+  "HIMPORT PREPARE": {
+    "summary": "Defines a session-local fieldset that maps a name to a sorted set of field names.",
+    "since": "8.10.0",
+    "group": "hash",
+    "complexity": "O(N*log(N)) where N is the number of fields.",
+    "acl_categories": [
+      "@hash",
+      "@slow"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "fieldset-name",
+        "type": "string"
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "denyoom"
+    ],
+    "hints": [
+      "request_policy:all_shards"
+    ]
+  },
+  "HIMPORT SET": {
+    "summary": "Creates a fieldset-based hash from values supplied in the order matching a previously prepared fieldset.",
+    "since": "8.10.0",
+    "group": "hash",
+    "complexity": "O(N) where N is the number of fields in the fieldset.",
+    "acl_categories": [
+      "@write",
+      "@hash",
+      "@slow"
+    ],
+    "arity": -5,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
-        "name": "expiration",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "seconds",
-            "type": "integer",
-            "display_text": "seconds",
-            "token": "EX"
-          },
-          {
-            "name": "milliseconds",
-            "type": "integer",
-            "display_text": "milliseconds",
-            "token": "PX"
-          },
-          {
-            "name": "unix-time-seconds",
-            "type": "unix-time",
-            "display_text": "unix-time-seconds",
-            "token": "EXAT"
-          },
-          {
-            "name": "unix-time-milliseconds",
-            "type": "unix-time",
-            "display_text": "unix-time-milliseconds",
-            "token": "PXAT"
-          },
-          {
-            "name": "persist",
-            "type": "pure-token",
-            "display_text": "persist",
-            "token": "PERSIST"
-          }
-        ]
+        "name": "fieldset-name",
+        "type": "string"
       },
       {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
+        "name": "value",
+        "type": "string",
+        "multiple": true
       }
     ],
     "command_flags": [
       "write",
-      "fast"
+      "denyoom"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 2
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "OW": true,
+        "update": true
+      }
     ]
   },
   "HINCRBY": {
@@ -7506,6 +9010,26 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string"
+      },
+      {
+        "name": "increment",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7526,29 +9050,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field"
-      },
-      {
-        "name": "increment",
-        "type": "integer",
-        "display_text": "increment"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "HINCRBYFLOAT": {
@@ -7562,6 +9063,26 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string"
+      },
+      {
+        "name": "increment",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7582,29 +9103,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field"
-      },
-      {
-        "name": "increment",
-        "type": "double",
-        "display_text": "increment"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "HKEYS": {
@@ -7618,6 +9116,19 @@
       "@slow"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7637,20 +9148,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output_order"
     ]
   },
   "HLEN": {
@@ -7664,6 +9161,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7682,18 +9190,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HMGET": {
@@ -7707,6 +9203,22 @@
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7726,24 +9238,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HMSET": {
@@ -7751,14 +9245,39 @@
     "since": "2.0.0",
     "group": "hash",
     "complexity": "O(N) where N is the number of fields being set.",
-    "deprecated_since": "4.0.0",
-    "replaced_by": "`HSET` with multiple field-value pairs",
     "acl_categories": [
       "@write",
       "@hash",
       "@fast"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "field",
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -7779,38 +9298,173 @@
         "update": true
       }
     ],
+    "deprecated_since": "4.0.0",
+    "replaced_by": "`HSET` with multiple field-value pairs",
+    "doc_flags": [
+      "deprecated"
+    ]
+  },
+  "HOTKEYS": {
+    "summary": "A container for hotkeys tracking commands.",
+    "since": "8.6.0",
+    "group": "server",
+    "complexity": "Depends on subcommand.",
+    "acl_categories": [
+      "@slow"
+    ],
+    "arity": -2
+  },
+  "HOTKEYS GET": {
+    "summary": "Returns lists of top K hotkeys depending on metrics chosen in HOTKEYS START command.",
+    "since": "8.6.0",
+    "group": "server",
+    "complexity": "O(K) where K is the number of hotkeys returned.",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ],
+    "hints": [
+      "nondeterministic_output",
+      "request_policy:special",
+      "response_policy:special"
+    ]
+  },
+  "HOTKEYS HELP": {
+    "summary": "Return helpful text about HOTKEYS command parameters.",
+    "since": "8.6.1",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@slow"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "loading",
+      "stale"
+    ]
+  },
+  "HOTKEYS RESET": {
+    "summary": "Release the resources used for hotkey tracking.",
+    "since": "8.6.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ],
+    "hints": [
+      "request_policy:special"
+    ]
+  },
+  "HOTKEYS START": {
+    "summary": "Starts hotkeys tracking.",
+    "since": "8.6.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": -2,
     "arguments": [
       {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "data",
+        "token": "METRICS",
+        "name": "metrics",
         "type": "block",
-        "multiple": true,
+        "optional": false,
         "arguments": [
           {
-            "name": "field",
-            "type": "string",
-            "display_text": "field"
+            "name": "count",
+            "type": "integer"
           },
           {
-            "name": "value",
-            "type": "string",
-            "display_text": "value"
+            "token": "CPU",
+            "name": "cpu",
+            "type": "pure-token",
+            "optional": true
+          },
+          {
+            "token": "NET",
+            "name": "net",
+            "type": "pure-token",
+            "optional": true
+          }
+        ]
+      },
+      {
+        "token": "COUNT",
+        "name": "k",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "DURATION",
+        "name": "seconds",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "SAMPLE",
+        "name": "ratio",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "SLOTS",
+        "name": "slots",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "slot",
+            "type": "integer",
+            "multiple": true
           }
         ]
       }
     ],
     "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
+      "admin",
+      "noscript"
     ],
-    "doc_flags": [
-      "deprecated"
+    "hints": [
+      "request_policy:special"
+    ]
+  },
+  "HOTKEYS STOP": {
+    "summary": "Stops hotkeys tracking.",
+    "since": "8.6.0",
+    "group": "server",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@admin",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": 2,
+    "command_flags": [
+      "admin",
+      "noscript"
+    ],
+    "hints": [
+      "request_policy:special"
     ]
   },
   "HPERSIST": {
@@ -7824,6 +9478,34 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -7843,36 +9525,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HPEXPIRE": {
@@ -7886,6 +9538,65 @@
       "@fast"
     ],
     "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "milliseconds",
+        "type": "integer"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -7905,72 +9616,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "milliseconds",
-        "type": "integer",
-        "display_text": "milliseconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HPEXPIREAT": {
@@ -7984,6 +9629,65 @@
       "@fast"
     ],
     "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "unix-time-milliseconds",
+        "type": "unix-time"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -8003,72 +9707,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "unix-time-milliseconds",
-        "type": "unix-time",
-        "display_text": "unix-time-milliseconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "HPEXPIRETIME": {
@@ -8082,6 +9720,34 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -8101,36 +9767,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HPTTL": {
@@ -8144,6 +9780,37 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -8163,39 +9830,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "HRANDFIELD": {
@@ -8209,6 +9843,36 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "options",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "withvalues",
+            "token": "WITHVALUES",
+            "type": "pure-token",
+            "optional": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8228,39 +9892,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "options",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          },
-          {
-            "name": "withvalues",
-            "type": "pure-token",
-            "display_text": "withvalues",
-            "token": "WITHVALUES",
-            "optional": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "HSCAN": {
@@ -8274,6 +9905,41 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "cursor",
+        "type": "integer"
+      },
+      {
+        "token": "MATCH",
+        "name": "pattern",
+        "type": "pattern",
+        "optional": true
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "NOVALUES",
+        "name": "novalues",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8293,46 +9959,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "cursor",
-        "type": "integer",
-        "display_text": "cursor"
-      },
-      {
-        "name": "pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "token": "MATCH",
-        "optional": true
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      },
-      {
-        "name": "novalues",
-        "type": "pure-token",
-        "display_text": "novalues",
-        "token": "NOVALUES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "HSET": {
@@ -8340,18 +9966,45 @@
     "since": "2.0.0",
     "group": "hash",
     "complexity": "O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.",
-    "history": [
-      [
-        "4.0.0",
-        "Accepts multiple `field` and `value` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@hash",
       "@fast"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "field",
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Accepts multiple `field` and `value` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8371,36 +10024,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "data",
-        "type": "block",
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field"
-          },
-          {
-            "name": "value",
-            "type": "string",
-            "display_text": "value"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "HSETEX": {
@@ -8414,6 +10037,93 @@
       "@fast"
     ],
     "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "fnx",
+            "type": "pure-token",
+            "token": "FNX"
+          },
+          {
+            "name": "fxx",
+            "type": "pure-token",
+            "token": "FXX"
+          }
+        ]
+      },
+      {
+        "name": "expiration",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "seconds",
+            "type": "integer",
+            "token": "EX"
+          },
+          {
+            "name": "milliseconds",
+            "type": "integer",
+            "token": "PX"
+          },
+          {
+            "name": "unix-time-seconds",
+            "type": "unix-time",
+            "token": "EXAT"
+          },
+          {
+            "name": "unix-time-milliseconds",
+            "type": "unix-time",
+            "token": "PXAT"
+          },
+          {
+            "name": "keepttl",
+            "type": "pure-token",
+            "token": "KEEPTTL"
+          }
+        ]
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "data",
+            "type": "block",
+            "multiple": true,
+            "arguments": [
+              {
+                "name": "field",
+                "type": "string"
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8433,104 +10143,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "fnx",
-            "type": "pure-token",
-            "display_text": "fnx",
-            "token": "FNX"
-          },
-          {
-            "name": "fxx",
-            "type": "pure-token",
-            "display_text": "fxx",
-            "token": "FXX"
-          }
-        ]
-      },
-      {
-        "name": "expiration",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "seconds",
-            "type": "integer",
-            "display_text": "seconds",
-            "token": "EX"
-          },
-          {
-            "name": "milliseconds",
-            "type": "integer",
-            "display_text": "milliseconds",
-            "token": "PX"
-          },
-          {
-            "name": "unix-time-seconds",
-            "type": "unix-time",
-            "display_text": "unix-time-seconds",
-            "token": "EXAT"
-          },
-          {
-            "name": "unix-time-milliseconds",
-            "type": "unix-time",
-            "display_text": "unix-time-milliseconds",
-            "token": "PXAT"
-          },
-          {
-            "name": "keepttl",
-            "type": "pure-token",
-            "display_text": "keepttl",
-            "token": "KEEPTTL"
-          }
-        ]
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "data",
-            "type": "block",
-            "multiple": true,
-            "arguments": [
-              {
-                "name": "field",
-                "type": "string",
-                "display_text": "field"
-              },
-              {
-                "name": "value",
-                "type": "string",
-                "display_text": "value"
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "HSETNX": {
@@ -8544,6 +10156,26 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8563,29 +10195,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field"
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "HSTRLEN": {
@@ -8599,6 +10208,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "field",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8617,23 +10241,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "field",
-        "type": "string",
-        "display_text": "field"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "HTTL": {
@@ -8647,6 +10254,37 @@
       "@fast"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "fields",
+        "token": "FIELDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numfields",
+            "type": "integer"
+          },
+          {
+            "name": "field",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -8666,39 +10304,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "fields",
-        "type": "block",
-        "token": "FIELDS",
-        "arguments": [
-          {
-            "name": "numfields",
-            "type": "integer",
-            "display_text": "numfields"
-          },
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "HVALS": {
@@ -8712,6 +10317,19 @@
       "@slow"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8731,20 +10349,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output_order"
     ]
   },
   "INCR": {
@@ -8758,6 +10362,18 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8778,19 +10394,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "INCRBY": {
@@ -8804,6 +10407,22 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "increment",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8824,24 +10443,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "increment",
-        "type": "integer",
-        "display_text": "increment"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "INCRBYFLOAT": {
@@ -8855,6 +10456,22 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "increment",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -8875,24 +10492,128 @@
         "access": true,
         "update": true
       }
+    ]
+  },
+  "INCREX": {
+    "summary": "Increments the numeric value of a key by a number and sets its expiration time. Uses 0 as initial value if the key doesn't exist.",
+    "since": "8.8.0",
+    "group": "string",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@write",
+      "@string",
+      "@fast"
     ],
+    "arity": -2,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "increment",
-        "type": "double",
-        "display_text": "increment"
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "float",
+            "type": "double",
+            "token": "BYFLOAT"
+          },
+          {
+            "name": "integer",
+            "type": "integer",
+            "token": "BYINT"
+          }
+        ]
+      },
+      {
+        "name": "saturate",
+        "token": "SATURATE",
+        "type": "pure-token",
+        "optional": true,
+        "summary": "Saturate the result to LBOUND/UBOUND (or the type limits when no explicit bound is given) when out of bounds. Without this option, out-of-bounds operations are rejected and reply [current_value, 0]."
+      },
+      {
+        "name": "lowerbound",
+        "token": "LBOUND",
+        "type": "string",
+        "summary": "Integer when used with BYINT, floating-point when used with BYFLOAT.",
+        "optional": true
+      },
+      {
+        "name": "upperbound",
+        "token": "UBOUND",
+        "type": "string",
+        "summary": "Integer when used with BYINT, floating-point when used with BYFLOAT.",
+        "optional": true
+      },
+      {
+        "name": "expiration",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "seconds",
+            "type": "integer",
+            "token": "EX"
+          },
+          {
+            "name": "milliseconds",
+            "type": "integer",
+            "token": "PX"
+          },
+          {
+            "name": "unix-time-seconds",
+            "type": "unix-time",
+            "token": "EXAT"
+          },
+          {
+            "name": "unix-time-milliseconds",
+            "type": "unix-time",
+            "token": "PXAT"
+          },
+          {
+            "name": "persist",
+            "type": "pure-token",
+            "token": "PERSIST"
+          }
+        ]
+      },
+      {
+        "name": "enx",
+        "type": "pure-token",
+        "token": "ENX",
+        "optional": true,
+        "summary": "Only set the expiration if the key currently has no TTL. Requires one of EX/PX/EXAT/PXAT; cannot be combined with PERSIST."
       }
     ],
     "command_flags": [
       "write",
       "denyoom",
       "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "access": true,
+        "update": true
+      }
     ]
   },
   "INFO": {
@@ -8900,12 +10621,6 @@
     "since": "1.0.0",
     "group": "server",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added support for taking multiple section arguments."
-      ]
-    ],
     "acl_categories": [
       "@slow",
       "@dangerous"
@@ -8915,20 +10630,40 @@
       {
         "name": "section",
         "type": "string",
-        "display_text": "section",
-        "optional": true,
-        "multiple": true
+        "multiple": true,
+        "optional": true
       }
     ],
     "command_flags": [
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ],
     "hints": [
       "nondeterministic_output",
       "request_policy:all_shards",
       "response_policy:special"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added support for taking multiple section arguments."
+      ]
     ]
+  },
+  "JSON.GET": {
+    "summary": "Return the value at path in JSON serialized form",
+    "since": "1.0.0",
+    "group": "json",
+    "complexity": "O(N) when path is evaluated to a single value where N is the size of the value, O(N) when path is evaluated to multiple values, where N is the size of the key",
+    "arguments": []
+  },
+  "JSON.SET": {
+    "summary": "Sets or updates the JSON value at a path",
+    "since": "1.0.0",
+    "group": "json",
+    "complexity": "O(M+N) where M is the original size and N is the new size",
+    "arguments": []
   },
   "KEYS": {
     "summary": "Returns all key names that match a pattern.",
@@ -8945,8 +10680,7 @@
     "arguments": [
       {
         "name": "pattern",
-        "type": "pattern",
-        "display_text": "pattern"
+        "type": "pattern"
       }
     ],
     "command_flags": [
@@ -9024,8 +10758,7 @@
     "arguments": [
       {
         "name": "event",
-        "type": "string",
-        "display_text": "event"
+        "type": "string"
       }
     ],
     "command_flags": [
@@ -9067,9 +10800,8 @@
     "arity": -2,
     "arguments": [
       {
-        "name": "command",
+        "name": "COMMAND",
         "type": "string",
-        "display_text": "command",
         "optional": true,
         "multiple": true
       }
@@ -9100,8 +10832,7 @@
     "arguments": [
       {
         "name": "event",
-        "type": "string",
-        "display_text": "event"
+        "type": "string"
       }
     ],
     "command_flags": [
@@ -9154,7 +10885,6 @@
       {
         "name": "event",
         "type": "string",
-        "display_text": "event",
         "optional": true,
         "multiple": true
       }
@@ -9181,6 +10911,45 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key1",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "key2",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "len",
+        "token": "LEN",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "idx",
+        "token": "IDX",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "MINMATCHLEN",
+        "name": "min-match-len",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "name": "withmatchlen",
+        "token": "WITHMATCHLEN",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9200,51 +10969,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key1",
-        "type": "key",
-        "display_text": "key1",
-        "key_spec_index": 0
-      },
-      {
-        "name": "key2",
-        "type": "key",
-        "display_text": "key2",
-        "key_spec_index": 0
-      },
-      {
-        "name": "len",
-        "type": "pure-token",
-        "display_text": "len",
-        "token": "LEN",
-        "optional": true
-      },
-      {
-        "name": "idx",
-        "type": "pure-token",
-        "display_text": "idx",
-        "token": "IDX",
-        "optional": true
-      },
-      {
-        "name": "min-match-len",
-        "type": "integer",
-        "display_text": "min-match-len",
-        "token": "MINMATCHLEN",
-        "optional": true
-      },
-      {
-        "name": "withmatchlen",
-        "type": "pure-token",
-        "display_text": "withmatchlen",
-        "token": "WITHMATCHLEN",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "LINDEX": {
@@ -9258,6 +10982,20 @@
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9277,22 +11015,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "index",
-        "type": "integer",
-        "display_text": "index"
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "LINSERT": {
@@ -9306,6 +11028,41 @@
       "@slow"
     ],
     "arity": 5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "where",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "before",
+            "type": "pure-token",
+            "token": "BEFORE"
+          },
+          {
+            "name": "after",
+            "type": "pure-token",
+            "token": "AFTER"
+          }
+        ]
+      },
+      {
+        "name": "pivot",
+        "type": "string"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9325,46 +11082,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "where",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "before",
-            "type": "pure-token",
-            "display_text": "before",
-            "token": "BEFORE"
-          },
-          {
-            "name": "after",
-            "type": "pure-token",
-            "display_text": "after",
-            "token": "AFTER"
-          }
-        ]
-      },
-      {
-        "name": "pivot",
-        "type": "string",
-        "display_text": "pivot"
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "LLEN": {
@@ -9378,6 +11095,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9396,18 +11124,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "LMOVE": {
@@ -9421,6 +11137,54 @@
       "@slow"
     ],
     "arity": 5,
+    "arguments": [
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "name": "wherefrom",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "left",
+            "type": "pure-token",
+            "token": "LEFT"
+          },
+          {
+            "name": "right",
+            "type": "pure-token",
+            "token": "RIGHT"
+          }
+        ]
+      },
+      {
+        "name": "whereto",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "left",
+            "type": "pure-token",
+            "token": "LEFT"
+          },
+          {
+            "name": "right",
+            "type": "pure-token",
+            "token": "RIGHT"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9459,18 +11223,28 @@
         "RW": true,
         "insert": true
       }
+    ]
+  },
+  "LMOVEM": {
+    "summary": "Moves up to (or exactly) a number of elements from one list to another and returns them. Deletes the source list if it becomes empty.",
+    "since": "8.10.0",
+    "group": "list",
+    "complexity": "O(N) where N is the number of elements moved.",
+    "acl_categories": [
+      "@write",
+      "@list",
+      "@slow"
     ],
+    "arity": -5,
     "arguments": [
       {
         "name": "source",
         "type": "key",
-        "display_text": "source",
         "key_spec_index": 0
       },
       {
         "name": "destination",
         "type": "key",
-        "display_text": "destination",
         "key_spec_index": 1
       },
       {
@@ -9480,13 +11254,11 @@
           {
             "name": "left",
             "type": "pure-token",
-            "display_text": "left",
             "token": "LEFT"
           },
           {
             "name": "right",
             "type": "pure-token",
-            "display_text": "right",
             "token": "RIGHT"
           }
         ]
@@ -9498,14 +11270,51 @@
           {
             "name": "left",
             "type": "pure-token",
-            "display_text": "left",
             "token": "LEFT"
           },
           {
             "name": "right",
             "type": "pure-token",
-            "display_text": "right",
             "token": "RIGHT"
+          }
+        ]
+      },
+      {
+        "name": "how-many",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "selector",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "count",
+                "type": "integer",
+                "token": "COUNT"
+              },
+              {
+                "name": "exactly",
+                "type": "integer",
+                "token": "EXACTLY"
+              }
+            ]
+          },
+          {
+            "name": "ordering",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "obo",
+                "type": "pure-token",
+                "token": "OBO"
+              },
+              {
+                "name": "bulk",
+                "type": "pure-token",
+                "token": "BULK"
+              }
+            ]
           }
         ]
       }
@@ -9513,6 +11322,45 @@
     "command_flags": [
       "write",
       "denyoom"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "access": true,
+        "delete": true
+      },
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 2
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "insert": true
+      }
     ]
   },
   "LMPOP": {
@@ -9526,6 +11374,43 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "where",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "left",
+            "type": "pure-token",
+            "token": "LEFT"
+          },
+          {
+            "name": "right",
+            "type": "pure-token",
+            "token": "RIGHT"
+          }
+        ]
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9546,49 +11431,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "where",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "left",
-            "type": "pure-token",
-            "display_text": "left",
-            "token": "LEFT"
-          },
-          {
-            "name": "right",
-            "type": "pure-token",
-            "display_text": "right",
-            "token": "RIGHT"
-          }
-        ]
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "movablekeys"
     ]
   },
   "LOLWUT": {
@@ -9602,10 +11444,9 @@
     "arity": -1,
     "arguments": [
       {
+        "token": "VERSION",
         "name": "version",
         "type": "integer",
-        "display_text": "version",
-        "token": "VERSION",
         "optional": true
       }
     ],
@@ -9619,18 +11460,35 @@
     "since": "1.0.0",
     "group": "list",
     "complexity": "O(N) where N is the number of elements returned",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `count` argument."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true,
+        "since": "6.2.0"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added the `count` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9651,25 +11509,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "since": "6.2.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "LPOS": {
@@ -9683,6 +11522,38 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "element",
+        "type": "string"
+      },
+      {
+        "token": "RANK",
+        "name": "rank",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "COUNT",
+        "name": "num-matches",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "MAXLEN",
+        "name": "len",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9702,43 +11573,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element"
-      },
-      {
-        "name": "rank",
-        "type": "integer",
-        "display_text": "rank",
-        "token": "RANK",
-        "optional": true
-      },
-      {
-        "name": "num-matches",
-        "type": "integer",
-        "display_text": "num-matches",
-        "token": "COUNT",
-        "optional": true
-      },
-      {
-        "name": "len",
-        "type": "integer",
-        "display_text": "len",
-        "token": "MAXLEN",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "LPUSH": {
@@ -9746,18 +11580,35 @@
     "since": "1.0.0",
     "group": "list",
     "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
-    "history": [
-      [
-        "2.4.0",
-        "Accepts multiple `element` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "element",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "2.4.0",
+        "Accepts multiple `element` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9777,25 +11628,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "LPUSHX": {
@@ -9803,18 +11635,35 @@
     "since": "2.2.0",
     "group": "list",
     "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
-    "history": [
-      [
-        "4.0.0",
-        "Accepts multiple `element` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "element",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Accepts multiple `element` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9834,25 +11683,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "LRANGE": {
@@ -9866,6 +11696,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "stop",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9885,27 +11733,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "integer",
-        "display_text": "start"
-      },
-      {
-        "name": "stop",
-        "type": "integer",
-        "display_text": "stop"
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "LREM": {
@@ -9919,6 +11746,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9938,27 +11783,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count"
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "LSET": {
@@ -9972,6 +11796,25 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "index",
+        "type": "integer"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -9991,28 +11834,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "index",
-        "type": "integer",
-        "display_text": "index"
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "LTRIM": {
@@ -10026,6 +11847,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "stop",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10045,27 +11884,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "integer",
-        "display_text": "start"
-      },
-      {
-        "name": "stop",
-        "type": "integer",
-        "display_text": "stop"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "MEMORY": {
@@ -10161,6 +11979,22 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "token": "SAMPLES",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10179,24 +12013,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "SAMPLES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "MGET": {
@@ -10210,6 +12026,21 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "request_policy:multi_shard"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10229,22 +12060,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "request_policy:multi_shard"
     ]
   },
   "MIGRATE": {
@@ -10252,6 +12067,107 @@
     "since": "2.6.0",
     "group": "generic",
     "complexity": "This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.",
+    "acl_categories": [
+      "@keyspace",
+      "@write",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": -6,
+    "arguments": [
+      {
+        "name": "host",
+        "type": "string"
+      },
+      {
+        "name": "port",
+        "type": "integer"
+      },
+      {
+        "name": "key-selector",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "key",
+            "type": "key",
+            "key_spec_index": 0
+          },
+          {
+            "name": "empty-string",
+            "type": "pure-token",
+            "token": "\"\""
+          }
+        ]
+      },
+      {
+        "name": "destination-db",
+        "type": "integer"
+      },
+      {
+        "name": "timeout",
+        "type": "integer"
+      },
+      {
+        "name": "copy",
+        "token": "COPY",
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.0.0"
+      },
+      {
+        "name": "replace",
+        "token": "REPLACE",
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.0.0"
+      },
+      {
+        "name": "authentication",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "token": "AUTH",
+            "name": "auth",
+            "display": "password",
+            "type": "string",
+            "since": "4.0.7"
+          },
+          {
+            "token": "AUTH2",
+            "name": "auth2",
+            "type": "block",
+            "since": "6.0.0",
+            "arguments": [
+              {
+                "name": "username",
+                "type": "string"
+              },
+              {
+                "name": "password",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "token": "KEYS",
+        "name": "keys",
+        "display": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "optional": true,
+        "multiple": true,
+        "since": "3.0.6"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "history": [
       [
         "3.0.0",
@@ -10270,13 +12186,6 @@
         "Added the `AUTH2` option."
       ]
     ],
-    "acl_categories": [
-      "@keyspace",
-      "@write",
-      "@slow",
-      "@dangerous"
-    ],
-    "arity": -6,
     "key_specs": [
       {
         "begin_search": {
@@ -10318,111 +12227,6 @@
         "delete": true,
         "incomplete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "host",
-        "type": "string",
-        "display_text": "host"
-      },
-      {
-        "name": "port",
-        "type": "integer",
-        "display_text": "port"
-      },
-      {
-        "name": "key-selector",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "key",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 0
-          },
-          {
-            "name": "empty-string",
-            "type": "pure-token",
-            "display_text": "empty-string",
-            "token": ""
-          }
-        ]
-      },
-      {
-        "name": "destination-db",
-        "type": "integer",
-        "display_text": "destination-db"
-      },
-      {
-        "name": "timeout",
-        "type": "integer",
-        "display_text": "timeout"
-      },
-      {
-        "name": "copy",
-        "type": "pure-token",
-        "display_text": "copy",
-        "token": "COPY",
-        "since": "3.0.0",
-        "optional": true
-      },
-      {
-        "name": "replace",
-        "type": "pure-token",
-        "display_text": "replace",
-        "token": "REPLACE",
-        "since": "3.0.0",
-        "optional": true
-      },
-      {
-        "name": "authentication",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "auth",
-            "type": "string",
-            "display_text": "password",
-            "token": "AUTH",
-            "since": "4.0.7"
-          },
-          {
-            "name": "auth2",
-            "type": "block",
-            "token": "AUTH2",
-            "since": "6.0.0",
-            "arguments": [
-              {
-                "name": "username",
-                "type": "string",
-                "display_text": "username"
-              },
-              {
-                "name": "password",
-                "type": "string",
-                "display_text": "password"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "keys",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "token": "KEYS",
-        "since": "3.0.6",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "movablekeys"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "MODULE": {
@@ -10482,21 +12286,20 @@
     "arguments": [
       {
         "name": "path",
-        "type": "string",
-        "display_text": "path"
+        "type": "string"
       },
       {
         "name": "arg",
         "type": "string",
-        "display_text": "arg",
         "optional": true,
         "multiple": true
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
       "noscript",
-      "no_async_loading"
+      "protected"
     ]
   },
   "MODULE LOADEX": {
@@ -10513,42 +12316,39 @@
     "arguments": [
       {
         "name": "path",
-        "type": "string",
-        "display_text": "path"
+        "type": "string"
       },
       {
         "name": "configs",
-        "type": "block",
         "token": "CONFIG",
-        "optional": true,
+        "type": "block",
         "multiple": true,
         "multiple_token": true,
+        "optional": true,
         "arguments": [
           {
             "name": "name",
-            "type": "string",
-            "display_text": "name"
+            "type": "string"
           },
           {
             "name": "value",
-            "type": "string",
-            "display_text": "value"
+            "type": "string"
           }
         ]
       },
       {
         "name": "args",
-        "type": "string",
-        "display_text": "args",
         "token": "ARGS",
-        "optional": true,
-        "multiple": true
+        "type": "string",
+        "multiple": true,
+        "optional": true
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
       "noscript",
-      "no_async_loading"
+      "protected"
     ]
   },
   "MODULE UNLOAD": {
@@ -10565,14 +12365,14 @@
     "arguments": [
       {
         "name": "name",
-        "type": "string",
-        "display_text": "name"
+        "type": "string"
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
       "noscript",
-      "no_async_loading"
+      "protected"
     ]
   },
   "MONITOR": {
@@ -10590,7 +12390,8 @@
       "noscript",
       "loading",
       "stale"
-    ]
+    ],
+    "history": []
   },
   "MOVE": {
     "summary": "Moves a key to another database.",
@@ -10603,6 +12404,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "db",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10623,23 +12439,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "db",
-        "type": "integer",
-        "display_text": "db"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "MSET": {
@@ -10653,6 +12452,32 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "key",
+            "type": "key",
+            "key_spec_index": 0
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "hints": [
+      "request_policy:multi_shard",
+      "response_policy:all_succeeded"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10672,8 +12497,24 @@
         "OW": true,
         "update": true
       }
+    ]
+  },
+  "MSETEX": {
+    "summary": "Atomically sets multiple string keys with a shared expiration in a single operation. Supports flexible argument parsing where condition and expiration flags can appear in any order.",
+    "since": "8.4.0",
+    "group": "string",
+    "complexity": "O(N) where N is the number of keys to set.",
+    "acl_categories": [
+      "@write",
+      "@string",
+      "@slow"
     ],
+    "arity": -4,
     "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
       {
         "name": "data",
         "type": "block",
@@ -10682,13 +12523,60 @@
           {
             "name": "key",
             "type": "key",
-            "display_text": "key",
             "key_spec_index": 0
           },
           {
             "name": "value",
-            "type": "string",
-            "display_text": "value"
+            "type": "string"
+          }
+        ]
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          }
+        ]
+      },
+      {
+        "name": "expiration",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "seconds",
+            "type": "integer",
+            "token": "EX"
+          },
+          {
+            "name": "milliseconds",
+            "type": "integer",
+            "token": "PX"
+          },
+          {
+            "name": "unix-time-seconds",
+            "type": "unix-time",
+            "token": "EXAT"
+          },
+          {
+            "name": "unix-time-milliseconds",
+            "type": "unix-time",
+            "token": "PXAT"
+          },
+          {
+            "name": "keepttl",
+            "type": "pure-token",
+            "token": "KEEPTTL"
           }
         ]
       }
@@ -10700,6 +12588,26 @@
     "hints": [
       "request_policy:multi_shard",
       "response_policy:all_succeeded"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "keynum",
+          "spec": {
+            "keynumidx": 0,
+            "firstkey": 1,
+            "keystep": 2
+          }
+        },
+        "OW": true,
+        "update": true
+      }
     ]
   },
   "MSETNX": {
@@ -10713,6 +12621,28 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "key",
+            "type": "key",
+            "key_spec_index": 0
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10732,30 +12662,6 @@
         "OW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "data",
-        "type": "block",
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "key",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 0
-          },
-          {
-            "name": "value",
-            "type": "string",
-            "display_text": "value"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "MULTI": {
@@ -10797,6 +12703,19 @@
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10815,20 +12734,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "OBJECT FREQ": {
@@ -10842,6 +12747,19 @@
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10860,20 +12778,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "OBJECT HELP": {
@@ -10902,6 +12806,19 @@
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10920,20 +12837,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "OBJECT REFCOUNT": {
@@ -10947,6 +12850,19 @@
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -10965,20 +12881,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "PERSIST": {
@@ -10992,6 +12894,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11011,18 +12924,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "PEXPIRE": {
@@ -11030,18 +12931,61 @@
     "since": "2.6.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added options: `NX`, `XX`, `GT` and `LT`."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "milliseconds",
+        "type": "integer"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "7.0.0",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added options: `NX`, `XX`, `GT` and `LT`."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11061,55 +13005,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "milliseconds",
-        "type": "integer",
-        "display_text": "milliseconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "7.0.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "PEXPIREAT": {
@@ -11117,18 +13012,61 @@
     "since": "2.6.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added options: `NX`, `XX`, `GT` and `LT`."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "unix-time-milliseconds",
+        "type": "unix-time"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "7.0.0",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added options: `NX`, `XX`, `GT` and `LT`."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11148,55 +13086,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "unix-time-milliseconds",
-        "type": "unix-time",
-        "display_text": "unix-time-milliseconds"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "7.0.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          },
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "PEXPIRETIME": {
@@ -11210,6 +13099,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11229,18 +13129,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "PFADD": {
@@ -11254,6 +13142,24 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "element",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11273,26 +13179,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "PFCOUNT": {
@@ -11306,6 +13192,18 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "may_replicate"
+    ],
     "key_specs": [
       {
         "notes": "RW because it may change the internal representation of the key, and propagate to replicas",
@@ -11326,18 +13224,6 @@
         "RW": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "PFDEBUG": {
@@ -11353,6 +13239,22 @@
       "@dangerous"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "subcommand",
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "admin"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11373,24 +13275,6 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "subcommand",
-        "type": "string",
-        "display_text": "subcommand"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "admin"
-    ],
     "doc_flags": [
       "syscmd"
     ]
@@ -11406,6 +13290,24 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "destkey",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "sourcekey",
+        "type": "key",
+        "key_spec_index": 1,
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11444,26 +13346,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destkey",
-        "type": "key",
-        "display_text": "destkey",
-        "key_spec_index": 0
-      },
-      {
-        "name": "sourcekey",
-        "type": "key",
-        "display_text": "sourcekey",
-        "key_spec_index": 1,
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "PFSELFTEST": {
@@ -11499,12 +13381,12 @@
       {
         "name": "message",
         "type": "string",
-        "display_text": "message",
         "optional": true
       }
     ],
     "command_flags": [
-      "fast"
+      "fast",
+      "sentinel"
     ],
     "hints": [
       "request_policy:all_shards",
@@ -11516,14 +13398,31 @@
     "since": "2.6.0",
     "group": "string",
     "complexity": "O(1)",
-    "deprecated_since": "2.6.12",
-    "replaced_by": "`SET` with the `PX` argument",
     "acl_categories": [
       "@write",
       "@string",
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "milliseconds",
+        "type": "integer"
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11544,28 +13443,8 @@
         "update": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "milliseconds",
-        "type": "integer",
-        "display_text": "milliseconds"
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
-    ],
+    "deprecated_since": "2.6.12",
+    "replaced_by": "`SET` with the `PX` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -11584,7 +13463,6 @@
       {
         "name": "pattern",
         "type": "pattern",
-        "display_text": "pattern",
         "multiple": true
       }
     ],
@@ -11592,7 +13470,9 @@
       "pubsub",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel",
+      "denyoom"
     ]
   },
   "PSYNC": {
@@ -11608,20 +13488,18 @@
     "arguments": [
       {
         "name": "replicationid",
-        "type": "string",
-        "display_text": "replicationid"
+        "type": "string"
       },
       {
         "name": "offset",
-        "type": "integer",
-        "display_text": "offset"
+        "type": "integer"
       }
     ],
     "command_flags": [
-      "admin",
-      "noscript",
       "no_async_loading",
-      "no_multi"
+      "admin",
+      "no_multi",
+      "noscript"
     ]
   },
   "PTTL": {
@@ -11629,18 +13507,32 @@
     "since": "2.6.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "2.8.0",
-        "Added the -2 reply."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@read",
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "2.8.0",
+        "Added the -2 reply."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -11660,21 +13552,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "PUBLISH": {
@@ -11690,20 +13567,20 @@
     "arguments": [
       {
         "name": "channel",
-        "type": "string",
-        "display_text": "channel"
+        "type": "string"
       },
       {
         "name": "message",
-        "type": "string",
-        "display_text": "message"
+        "type": "string"
       }
     ],
     "command_flags": [
       "pubsub",
       "loading",
       "stale",
-      "fast"
+      "fast",
+      "may_replicate",
+      "sentinel"
     ]
   },
   "PUBSUB": {
@@ -11730,7 +13607,6 @@
       {
         "name": "pattern",
         "type": "pattern",
-        "display_text": "pattern",
         "optional": true
       }
     ],
@@ -11784,7 +13660,6 @@
       {
         "name": "channel",
         "type": "string",
-        "display_text": "channel",
         "optional": true,
         "multiple": true
       }
@@ -11809,7 +13684,6 @@
       {
         "name": "pattern",
         "type": "pattern",
-        "display_text": "pattern",
         "optional": true
       }
     ],
@@ -11833,7 +13707,6 @@
       {
         "name": "shardchannel",
         "type": "string",
-        "display_text": "shardchannel",
         "optional": true,
         "multiple": true
       }
@@ -11858,7 +13731,6 @@
       {
         "name": "pattern",
         "type": "pattern",
-        "display_text": "pattern",
         "optional": true,
         "multiple": true
       }
@@ -11867,7 +13739,8 @@
       "pubsub",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "QUIT": {
@@ -11875,21 +13748,21 @@
     "since": "1.0.0",
     "group": "connection",
     "complexity": "O(1)",
-    "deprecated_since": "7.2.0",
-    "replaced_by": "just closing the connection",
     "acl_categories": [
       "@fast",
       "@connection"
     ],
     "arity": -1,
     "command_flags": [
+      "allow_busy",
       "noscript",
       "loading",
       "stale",
       "fast",
-      "no_auth",
-      "allow_busy"
+      "no_auth"
     ],
+    "deprecated_since": "7.2.0",
+    "replaced_by": "just closing the connection",
     "doc_flags": [
       "deprecated"
     ]
@@ -11906,7 +13779,8 @@
     ],
     "arity": 1,
     "command_flags": [
-      "readonly"
+      "readonly",
+      "touches_arbitrary_keys"
     ],
     "hints": [
       "request_policy:all_shards",
@@ -11925,9 +13799,9 @@
     ],
     "arity": 1,
     "command_flags": [
+      "fast",
       "loading",
-      "stale",
-      "fast"
+      "stale"
     ]
   },
   "READWRITE": {
@@ -11941,9 +13815,9 @@
     ],
     "arity": 1,
     "command_flags": [
+      "fast",
       "loading",
-      "stale",
-      "fast"
+      "stale"
     ]
   },
   "RENAME": {
@@ -11957,6 +13831,22 @@
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "newkey",
+        "type": "key",
+        "key_spec_index": 1
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
+    "history": [],
     "key_specs": [
       {
         "begin_search": {
@@ -11995,23 +13885,6 @@
         "OW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "newkey",
-        "type": "key",
-        "display_text": "newkey",
-        "key_spec_index": 1
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "RENAMENX": {
@@ -12019,18 +13892,34 @@
     "since": "1.0.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "3.2.0",
-        "The command no longer returns an error when source and destination names are the same."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@write",
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "newkey",
+        "type": "key",
+        "key_spec_index": 1
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "3.2.0",
+        "The command no longer returns an error when source and destination names are the same."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12069,24 +13958,6 @@
         "OW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "newkey",
-        "type": "key",
-        "display_text": "newkey",
-        "key_spec_index": 1
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "REPLCONF": {
@@ -12133,13 +14004,11 @@
             "arguments": [
               {
                 "name": "host",
-                "type": "string",
-                "display_text": "host"
+                "type": "string"
               },
               {
                 "name": "port",
-                "type": "integer",
-                "display_text": "port"
+                "type": "integer"
               }
             ]
           },
@@ -12150,13 +14019,11 @@
               {
                 "name": "no",
                 "type": "pure-token",
-                "display_text": "no",
                 "token": "NO"
               },
               {
                 "name": "one",
                 "type": "pure-token",
-                "display_text": "one",
                 "token": "ONE"
               }
             ]
@@ -12165,10 +14032,10 @@
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
       "noscript",
-      "stale",
-      "no_async_loading"
+      "stale"
     ]
   },
   "RESET": {
@@ -12195,6 +14062,60 @@
     "since": "2.6.0",
     "group": "generic",
     "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+    "acl_categories": [
+      "@keyspace",
+      "@write",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "ttl",
+        "type": "integer"
+      },
+      {
+        "name": "serialized-value",
+        "type": "string"
+      },
+      {
+        "name": "replace",
+        "token": "REPLACE",
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.0.0"
+      },
+      {
+        "name": "absttl",
+        "token": "ABSTTL",
+        "type": "pure-token",
+        "optional": true,
+        "since": "5.0.0"
+      },
+      {
+        "token": "IDLETIME",
+        "name": "seconds",
+        "type": "integer",
+        "optional": true,
+        "since": "5.0.0"
+      },
+      {
+        "token": "FREQ",
+        "name": "frequency",
+        "type": "integer",
+        "optional": true,
+        "since": "5.0.0"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "history": [
       [
         "3.0.0",
@@ -12209,13 +14130,6 @@
         "Added the `IDLETIME` and `FREQ` options."
       ]
     ],
-    "acl_categories": [
-      "@keyspace",
-      "@write",
-      "@slow",
-      "@dangerous"
-    ],
-    "arity": -4,
     "key_specs": [
       {
         "begin_search": {
@@ -12235,60 +14149,6 @@
         "OW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "ttl",
-        "type": "integer",
-        "display_text": "ttl"
-      },
-      {
-        "name": "serialized-value",
-        "type": "string",
-        "display_text": "serialized-value"
-      },
-      {
-        "name": "replace",
-        "type": "pure-token",
-        "display_text": "replace",
-        "token": "REPLACE",
-        "since": "3.0.0",
-        "optional": true
-      },
-      {
-        "name": "absttl",
-        "type": "pure-token",
-        "display_text": "absttl",
-        "token": "ABSTTL",
-        "since": "5.0.0",
-        "optional": true
-      },
-      {
-        "name": "seconds",
-        "type": "integer",
-        "display_text": "seconds",
-        "token": "IDLETIME",
-        "since": "5.0.0",
-        "optional": true
-      },
-      {
-        "name": "frequency",
-        "type": "integer",
-        "display_text": "frequency",
-        "token": "FREQ",
-        "since": "5.0.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "RESTORE-ASKING": {
@@ -12296,6 +14156,61 @@
     "since": "3.0.0",
     "group": "server",
     "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+    "acl_categories": [
+      "@keyspace",
+      "@write",
+      "@slow",
+      "@dangerous"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "ttl",
+        "type": "integer"
+      },
+      {
+        "name": "serialized-value",
+        "type": "string"
+      },
+      {
+        "name": "replace",
+        "token": "REPLACE",
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.0.0"
+      },
+      {
+        "name": "absttl",
+        "token": "ABSTTL",
+        "type": "pure-token",
+        "optional": true,
+        "since": "5.0.0"
+      },
+      {
+        "token": "IDLETIME",
+        "name": "seconds",
+        "type": "integer",
+        "optional": true,
+        "since": "5.0.0"
+      },
+      {
+        "token": "FREQ",
+        "name": "frequency",
+        "type": "integer",
+        "optional": true,
+        "since": "5.0.0"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "asking"
+    ],
     "history": [
       [
         "3.0.0",
@@ -12310,13 +14225,6 @@
         "Added the `IDLETIME` and `FREQ` options."
       ]
     ],
-    "acl_categories": [
-      "@keyspace",
-      "@write",
-      "@slow",
-      "@dangerous"
-    ],
-    "arity": -4,
     "key_specs": [
       {
         "begin_search": {
@@ -12336,61 +14244,6 @@
         "OW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "ttl",
-        "type": "integer",
-        "display_text": "ttl"
-      },
-      {
-        "name": "serialized-value",
-        "type": "string",
-        "display_text": "serialized-value"
-      },
-      {
-        "name": "replace",
-        "type": "pure-token",
-        "display_text": "replace",
-        "token": "REPLACE",
-        "since": "3.0.0",
-        "optional": true
-      },
-      {
-        "name": "absttl",
-        "type": "pure-token",
-        "display_text": "absttl",
-        "token": "ABSTTL",
-        "since": "5.0.0",
-        "optional": true
-      },
-      {
-        "name": "seconds",
-        "type": "integer",
-        "display_text": "seconds",
-        "token": "IDLETIME",
-        "since": "5.0.0",
-        "optional": true
-      },
-      {
-        "name": "frequency",
-        "type": "integer",
-        "display_text": "frequency",
-        "token": "FREQ",
-        "since": "5.0.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "asking"
     ],
     "doc_flags": [
       "syscmd"
@@ -12411,7 +14264,8 @@
       "noscript",
       "loading",
       "stale",
-      "fast"
+      "fast",
+      "sentinel"
     ]
   },
   "RPOP": {
@@ -12419,18 +14273,35 @@
     "since": "1.0.0",
     "group": "list",
     "complexity": "O(N) where N is the number of elements returned",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `count` argument."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true,
+        "since": "6.2.0"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added the `count` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12451,25 +14322,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "since": "6.2.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "RPOPLPUSH": {
@@ -12477,14 +14329,28 @@
     "since": "1.2.0",
     "group": "list",
     "complexity": "O(1)",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`LMOVE` with the `RIGHT` and `LEFT` arguments",
     "acl_categories": [
       "@write",
       "@list",
       "@slow"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 1
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12524,24 +14390,8 @@
         "insert": true
       }
     ],
-    "arguments": [
-      {
-        "name": "source",
-        "type": "key",
-        "display_text": "source",
-        "key_spec_index": 0
-      },
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 1
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`LMOVE` with the `RIGHT` and `LEFT` arguments",
     "doc_flags": [
       "deprecated"
     ]
@@ -12551,18 +14401,35 @@
     "since": "1.0.0",
     "group": "list",
     "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
-    "history": [
-      [
-        "2.4.0",
-        "Accepts multiple `element` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "element",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "2.4.0",
+        "Accepts multiple `element` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12582,25 +14449,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "RPUSHX": {
@@ -12608,18 +14456,35 @@
     "since": "2.2.0",
     "group": "list",
     "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
-    "history": [
-      [
-        "4.0.0",
-        "Accepts multiple `element` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@list",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "element",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Accepts multiple `element` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12639,25 +14504,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "element",
-        "type": "string",
-        "display_text": "element",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "SADD": {
@@ -12665,18 +14511,35 @@
     "since": "1.0.0",
     "group": "set",
     "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
-    "history": [
-      [
-        "2.4.0",
-        "Accepts multiple `member` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@set",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "2.4.0",
+        "Accepts multiple `member` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12696,25 +14559,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "SAVE": {
@@ -12729,9 +14573,9 @@
     ],
     "arity": 1,
     "command_flags": [
+      "no_async_loading",
       "admin",
       "noscript",
-      "no_async_loading",
       "no_multi"
     ]
   },
@@ -12740,12 +14584,6 @@
     "since": "2.8.0",
     "group": "generic",
     "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
-    "history": [
-      [
-        "6.0.0",
-        "Added the `TYPE` subcommand."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@read",
@@ -12755,39 +14593,42 @@
     "arguments": [
       {
         "name": "cursor",
-        "type": "integer",
-        "display_text": "cursor"
+        "type": "integer"
       },
       {
+        "token": "MATCH",
         "name": "pattern",
         "type": "pattern",
-        "display_text": "pattern",
-        "token": "MATCH",
         "optional": true
       },
       {
+        "token": "COUNT",
         "name": "count",
         "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
         "optional": true
       },
       {
+        "token": "TYPE",
         "name": "type",
         "type": "string",
-        "display_text": "type",
-        "token": "TYPE",
-        "since": "6.0.0",
-        "optional": true
+        "optional": true,
+        "since": "6.0.0"
       }
     ],
     "command_flags": [
-      "readonly"
+      "readonly",
+      "touches_arbitrary_keys"
     ],
     "hints": [
       "nondeterministic_output",
       "request_policy:special",
       "response_policy:special"
+    ],
+    "history": [
+      [
+        "6.0.0",
+        "Added the `TYPE` subcommand."
+      ]
     ]
   },
   "SCARD": {
@@ -12801,6 +14642,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -12819,18 +14671,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "SCRIPT": {
@@ -12861,19 +14701,16 @@
           {
             "name": "yes",
             "type": "pure-token",
-            "display_text": "yes",
             "token": "YES"
           },
           {
             "name": "sync",
             "type": "pure-token",
-            "display_text": "sync",
             "token": "SYNC"
           },
           {
             "name": "no",
             "type": "pure-token",
-            "display_text": "no",
             "token": "NO"
           }
         ]
@@ -12897,7 +14734,6 @@
       {
         "name": "sha1",
         "type": "string",
-        "display_text": "sha1",
         "multiple": true
       }
     ],
@@ -12914,12 +14750,6 @@
     "since": "2.6.0",
     "group": "scripting",
     "complexity": "O(N) with N being the number of scripts in cache",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `ASYNC` and `SYNC` flushing mode modifiers."
-      ]
-    ],
     "acl_categories": [
       "@slow",
       "@scripting"
@@ -12929,19 +14759,17 @@
       {
         "name": "flush-type",
         "type": "oneof",
-        "since": "6.2.0",
         "optional": true,
+        "since": "6.2.0",
         "arguments": [
           {
             "name": "async",
             "type": "pure-token",
-            "display_text": "async",
             "token": "ASYNC"
           },
           {
             "name": "sync",
             "type": "pure-token",
-            "display_text": "sync",
             "token": "SYNC"
           }
         ]
@@ -12953,6 +14781,12 @@
     "hints": [
       "request_policy:all_nodes",
       "response_policy:all_succeeded"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added the `ASYNC` and `SYNC` flushing mode modifiers."
+      ]
     ]
   },
   "SCRIPT HELP": {
@@ -13002,8 +14836,7 @@
     "arguments": [
       {
         "name": "script",
-        "type": "string",
-        "display_text": "script"
+        "type": "string"
       }
     ],
     "command_flags": [
@@ -13026,6 +14859,20 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13045,21 +14892,59 @@
         "RO": true,
         "access": true
       }
+    ]
+  },
+  "SDIFFCARD": {
+    "summary": "Returns the number of members of the difference between the first set and all successive sets.",
+    "since": "8.10.0",
+    "group": "set",
+    "complexity": "O(N) where N is the total number of elements in all given sets.",
+    "acl_categories": [
+      "@read",
+      "@set",
+      "@slow"
     ],
+    "arity": -3,
     "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0,
         "multiple": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "integer",
+        "optional": true
       }
     ],
     "command_flags": [
       "readonly"
     ],
-    "hints": [
-      "nondeterministic_output_order"
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "keynum",
+          "spec": {
+            "keynumidx": 0,
+            "firstkey": 1,
+            "keystep": 1
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "SDIFFSTORE": {
@@ -13073,6 +14958,23 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13110,25 +15012,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "SELECT": {
@@ -13144,8 +15027,7 @@
     "arguments": [
       {
         "name": "index",
-        "type": "integer",
-        "display_text": "index"
+        "type": "integer"
       }
     ],
     "command_flags": [
@@ -13159,6 +15041,113 @@
     "since": "1.0.0",
     "group": "string",
     "complexity": "O(1)",
+    "acl_categories": [
+      "@write",
+      "@string",
+      "@slow"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "value",
+        "type": "string"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "2.6.12",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          },
+          {
+            "name": "ifeq-value",
+            "type": "string",
+            "token": "IFEQ",
+            "since": "8.4.0"
+          },
+          {
+            "name": "ifne-value",
+            "type": "string",
+            "token": "IFNE",
+            "since": "8.4.0"
+          },
+          {
+            "name": "ifdeq-digest",
+            "type": "string",
+            "token": "IFDEQ",
+            "since": "8.4.0"
+          },
+          {
+            "name": "ifdne-digest",
+            "type": "string",
+            "token": "IFDNE",
+            "since": "8.4.0"
+          }
+        ]
+      },
+      {
+        "name": "get",
+        "token": "GET",
+        "type": "pure-token",
+        "optional": true,
+        "since": "6.2.0"
+      },
+      {
+        "name": "expiration",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "seconds",
+            "type": "integer",
+            "token": "EX",
+            "since": "2.6.12"
+          },
+          {
+            "name": "milliseconds",
+            "type": "integer",
+            "token": "PX",
+            "since": "2.6.12"
+          },
+          {
+            "name": "unix-time-seconds",
+            "type": "unix-time",
+            "token": "EXAT",
+            "since": "6.2.0"
+          },
+          {
+            "name": "unix-time-milliseconds",
+            "type": "unix-time",
+            "token": "PXAT",
+            "since": "6.2.0"
+          },
+          {
+            "name": "keepttl",
+            "type": "pure-token",
+            "token": "KEEPTTL",
+            "since": "6.0.0"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "history": [
       [
         "2.6.12",
@@ -13175,14 +15164,12 @@
       [
         "7.0.0",
         "Allowed the `NX` and `GET` options to be used together."
+      ],
+      [
+        "8.4.0",
+        "Added 'IFEQ', 'IFNE', 'IFDEQ', 'IFDNE' options."
       ]
     ],
-    "acl_categories": [
-      "@write",
-      "@string",
-      "@slow"
-    ],
-    "arity": -3,
     "key_specs": [
       {
         "notes": "RW and ACCESS due to the optional `GET` argument",
@@ -13205,93 +15192,6 @@
         "update": true,
         "variable_flags": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "2.6.12",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          }
-        ]
-      },
-      {
-        "name": "get",
-        "type": "pure-token",
-        "display_text": "get",
-        "token": "GET",
-        "since": "6.2.0",
-        "optional": true
-      },
-      {
-        "name": "expiration",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "seconds",
-            "type": "integer",
-            "display_text": "seconds",
-            "token": "EX",
-            "since": "2.6.12"
-          },
-          {
-            "name": "milliseconds",
-            "type": "integer",
-            "display_text": "milliseconds",
-            "token": "PX",
-            "since": "2.6.12"
-          },
-          {
-            "name": "unix-time-seconds",
-            "type": "unix-time",
-            "display_text": "unix-time-seconds",
-            "token": "EXAT",
-            "since": "6.2.0"
-          },
-          {
-            "name": "unix-time-milliseconds",
-            "type": "unix-time",
-            "display_text": "unix-time-milliseconds",
-            "token": "PXAT",
-            "since": "6.2.0"
-          },
-          {
-            "name": "keepttl",
-            "type": "pure-token",
-            "display_text": "keepttl",
-            "token": "KEEPTTL",
-            "since": "6.0.0"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "SETBIT": {
@@ -13305,6 +15205,25 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "offset",
+        "type": "integer"
+      },
+      {
+        "name": "value",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13325,28 +15244,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "offset",
-        "type": "integer",
-        "display_text": "offset"
-      },
-      {
-        "name": "value",
-        "type": "integer",
-        "display_text": "value"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "SETEX": {
@@ -13354,14 +15251,31 @@
     "since": "2.0.0",
     "group": "string",
     "complexity": "O(1)",
-    "deprecated_since": "2.6.12",
-    "replaced_by": "`SET` with the `EX` argument",
     "acl_categories": [
       "@write",
       "@string",
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "seconds",
+        "type": "integer"
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13382,28 +15296,8 @@
         "update": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "seconds",
-        "type": "integer",
-        "display_text": "seconds"
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
-    ],
+    "deprecated_since": "2.6.12",
+    "replaced_by": "`SET` with the `EX` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -13413,14 +15307,28 @@
     "since": "1.0.0",
     "group": "string",
     "complexity": "O(1)",
-    "deprecated_since": "2.6.12",
-    "replaced_by": "`SET` with the `NX` argument",
     "acl_categories": [
       "@write",
       "@string",
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13441,24 +15349,8 @@
         "insert": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
-    ],
+    "deprecated_since": "2.6.12",
+    "replaced_by": "`SET` with the `NX` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -13474,6 +15366,25 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "offset",
+        "type": "integer"
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13493,41 +15404,65 @@
         "RW": true,
         "update": true
       }
+    ]
+  },
+  "SFLUSH": {
+    "summary": "Remove all keys from selected range of slots.",
+    "since": "8.0.0",
+    "group": "server",
+    "complexity": "O(N)+O(k) where N is the number of keys and k is the number of slots.",
+    "acl_categories": [
+      "@keyspace",
+      "@write",
+      "@slow",
+      "@dangerous"
     ],
+    "arity": -3,
     "arguments": [
       {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "slot-start",
+            "type": "integer"
+          },
+          {
+            "name": "slot-last",
+            "type": "integer"
+          }
+        ]
       },
       {
-        "name": "offset",
-        "type": "integer",
-        "display_text": "offset"
-      },
-      {
-        "name": "value",
-        "type": "string",
-        "display_text": "value"
+        "name": "flush-type",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "async",
+            "type": "pure-token",
+            "token": "ASYNC"
+          },
+          {
+            "name": "sync",
+            "type": "pure-token",
+            "token": "SYNC"
+          }
+        ]
       }
     ],
     "command_flags": [
       "write",
-      "denyoom"
-    ]
+      "experimental"
+    ],
+    "hints": []
   },
   "SHUTDOWN": {
     "summary": "Synchronously saves the database(s) to disk and shuts down the Redis server.",
     "since": "1.0.0",
     "group": "server",
     "complexity": "O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added the `NOW`, `FORCE` and `ABORT` modifiers."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -13543,13 +15478,11 @@
           {
             "name": "nosave",
             "type": "pure-token",
-            "display_text": "nosave",
             "token": "NOSAVE"
           },
           {
             "name": "save",
             "type": "pure-token",
-            "display_text": "save",
             "token": "SAVE"
           }
         ]
@@ -13557,26 +15490,23 @@
       {
         "name": "now",
         "type": "pure-token",
-        "display_text": "now",
         "token": "NOW",
-        "since": "7.0.0",
-        "optional": true
+        "optional": true,
+        "since": "7.0.0"
       },
       {
         "name": "force",
         "type": "pure-token",
-        "display_text": "force",
         "token": "FORCE",
-        "since": "7.0.0",
-        "optional": true
+        "optional": true,
+        "since": "7.0.0"
       },
       {
         "name": "abort",
         "type": "pure-token",
-        "display_text": "abort",
         "token": "ABORT",
-        "since": "7.0.0",
-        "optional": true
+        "optional": true,
+        "since": "7.0.0"
       }
     ],
     "command_flags": [
@@ -13585,7 +15515,14 @@
       "loading",
       "stale",
       "no_multi",
+      "sentinel",
       "allow_busy"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the `NOW`, `FORCE` and `ABORT` modifiers."
+      ]
     ]
   },
   "SINTER": {
@@ -13599,6 +15536,20 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13618,21 +15569,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output_order"
     ]
   },
   "SINTERCARD": {
@@ -13646,6 +15582,27 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13665,31 +15622,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "limit",
-        "type": "integer",
-        "display_text": "limit",
-        "token": "LIMIT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "movablekeys"
     ]
   },
   "SINTERSTORE": {
@@ -13703,6 +15635,23 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13740,25 +15689,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "SISMEMBER": {
@@ -13772,6 +15702,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -13790,23 +15735,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "SLAVEOF": {
@@ -13814,8 +15742,6 @@
     "since": "1.0.0",
     "group": "server",
     "complexity": "O(1)",
-    "deprecated_since": "5.0.0",
-    "replaced_by": "`REPLICAOF`",
     "acl_categories": [
       "@admin",
       "@slow",
@@ -13833,13 +15759,11 @@
             "arguments": [
               {
                 "name": "host",
-                "type": "string",
-                "display_text": "host"
+                "type": "string"
               },
               {
                 "name": "port",
-                "type": "integer",
-                "display_text": "port"
+                "type": "integer"
               }
             ]
           },
@@ -13850,13 +15774,11 @@
               {
                 "name": "no",
                 "type": "pure-token",
-                "display_text": "no",
                 "token": "NO"
               },
               {
                 "name": "one",
                 "type": "pure-token",
-                "display_text": "one",
                 "token": "ONE"
               }
             ]
@@ -13865,11 +15787,13 @@
       }
     ],
     "command_flags": [
+      "no_async_loading",
       "admin",
       "noscript",
-      "stale",
-      "no_async_loading"
+      "stale"
     ],
+    "deprecated_since": "5.0.0",
+    "replaced_by": "`REPLICAOF`",
     "doc_flags": [
       "deprecated"
     ]
@@ -13889,12 +15813,6 @@
     "since": "2.2.12",
     "group": "server",
     "complexity": "O(N) where N is the number of entries returned",
-    "history": [
-      [
-        "4.0.0",
-        "Added client IP address, port and name to the reply."
-      ]
-    ],
     "acl_categories": [
       "@admin",
       "@slow",
@@ -13905,7 +15823,6 @@
       {
         "name": "count",
         "type": "integer",
-        "display_text": "count",
         "optional": true
       }
     ],
@@ -13917,6 +15834,16 @@
     "hints": [
       "request_policy:all_nodes",
       "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "4.0.0",
+        "Added client IP address, port and name to the reply."
+      ],
+      [
+        "8.10.0",
+        "Added original command argument count to the reply."
+      ]
     ]
   },
   "SLOWLOG HELP": {
@@ -13987,6 +15914,19 @@
       "@slow"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14006,20 +15946,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output_order"
     ]
   },
   "SMISMEMBER": {
@@ -14033,6 +15959,22 @@
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14052,24 +15994,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "SMOVE": {
@@ -14083,6 +16007,26 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "source",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "name": "member",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14121,29 +16065,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "source",
-        "type": "key",
-        "display_text": "source",
-        "key_spec_index": 0
-      },
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 1
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "SORT": {
@@ -14160,6 +16081,81 @@
       "@dangerous"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "token": "BY",
+        "name": "by-pattern",
+        "display": "pattern",
+        "type": "pattern",
+        "key_spec_index": 1,
+        "optional": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      },
+      {
+        "token": "GET",
+        "name": "get-pattern",
+        "display": "pattern",
+        "key_spec_index": 1,
+        "type": "pattern",
+        "optional": true,
+        "multiple": true,
+        "multiple_token": true
+      },
+      {
+        "name": "order",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "asc",
+            "type": "pure-token",
+            "token": "ASC"
+          },
+          {
+            "name": "desc",
+            "type": "pure-token",
+            "token": "DESC"
+          }
+        ]
+      },
+      {
+        "name": "sorting",
+        "token": "ALPHA",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "STORE",
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 2,
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14205,89 +16201,6 @@
         "OW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "by-pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "key_spec_index": 1,
-        "token": "BY",
-        "optional": true
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      },
-      {
-        "name": "get-pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "key_spec_index": 1,
-        "token": "GET",
-        "optional": true,
-        "multiple": true,
-        "multiple_token": true
-      },
-      {
-        "name": "order",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "asc",
-            "type": "pure-token",
-            "display_text": "asc",
-            "token": "ASC"
-          },
-          {
-            "name": "desc",
-            "type": "pure-token",
-            "display_text": "desc",
-            "token": "DESC"
-          }
-        ]
-      },
-      {
-        "name": "sorting",
-        "type": "pure-token",
-        "display_text": "sorting",
-        "token": "ALPHA",
-        "optional": true
-      },
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 2,
-        "token": "STORE",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "movablekeys"
     ]
   },
   "SORT_RO": {
@@ -14304,6 +16217,73 @@
       "@dangerous"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "token": "BY",
+        "name": "by-pattern",
+        "display": "pattern",
+        "type": "pattern",
+        "key_spec_index": 1,
+        "optional": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      },
+      {
+        "token": "GET",
+        "name": "get-pattern",
+        "display": "pattern",
+        "key_spec_index": 1,
+        "type": "pattern",
+        "optional": true,
+        "multiple": true,
+        "multiple_token": true
+      },
+      {
+        "name": "order",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "asc",
+            "type": "pure-token",
+            "token": "ASC"
+          },
+          {
+            "name": "desc",
+            "type": "pure-token",
+            "token": "DESC"
+          }
+        ]
+      },
+      {
+        "name": "sorting",
+        "token": "ALPHA",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14336,80 +16316,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "by-pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "key_spec_index": 1,
-        "token": "BY",
-        "optional": true
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      },
-      {
-        "name": "get-pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "key_spec_index": 1,
-        "token": "GET",
-        "optional": true,
-        "multiple": true,
-        "multiple_token": true
-      },
-      {
-        "name": "order",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "asc",
-            "type": "pure-token",
-            "display_text": "asc",
-            "token": "ASC"
-          },
-          {
-            "name": "desc",
-            "type": "pure-token",
-            "display_text": "desc",
-            "token": "DESC"
-          }
-        ]
-      },
-      {
-        "name": "sorting",
-        "type": "pure-token",
-        "display_text": "sorting",
-        "token": "ALPHA",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "movablekeys"
     ]
   },
   "SPOP": {
@@ -14417,18 +16323,38 @@
     "since": "1.0.0",
     "group": "set",
     "complexity": "Without the count argument O(1), otherwise O(N) where N is the value of the passed count.",
-    "history": [
-      [
-        "3.2.0",
-        "Added the `count` argument."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@set",
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true,
+        "since": "3.2.0"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "3.2.0",
+        "Added the `count` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14449,28 +16375,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "since": "3.2.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "SPUBLISH": {
@@ -14483,6 +16387,23 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "shardchannel",
+        "type": "string"
+      },
+      {
+        "name": "message",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "pubsub",
+      "loading",
+      "stale",
+      "fast",
+      "may_replicate"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14501,24 +16422,6 @@
         },
         "not_key": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "shardchannel",
-        "type": "string",
-        "display_text": "shardchannel"
-      },
-      {
-        "name": "message",
-        "type": "string",
-        "display_text": "message"
-      }
-    ],
-    "command_flags": [
-      "pubsub",
-      "loading",
-      "stale",
-      "fast"
     ]
   },
   "SRANDMEMBER": {
@@ -14526,18 +16429,37 @@
     "since": "1.0.0",
     "group": "set",
     "complexity": "Without the count argument O(1), otherwise O(N) where N is the absolute value of the passed count.",
-    "history": [
-      [
-        "2.6.0",
-        "Added the optional `count` argument."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@set",
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true,
+        "since": "2.6.0"
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "2.6.0",
+        "Added the optional `count` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14557,27 +16479,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "since": "2.6.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "SREM": {
@@ -14585,18 +16486,34 @@
     "since": "1.0.0",
     "group": "set",
     "complexity": "O(N) where N is the number of members to be removed.",
-    "history": [
-      [
-        "2.4.0",
-        "Accepts multiple `member` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@set",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "2.4.0",
+        "Accepts multiple `member` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14616,24 +16533,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "SSCAN": {
@@ -14647,6 +16546,35 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "cursor",
+        "type": "integer"
+      },
+      {
+        "token": "MATCH",
+        "name": "pattern",
+        "type": "pattern",
+        "optional": true
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14666,39 +16594,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "cursor",
-        "type": "integer",
-        "display_text": "cursor"
-      },
-      {
-        "name": "pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "token": "MATCH",
-        "optional": true
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "SSUBSCRIBE": {
@@ -14711,6 +16606,20 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "shardchannel",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "pubsub",
+      "noscript",
+      "loading",
+      "stale",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14729,20 +16638,6 @@
         },
         "not_key": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "shardchannel",
-        "type": "string",
-        "display_text": "shardchannel",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "pubsub",
-      "noscript",
-      "loading",
-      "stale"
     ]
   },
   "STRLEN": {
@@ -14756,6 +16651,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14774,18 +16680,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "SUBSCRIBE": {
@@ -14802,7 +16696,6 @@
       {
         "name": "channel",
         "type": "string",
-        "display_text": "channel",
         "multiple": true
       }
     ],
@@ -14810,22 +16703,41 @@
       "pubsub",
       "noscript",
       "loading",
-      "stale"
-    ]
+      "stale",
+      "sentinel",
+      "denyoom"
+    ],
+    "history": []
   },
   "SUBSTR": {
     "summary": "Returns a substring from a string value.",
     "since": "1.0.0",
     "group": "string",
     "complexity": "O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.",
-    "deprecated_since": "2.0.0",
-    "replaced_by": "`GETRANGE`",
     "acl_categories": [
       "@read",
       "@string",
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "end",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14846,27 +16758,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "integer",
-        "display_text": "start"
-      },
-      {
-        "name": "end",
-        "type": "integer",
-        "display_text": "end"
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "2.0.0",
+    "replaced_by": "`GETRANGE`",
     "doc_flags": [
       "deprecated"
     ]
@@ -14882,6 +16775,20 @@
       "@slow"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output_order"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14901,21 +16808,65 @@
         "RO": true,
         "access": true
       }
+    ]
+  },
+  "SUNIONCARD": {
+    "summary": "Returns the number of members of the union of multiple sets.",
+    "since": "8.10.0",
+    "group": "set",
+    "complexity": "O(N) where N is the total number of elements in all given sets.",
+    "acl_categories": [
+      "@read",
+      "@set",
+      "@slow"
     ],
+    "arity": -3,
     "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0,
         "multiple": true
+      },
+      {
+        "name": "approx",
+        "token": "APPROX",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "integer",
+        "optional": true
       }
     ],
     "command_flags": [
       "readonly"
     ],
-    "hints": [
-      "nondeterministic_output_order"
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "keynum",
+          "spec": {
+            "keynumidx": 0,
+            "firstkey": 1,
+            "keystep": 1
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "SUNIONSTORE": {
@@ -14929,6 +16880,23 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -14966,25 +16934,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "SUNSUBSCRIBE": {
@@ -14997,6 +16946,20 @@
       "@slow"
     ],
     "arity": -1,
+    "arguments": [
+      {
+        "name": "shardchannel",
+        "type": "string",
+        "optional": true,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "pubsub",
+      "noscript",
+      "loading",
+      "stale"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15015,21 +16978,6 @@
         },
         "not_key": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "shardchannel",
-        "type": "string",
-        "display_text": "shardchannel",
-        "optional": true,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "pubsub",
-      "noscript",
-      "loading",
-      "stale"
     ]
   },
   "SWAPDB": {
@@ -15047,13 +16995,11 @@
     "arguments": [
       {
         "name": "index1",
-        "type": "integer",
-        "display_text": "index1"
+        "type": "integer"
       },
       {
         "name": "index2",
-        "type": "integer",
-        "display_text": "index2"
+        "type": "integer"
       }
     ],
     "command_flags": [
@@ -15072,10 +17018,10 @@
     ],
     "arity": 1,
     "command_flags": [
-      "admin",
-      "noscript",
       "no_async_loading",
-      "no_multi"
+      "admin",
+      "no_multi",
+      "noscript"
     ]
   },
   "TIME": {
@@ -15107,6 +17053,22 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "request_policy:multi_shard",
+      "response_policy:agg_sum"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15125,23 +17087,50 @@
         },
         "RO": true
       }
+    ]
+  },
+  "TRIMSLOTS": {
+    "summary": "Trim the keys that belong to specified slots.",
+    "since": "8.4.0",
+    "group": "server",
+    "complexity": "O(N) where N is the total number of keys in all databases",
+    "acl_categories": [
+      "@keyspace",
+      "@write",
+      "@slow",
+      "@dangerous"
     ],
+    "arity": -5,
     "arguments": [
       {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
+        "name": "ranges",
+        "token": "RANGES",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numranges",
+            "type": "integer"
+          },
+          {
+            "name": "slots",
+            "type": "block",
+            "multiple": true,
+            "arguments": [
+              {
+                "name": "startslot",
+                "type": "integer"
+              },
+              {
+                "name": "endslot",
+                "type": "integer"
+              }
+            ]
+          }
+        ]
       }
     ],
     "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "request_policy:multi_shard",
-      "response_policy:agg_sum"
+      "write"
     ]
   },
   "TTL": {
@@ -15149,18 +17138,32 @@
     "since": "1.0.0",
     "group": "generic",
     "complexity": "O(1)",
-    "history": [
-      [
-        "2.8.0",
-        "Added the -2 reply."
-      ]
-    ],
     "acl_categories": [
       "@keyspace",
       "@read",
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "2.8.0",
+        "Added the -2 reply."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15180,21 +17183,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "TYPE": {
@@ -15208,6 +17196,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15226,18 +17225,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "UNLINK": {
@@ -15251,6 +17238,22 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "hints": [
+      "request_policy:multi_shard",
+      "response_policy:agg_sum"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15270,23 +17273,6 @@
         "RM": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
-    ],
-    "hints": [
-      "request_policy:multi_shard",
-      "response_policy:agg_sum"
     ]
   },
   "UNSUBSCRIBE": {
@@ -15303,7 +17289,6 @@
       {
         "name": "channel",
         "type": "string",
-        "display_text": "channel",
         "optional": true,
         "multiple": true
       }
@@ -15312,7 +17297,8 @@
       "pubsub",
       "noscript",
       "loading",
-      "stale"
+      "stale",
+      "sentinel"
     ]
   },
   "UNWATCH": {
@@ -15334,370 +17320,446 @@
     ]
   },
   "VADD": {
+    "summary": "Add one or more elements to a vector set, or update its vector if it already exists",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(log(N)) for each element added, where N is the number of elements in the vector set.",
+    "arity": -5,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "token": "REDUCE",
+        "name": "reduce",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "dim",
+            "type": "integer"
           }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
+        ]
+      },
+      {
+        "name": "format",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "fp32",
+            "type": "pure-token",
+            "token": "FP32"
+          },
+          {
+            "name": "values",
+            "type": "pure-token",
+            "token": "VALUES"
           }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        ]
+      },
+      {
+        "name": "vector",
+        "type": "string"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      },
+      {
+        "token": "CAS",
+        "name": "cas",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "quant_type",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "noquant",
+            "type": "pure-token",
+            "token": "NOQUANT"
+          },
+          {
+            "name": "bin",
+            "type": "pure-token",
+            "token": "BIN"
+          },
+          {
+            "name": "q8",
+            "type": "pure-token",
+            "token": "Q8"
+          }
+        ]
+      },
+      {
+        "token": "EF",
+        "name": "build-exploration-factor",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "SETATTR",
+        "name": "attributes",
+        "type": "string",
+        "optional": true
+      },
+      {
+        "token": "M",
+        "name": "numlinks",
+        "type": "integer",
+        "optional": true
       }
     ],
     "command_flags": [
       "write",
-      "denyoom",
-      "module"
+      "denyoom"
     ],
     "module": "vectorset"
   },
   "VCARD": {
+    "summary": "Return the number of elements in a vector set",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": 2,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
       }
     ],
     "command_flags": [
       "readonly",
-      "module",
       "fast"
     ],
     "module": "vectorset"
   },
   "VDIM": {
+    "summary": "Return the dimension of vectors in the vector set",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": 2,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
       }
     ],
     "command_flags": [
       "readonly",
-      "module",
       "fast"
     ],
     "module": "vectorset"
   },
   "VEMB": {
+    "summary": "Return the vector associated with an element",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": -3,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      },
+      {
+        "token": "RAW",
+        "name": "raw",
+        "type": "pure-token",
+        "optional": true
       }
     ],
     "command_flags": [
-      "readonly",
-      "module",
-      "fast"
+      "readonly"
     ],
     "module": "vectorset"
   },
   "VGETATTR": {
+    "summary": "Retrieve the JSON attributes of elements",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": 3,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
       }
     ],
     "command_flags": [
-      "readonly",
-      "module",
-      "fast"
+      "readonly"
     ],
     "module": "vectorset"
   },
   "VINFO": {
+    "summary": "Return information about a vector set",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": 2,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
       }
     ],
     "command_flags": [
       "readonly",
-      "module",
       "fast"
     ],
     "module": "vectorset"
   },
   "VISMEMBER": {
+    "summary": "Check if an element exists in a vector set",
+    "since": "8.2.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": 3,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
       }
     ],
     "command_flags": [
-      "readonly",
-      "module"
+      "readonly"
     ],
     "module": "vectorset"
   },
   "VLINKS": {
+    "summary": "Return the neighbors of an element at each layer in the HNSW graph",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": -3,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      },
+      {
+        "token": "WITHSCORES",
+        "name": "withscores",
+        "type": "pure-token",
+        "optional": true
       }
     ],
     "command_flags": [
-      "readonly",
-      "module",
-      "fast"
+      "readonly"
     ],
     "module": "vectorset"
   },
   "VRANDMEMBER": {
+    "summary": "Return one or multiple random members from a vector set",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(N) where N is the absolute value of the count argument.",
+    "arity": -2,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true
       }
     ],
     "command_flags": [
-      "readonly",
-      "module"
+      "readonly"
+    ],
+    "module": "vectorset"
+  },
+  "VRANGE": {
+    "summary": "Return elements in a lexicographical range",
+    "since": "8.4.0",
+    "group": "module",
+    "complexity": "O(log(K)+M) where K is the number of elements in the start prefix, and M is the number of elements returned. In practical terms, the command is just O(M)",
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "start",
+        "type": "string"
+      },
+      {
+        "name": "end",
+        "type": "string"
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
     ],
     "module": "vectorset"
   },
   "VREM": {
+    "summary": "Remove an element from a vector set",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(log(N)) for each element removed, where N is the number of elements in the vector set.",
+    "arity": 3,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
       }
     ],
     "command_flags": [
-      "write",
-      "module"
+      "write"
     ],
     "module": "vectorset"
   },
   "VSETATTR": {
+    "summary": "Associate or remove the JSON attributes of elements",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(1)",
+    "arity": 4,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      },
+      {
+        "name": "json",
+        "type": "string"
       }
     ],
     "command_flags": [
-      "write",
-      "module",
-      "fast"
+      "write"
     ],
     "module": "vectorset"
   },
   "VSIM": {
+    "summary": "Return elements by vector similarity",
+    "since": "8.0.0",
     "group": "module",
-    "arity": -1,
-    "key_specs": [
+    "complexity": "O(log(N)) where N is the number of elements in the vector set.",
+    "arity": -4,
+    "arguments": [
       {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "format",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "ele",
+            "type": "pure-token",
+            "token": "ELE"
+          },
+          {
+            "name": "fp32",
+            "type": "pure-token",
+            "token": "FP32"
+          },
+          {
+            "name": "values",
+            "type": "pure-token",
+            "token": "VALUES"
           }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RW": true,
-        "access": true,
-        "update": true
+        ]
+      },
+      {
+        "name": "vector_or_element",
+        "type": "string"
+      },
+      {
+        "token": "WITHSCORES",
+        "name": "withscores",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "WITHATTRIBS",
+        "name": "withattribs",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "EPSILON",
+        "name": "max_distance",
+        "type": "double",
+        "optional": true
+      },
+      {
+        "token": "EF",
+        "name": "search-exploration-factor",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "FILTER",
+        "name": "expression",
+        "type": "string",
+        "optional": true
+      },
+      {
+        "token": "FILTER-EF",
+        "name": "max-filtering-effort",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "TRUTH",
+        "name": "truth",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "NOTHREAD",
+        "name": "nothread",
+        "type": "pure-token",
+        "optional": true
       }
     ],
     "command_flags": [
-      "readonly",
-      "module"
+      "readonly"
     ],
     "module": "vectorset"
   },
@@ -15715,13 +17777,11 @@
     "arguments": [
       {
         "name": "numreplicas",
-        "type": "integer",
-        "display_text": "numreplicas"
+        "type": "integer"
       },
       {
         "name": "timeout",
-        "type": "integer",
-        "display_text": "timeout"
+        "type": "integer"
       }
     ],
     "command_flags": [
@@ -15746,18 +17806,15 @@
     "arguments": [
       {
         "name": "numlocal",
-        "type": "integer",
-        "display_text": "numlocal"
+        "type": "integer"
       },
       {
         "name": "numreplicas",
-        "type": "integer",
-        "display_text": "numreplicas"
+        "type": "integer"
       },
       {
         "name": "timeout",
-        "type": "integer",
-        "display_text": "timeout"
+        "type": "integer"
       }
     ],
     "command_flags": [
@@ -15778,6 +17835,21 @@
       "@transaction"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "noscript",
+      "loading",
+      "stale",
+      "fast",
+      "allow_busy"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15796,22 +17868,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "noscript",
-      "loading",
-      "stale",
-      "fast",
-      "allow_busy"
     ]
   },
   "XACK": {
@@ -15825,6 +17881,26 @@
       "@fast"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ID",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -15844,29 +17920,92 @@
         "RW": true,
         "update": true
       }
+    ]
+  },
+  "XACKDEL": {
+    "summary": "Acknowledges and deletes one or multiple messages for a stream consumer group.",
+    "since": "8.2.0",
+    "group": "stream",
+    "complexity": "O(1) for each message ID processed.",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
     ],
+    "arity": -6,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "group",
-        "type": "string",
-        "display_text": "group"
+        "type": "string"
       },
       {
-        "name": "id",
-        "type": "string",
-        "display_text": "id",
-        "multiple": true
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "keepref",
+            "type": "pure-token",
+            "token": "KEEPREF"
+          },
+          {
+            "name": "delref",
+            "type": "pure-token",
+            "token": "DELREF"
+          },
+          {
+            "name": "acked",
+            "type": "pure-token",
+            "token": "ACKED"
+          }
+        ]
+      },
+      {
+        "name": "ids",
+        "token": "IDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numids",
+            "type": "integer"
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "multiple": true
+          }
+        ]
       }
     ],
     "command_flags": [
       "write",
       "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true,
+        "delete": true
+      }
     ]
   },
   "XADD": {
@@ -15874,6 +18013,169 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(1) when adding a new entry, O(N) when trimming where N being the number of entries evicted.",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
+    ],
+    "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "token": "NOMKSTREAM",
+        "name": "nomkstream",
+        "type": "pure-token",
+        "optional": true,
+        "since": "6.2.0"
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "keepref",
+            "type": "pure-token",
+            "token": "KEEPREF"
+          },
+          {
+            "name": "delref",
+            "type": "pure-token",
+            "token": "DELREF"
+          },
+          {
+            "name": "acked",
+            "type": "pure-token",
+            "token": "ACKED"
+          }
+        ]
+      },
+      {
+        "name": "idmp",
+        "type": "oneof",
+        "optional": true,
+        "since": "8.6.0",
+        "arguments": [
+          {
+            "token": "IDMPAUTO",
+            "type": "string",
+            "name": "pid",
+            "display_text": "producer-id"
+          },
+          {
+            "token": "IDMP",
+            "type": "block",
+            "name": "idmp",
+            "arguments": [
+              {
+                "name": "pid",
+                "type": "string",
+                "display_text": "producer-id"
+              },
+              {
+                "name": "iid",
+                "type": "string",
+                "display_text": "idempotent-id"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "trim",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "strategy",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "maxlen",
+                "type": "pure-token",
+                "token": "MAXLEN"
+              },
+              {
+                "name": "minid",
+                "type": "pure-token",
+                "token": "MINID",
+                "since": "6.2.0"
+              }
+            ]
+          },
+          {
+            "name": "operator",
+            "type": "oneof",
+            "optional": true,
+            "arguments": [
+              {
+                "name": "equal",
+                "type": "pure-token",
+                "token": "="
+              },
+              {
+                "name": "approximately",
+                "type": "pure-token",
+                "token": "~"
+              }
+            ]
+          },
+          {
+            "name": "threshold",
+            "type": "string"
+          },
+          {
+            "token": "LIMIT",
+            "name": "count",
+            "type": "integer",
+            "optional": true,
+            "since": "6.2.0"
+          }
+        ]
+      },
+      {
+        "name": "id-selector",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "auto-id",
+            "type": "pure-token",
+            "token": "*"
+          },
+          {
+            "name": "id",
+            "type": "string"
+          }
+        ]
+      },
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "field",
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "history": [
       [
         "6.2.0",
@@ -15882,14 +18184,12 @@
       [
         "7.0.0",
         "Added support for the `<ms>-*` explicit ID form."
+      ],
+      [
+        "8.2.0",
+        "Added the `KEEPREF`, `DELREF` and `ACKED` options."
       ]
     ],
-    "acl_categories": [
-      "@write",
-      "@stream",
-      "@fast"
-    ],
-    "arity": -5,
     "key_specs": [
       {
         "notes": "UPDATE instead of INSERT because of the optional trimming feature",
@@ -15910,122 +18210,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "nomkstream",
-        "type": "pure-token",
-        "display_text": "nomkstream",
-        "token": "NOMKSTREAM",
-        "since": "6.2.0",
-        "optional": true
-      },
-      {
-        "name": "trim",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "strategy",
-            "type": "oneof",
-            "arguments": [
-              {
-                "name": "maxlen",
-                "type": "pure-token",
-                "display_text": "maxlen",
-                "token": "MAXLEN"
-              },
-              {
-                "name": "minid",
-                "type": "pure-token",
-                "display_text": "minid",
-                "token": "MINID",
-                "since": "6.2.0"
-              }
-            ]
-          },
-          {
-            "name": "operator",
-            "type": "oneof",
-            "optional": true,
-            "arguments": [
-              {
-                "name": "equal",
-                "type": "pure-token",
-                "display_text": "equal",
-                "token": "="
-              },
-              {
-                "name": "approximately",
-                "type": "pure-token",
-                "display_text": "approximately",
-                "token": "~"
-              }
-            ]
-          },
-          {
-            "name": "threshold",
-            "type": "string",
-            "display_text": "threshold"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "LIMIT",
-            "since": "6.2.0",
-            "optional": true
-          }
-        ]
-      },
-      {
-        "name": "id-selector",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "auto-id",
-            "type": "pure-token",
-            "display_text": "auto-id",
-            "token": "*"
-          },
-          {
-            "name": "id",
-            "type": "string",
-            "display_text": "id"
-          }
-        ]
-      },
-      {
-        "name": "data",
-        "type": "block",
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "field",
-            "type": "string",
-            "display_text": "field"
-          },
-          {
-            "name": "value",
-            "type": "string",
-            "display_text": "value"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "XAUTOCLAIM": {
@@ -16033,18 +18217,60 @@
     "since": "6.2.0",
     "group": "stream",
     "complexity": "O(1) if COUNT is small.",
-    "history": [
-      [
-        "7.0.0",
-        "Added an element to the reply array, containing deleted entries the command cleared from the PEL"
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@stream",
       "@fast"
     ],
     "arity": -6,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "consumer",
+        "type": "string"
+      },
+      {
+        "name": "min-idle-time",
+        "type": "string"
+      },
+      {
+        "name": "start",
+        "type": "string"
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "name": "justid",
+        "token": "JUSTID",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added an element to the reply array, containing deleted entries the command cleared from the PEL"
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16064,46 +18290,35 @@
         "RW": true,
         "delete": true
       }
+    ]
+  },
+  "XCFGSET": {
+    "summary": "Sets the IDMP configuration parameters for a stream.",
+    "since": "8.6.0",
+    "group": "stream",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
     ],
+    "arity": -2,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
-        "name": "group",
-        "type": "string",
-        "display_text": "group"
-      },
-      {
-        "name": "consumer",
-        "type": "string",
-        "display_text": "consumer"
-      },
-      {
-        "name": "min-idle-time",
-        "type": "string",
-        "display_text": "min-idle-time"
-      },
-      {
-        "name": "start",
-        "type": "string",
-        "display_text": "start"
-      },
-      {
-        "name": "count",
+        "name": "idmp-duration",
         "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
+        "token": "IDMP-DURATION",
         "optional": true
       },
       {
-        "name": "justid",
-        "type": "pure-token",
-        "display_text": "justid",
-        "token": "JUSTID",
+        "name": "idmp-maxsize",
+        "type": "integer",
+        "token": "IDMP-MAXSIZE",
         "optional": true
       }
     ],
@@ -16111,21 +18326,6 @@
       "write",
       "fast"
     ],
-    "hints": [
-      "nondeterministic_output"
-    ]
-  },
-  "XCLAIM": {
-    "summary": "Changes, or acquires, ownership of a message in a consumer group, as if the message was delivered a consumer group member.",
-    "since": "5.0.0",
-    "group": "stream",
-    "complexity": "O(log N) with N being the number of messages in the PEL of the consumer group.",
-    "acl_categories": [
-      "@write",
-      "@stream",
-      "@fast"
-    ],
-    "arity": -6,
     "key_specs": [
       {
         "begin_search": {
@@ -16145,75 +18345,76 @@
         "RW": true,
         "update": true
       }
+    ]
+  },
+  "XCLAIM": {
+    "summary": "Changes, or acquires, ownership of a message in a consumer group, as if the message was delivered a consumer group member.",
+    "since": "5.0.0",
+    "group": "stream",
+    "complexity": "O(log N) with N being the number of messages in the PEL of the consumer group.",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
     ],
+    "arity": -6,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "group",
-        "type": "string",
-        "display_text": "group"
+        "type": "string"
       },
       {
         "name": "consumer",
-        "type": "string",
-        "display_text": "consumer"
+        "type": "string"
       },
       {
         "name": "min-idle-time",
-        "type": "string",
-        "display_text": "min-idle-time"
+        "type": "string"
       },
       {
-        "name": "id",
+        "name": "ID",
         "type": "string",
-        "display_text": "id",
         "multiple": true
       },
       {
+        "token": "IDLE",
         "name": "ms",
         "type": "integer",
-        "display_text": "ms",
-        "token": "IDLE",
         "optional": true
       },
       {
+        "token": "TIME",
         "name": "unix-time-milliseconds",
         "type": "unix-time",
-        "display_text": "unix-time-milliseconds",
-        "token": "TIME",
         "optional": true
       },
       {
+        "token": "RETRYCOUNT",
         "name": "count",
         "type": "integer",
-        "display_text": "count",
-        "token": "RETRYCOUNT",
         "optional": true
       },
       {
         "name": "force",
-        "type": "pure-token",
-        "display_text": "force",
         "token": "FORCE",
+        "type": "pure-token",
         "optional": true
       },
       {
         "name": "justid",
-        "type": "pure-token",
-        "display_text": "justid",
         "token": "JUSTID",
+        "type": "pure-token",
         "optional": true
       },
       {
         "name": "lastid",
-        "type": "string",
-        "display_text": "lastid",
         "token": "LASTID",
+        "type": "string",
         "optional": true
       }
     ],
@@ -16223,6 +18424,26 @@
     ],
     "hints": [
       "nondeterministic_output"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
     ]
   },
   "XDEL": {
@@ -16236,6 +18457,22 @@
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "ID",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16255,24 +18492,87 @@
         "RW": true,
         "delete": true
       }
+    ]
+  },
+  "XDELEX": {
+    "summary": "Deletes one or multiple entries from the stream.",
+    "since": "8.2.0",
+    "group": "stream",
+    "complexity": "O(1) for each single item to delete in the stream, regardless of the stream size.",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
     ],
+    "arity": -5,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
-        "name": "id",
-        "type": "string",
-        "display_text": "id",
-        "multiple": true
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "keepref",
+            "type": "pure-token",
+            "token": "KEEPREF"
+          },
+          {
+            "name": "delref",
+            "type": "pure-token",
+            "token": "DELREF"
+          },
+          {
+            "name": "acked",
+            "type": "pure-token",
+            "token": "ACKED"
+          }
+        ]
+      },
+      {
+        "name": "ids",
+        "token": "IDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numids",
+            "type": "integer"
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "multiple": true
+          }
+        ]
       }
     ],
     "command_flags": [
       "write",
       "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "delete": true
+      }
     ]
   },
   "XGROUP": {
@@ -16290,18 +18590,61 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added the `entries_read` named argument."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@stream",
       "@slow"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "id-selector",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "new-id",
+            "type": "pure-token",
+            "token": "$"
+          }
+        ]
+      },
+      {
+        "token": "MKSTREAM",
+        "name": "mkstream",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "entriesread",
+        "display": "entries-read",
+        "token": "ENTRIESREAD",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the `entries_read` named argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16321,54 +18664,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "group",
-        "type": "string",
-        "display_text": "group"
-      },
-      {
-        "name": "id-selector",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "id",
-            "type": "string",
-            "display_text": "id"
-          },
-          {
-            "name": "new-id",
-            "type": "pure-token",
-            "display_text": "new-id",
-            "token": "$"
-          }
-        ]
-      },
-      {
-        "name": "mkstream",
-        "type": "pure-token",
-        "display_text": "mkstream",
-        "token": "MKSTREAM",
-        "optional": true
-      },
-      {
-        "name": "entriesread",
-        "type": "integer",
-        "display_text": "entries-read",
-        "token": "ENTRIESREAD",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "XGROUP CREATECONSUMER": {
@@ -16382,6 +18677,25 @@
       "@slow"
     ],
     "arity": 5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "consumer",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16401,28 +18715,6 @@
         "RW": true,
         "insert": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "group",
-        "type": "string",
-        "display_text": "group"
-      },
-      {
-        "name": "consumer",
-        "type": "string",
-        "display_text": "consumer"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "XGROUP DELCONSUMER": {
@@ -16436,6 +18728,24 @@
       "@slow"
     ],
     "arity": 5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "consumer",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16455,27 +18765,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "group",
-        "type": "string",
-        "display_text": "group"
-      },
-      {
-        "name": "consumer",
-        "type": "string",
-        "display_text": "consumer"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "XGROUP DESTROY": {
@@ -16489,6 +18778,20 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16508,22 +18811,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "group",
-        "type": "string",
-        "display_text": "group"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "XGROUP HELP": {
@@ -16546,18 +18833,54 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added the optional `entries_read` argument."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@stream",
       "@slow"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "id-selector",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "new-id",
+            "type": "pure-token",
+            "token": "$"
+          }
+        ]
+      },
+      {
+        "name": "entriesread",
+        "display": "entries-read",
+        "token": "ENTRIESREAD",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the optional `entries_read` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16577,46 +18900,62 @@
         "RW": true,
         "update": true
       }
+    ]
+  },
+  "XIDMPRECORD": {
+    "summary": "An internal command for setting IDMP metadata on an existing stream message.",
+    "since": "8.6.2",
+    "group": "stream",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
     ],
+    "arity": 5,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
-        "name": "group",
-        "type": "string",
-        "display_text": "group"
+        "name": "pid",
+        "type": "string"
       },
       {
-        "name": "id-selector",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "id",
-            "type": "string",
-            "display_text": "id"
-          },
-          {
-            "name": "new-id",
-            "type": "pure-token",
-            "display_text": "new-id",
-            "token": "$"
-          }
-        ]
+        "name": "iid",
+        "type": "string"
       },
       {
-        "name": "entriesread",
-        "type": "integer",
-        "display_text": "entries-read",
-        "token": "ENTRIESREAD",
-        "optional": true
+        "name": "stream-id",
+        "type": "string"
       }
     ],
     "command_flags": [
-      "write"
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RW": true,
+        "update": true
+      }
     ]
   },
   "XINFO": {
@@ -16634,49 +18973,21 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.2.0",
-        "Added the `inactive` field, and changed the meaning of `idle`."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@stream",
       "@slow"
     ],
     "arity": 4,
-    "key_specs": [
-      {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 2
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RO": true,
-        "access": true
-      }
-    ],
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "group",
-        "type": "string",
-        "display_text": "group"
+        "type": "string"
       }
     ],
     "command_flags": [
@@ -16684,25 +18995,13 @@
     ],
     "hints": [
       "nondeterministic_output"
-    ]
-  },
-  "XINFO GROUPS": {
-    "summary": "Returns a list of the consumer groups of a stream.",
-    "since": "5.0.0",
-    "group": "stream",
-    "complexity": "O(1)",
+    ],
     "history": [
       [
-        "7.0.0",
-        "Added the `entries-read` and `lag` fields"
+        "7.2.0",
+        "Added the `inactive` field, and changed the meaning of `idle`."
       ]
     ],
-    "acl_categories": [
-      "@read",
-      "@stream",
-      "@slow"
-    ],
-    "arity": 3,
     "key_specs": [
       {
         "begin_search": {
@@ -16722,17 +19021,54 @@
         "RO": true,
         "access": true
       }
+    ]
+  },
+  "XINFO GROUPS": {
+    "summary": "Returns a list of the consumer groups of a stream.",
+    "since": "5.0.0",
+    "group": "stream",
+    "complexity": "O(1)",
+    "acl_categories": [
+      "@read",
+      "@stream",
+      "@slow"
     ],
+    "arity": 3,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       }
     ],
     "command_flags": [
       "readonly"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the `entries-read` and `lag` fields"
+      ]
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 2
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "XINFO HELP": {
@@ -16755,6 +19091,40 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(1)",
+    "acl_categories": [
+      "@read",
+      "@stream",
+      "@slow"
+    ],
+    "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "full-block",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "full",
+            "token": "FULL",
+            "type": "pure-token"
+          },
+          {
+            "token": "COUNT",
+            "name": "count",
+            "type": "integer",
+            "optional": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "history": [
       [
         "6.0.0",
@@ -16767,14 +19137,16 @@
       [
         "7.2.0",
         "Added the `active-time` field, and changed the meaning of `seen-time`."
+      ],
+      [
+        "8.6.0",
+        "Added the `idmp-duration`, `idmp-maxsize`, `pids-tracked`, `iids-tracked`, `iids-added` and `iids-duplicates` fields for IDMP tracking."
+      ],
+      [
+        "8.8.0",
+        "Added the `nacked-count` field to consumer groups in `FULL` output."
       ]
     ],
-    "acl_categories": [
-      "@read",
-      "@stream",
-      "@slow"
-    ],
-    "arity": -3,
     "key_specs": [
       {
         "begin_search": {
@@ -16794,37 +19166,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "full-block",
-        "type": "block",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "full",
-            "type": "pure-token",
-            "display_text": "full",
-            "token": "FULL"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "COUNT",
-            "optional": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "XLEN": {
@@ -16838,6 +19179,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -16856,37 +19208,83 @@
         },
         "RO": true
       }
+    ]
+  },
+  "XNACK": {
+    "summary": "Releases claimed messages back to the group's PEL without acknowledging them, making them available for re-delivery.",
+    "since": "8.8.0",
+    "group": "stream",
+    "complexity": "O(1) for each message ID processed.",
+    "acl_categories": [
+      "@write",
+      "@stream",
+      "@fast"
     ],
+    "arity": -7,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "silent",
+            "type": "pure-token",
+            "token": "SILENT"
+          },
+          {
+            "name": "fail",
+            "type": "pure-token",
+            "token": "FAIL"
+          },
+          {
+            "name": "fatal",
+            "type": "pure-token",
+            "token": "FATAL"
+          }
+        ]
+      },
+      {
+        "name": "ids",
+        "token": "IDS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "numids",
+            "type": "integer"
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      },
+      {
+        "token": "RETRYCOUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "name": "force",
+        "token": "FORCE",
+        "type": "pure-token",
+        "optional": true
       }
     ],
     "command_flags": [
-      "readonly",
+      "write",
       "fast"
-    ]
-  },
-  "XPENDING": {
-    "summary": "Returns the information and entries from a stream consumer group's pending entries list.",
-    "since": "5.0.0",
-    "group": "stream",
-    "complexity": "O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1). O(M), where M is the total number of entries scanned when used with the IDLE filter. When the command returns just the summary and the list of consumers is small, it runs in O(1) time; otherwise, an additional O(N) time for iterating every consumer.",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `IDLE` option and exclusive range intervals."
-      ]
     ],
-    "acl_categories": [
-      "@read",
-      "@stream",
-      "@slow"
-    ],
-    "arity": -3,
     "key_specs": [
       {
         "begin_search": {
@@ -16903,21 +19301,31 @@
             "limit": 0
           }
         },
-        "RO": true,
-        "access": true
+        "RW": true,
+        "update": true
       }
+    ]
+  },
+  "XPENDING": {
+    "summary": "Returns the information and entries from a stream consumer group's pending entries list.",
+    "since": "5.0.0",
+    "group": "stream",
+    "complexity": "O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1). O(M), where M is the total number of entries scanned when used with the IDLE filter. When the command returns just the summary and the list of consumers is small, it runs in O(1) time; otherwise, an additional O(N) time for iterating every consumer.",
+    "acl_categories": [
+      "@read",
+      "@stream",
+      "@slow"
     ],
+    "arity": -3,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "group",
-        "type": "string",
-        "display_text": "group"
+        "type": "string"
       },
       {
         "name": "filters",
@@ -16925,32 +19333,27 @@
         "optional": true,
         "arguments": [
           {
+            "token": "IDLE",
             "name": "min-idle-time",
             "type": "integer",
-            "display_text": "min-idle-time",
-            "token": "IDLE",
-            "since": "6.2.0",
-            "optional": true
+            "optional": true,
+            "since": "6.2.0"
           },
           {
             "name": "start",
-            "type": "string",
-            "display_text": "start"
+            "type": "string"
           },
           {
             "name": "end",
-            "type": "string",
-            "display_text": "end"
+            "type": "string"
           },
           {
             "name": "count",
-            "type": "integer",
-            "display_text": "count"
+            "type": "integer"
           },
           {
             "name": "consumer",
             "type": "string",
-            "display_text": "consumer",
             "optional": true
           }
         ]
@@ -16961,25 +19364,13 @@
     ],
     "hints": [
       "nondeterministic_output"
-    ]
-  },
-  "XRANGE": {
-    "summary": "Returns the messages from a stream within a range of IDs.",
-    "since": "5.0.0",
-    "group": "stream",
-    "complexity": "O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+    ],
     "history": [
       [
         "6.2.0",
-        "Added exclusive ranges."
+        "Added the `IDLE` option and exclusive range intervals."
       ]
     ],
-    "acl_categories": [
-      "@read",
-      "@stream",
-      "@slow"
-    ],
-    "arity": -4,
     "key_specs": [
       {
         "begin_search": {
@@ -16999,34 +19390,68 @@
         "RO": true,
         "access": true
       }
+    ]
+  },
+  "XRANGE": {
+    "summary": "Returns the messages from a stream within a range of IDs.",
+    "since": "5.0.0",
+    "group": "stream",
+    "complexity": "O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+    "acl_categories": [
+      "@read",
+      "@stream",
+      "@slow"
     ],
+    "arity": -4,
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
         "name": "start",
-        "type": "string",
-        "display_text": "start"
+        "type": "string"
       },
       {
         "name": "end",
-        "type": "string",
-        "display_text": "end"
+        "type": "string"
       },
       {
+        "token": "COUNT",
         "name": "count",
         "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
         "optional": true
       }
     ],
     "command_flags": [
       "readonly"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added exclusive ranges."
+      ]
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "XREAD": {
@@ -17040,8 +19465,65 @@
       "@blocking"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "MAXCOUNT",
+        "name": "maxcount",
+        "type": "integer",
+        "optional": true,
+        "since": "8.10.0"
+      },
+      {
+        "token": "MAXSIZE",
+        "name": "maxsize",
+        "type": "integer",
+        "optional": true,
+        "since": "8.10.0"
+      },
+      {
+        "token": "BLOCK",
+        "name": "milliseconds",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "name": "streams",
+        "token": "STREAMS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "key",
+            "type": "key",
+            "key_spec_index": 0,
+            "multiple": true
+          },
+          {
+            "name": "ID",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "blocking",
+      "readonly"
+    ],
+    "history": [
+      [
+        "8.10.0",
+        "Added the `MAXCOUNT` and `MAXSIZE` options."
+      ]
+    ],
     "key_specs": [
       {
+        "notes": "Incomplete because a stream key named STREAMS (or options before it) can shift the STREAMS keyword; fall back to xreadGetKeys",
         "begin_search": {
           "type": "keyword",
           "spec": {
@@ -17058,49 +19540,9 @@
           }
         },
         "RO": true,
-        "access": true
+        "access": true,
+        "incomplete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      },
-      {
-        "name": "milliseconds",
-        "type": "integer",
-        "display_text": "milliseconds",
-        "token": "BLOCK",
-        "optional": true
-      },
-      {
-        "name": "streams",
-        "type": "block",
-        "token": "STREAMS",
-        "arguments": [
-          {
-            "name": "key",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 0,
-            "multiple": true
-          },
-          {
-            "name": "id",
-            "type": "string",
-            "display_text": "id",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "blocking",
-      "movablekeys"
     ]
   },
   "XREADGROUP": {
@@ -17115,8 +19557,97 @@
       "@blocking"
     ],
     "arity": -7,
+    "arguments": [
+      {
+        "token": "GROUP",
+        "name": "group-block",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "group",
+            "type": "string"
+          },
+          {
+            "name": "consumer",
+            "type": "string"
+          }
+        ]
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "MAXCOUNT",
+        "name": "maxcount",
+        "type": "integer",
+        "optional": true,
+        "since": "8.10.0"
+      },
+      {
+        "token": "MAXSIZE",
+        "name": "maxsize",
+        "type": "integer",
+        "optional": true,
+        "since": "8.10.0"
+      },
+      {
+        "token": "BLOCK",
+        "name": "milliseconds",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "token": "CLAIM",
+        "name": "min-idle-time",
+        "type": "integer",
+        "optional": true,
+        "since": "8.4.0"
+      },
+      {
+        "name": "noack",
+        "token": "NOACK",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "name": "streams",
+        "token": "STREAMS",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "key",
+            "type": "key",
+            "key_spec_index": 0,
+            "multiple": true
+          },
+          {
+            "name": "ID",
+            "type": "string",
+            "multiple": true
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "blocking",
+      "write"
+    ],
+    "history": [
+      [
+        "8.4.0",
+        "Added the `CLAIM` option."
+      ],
+      [
+        "8.10.0",
+        "Added the `MAXCOUNT` and `MAXSIZE` options."
+      ]
+    ],
     "key_specs": [
       {
+        "notes": "Incomplete because a consumer/group named STREAMS (or options before GROUP) can shift the STREAMS keyword; fall back to xreadGetKeys",
         "begin_search": {
           "type": "keyword",
           "spec": {
@@ -17133,73 +19664,9 @@
           }
         },
         "RO": true,
-        "access": true
+        "access": true,
+        "incomplete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "group-block",
-        "type": "block",
-        "token": "GROUP",
-        "arguments": [
-          {
-            "name": "group",
-            "type": "string",
-            "display_text": "group"
-          },
-          {
-            "name": "consumer",
-            "type": "string",
-            "display_text": "consumer"
-          }
-        ]
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      },
-      {
-        "name": "milliseconds",
-        "type": "integer",
-        "display_text": "milliseconds",
-        "token": "BLOCK",
-        "optional": true
-      },
-      {
-        "name": "noack",
-        "type": "pure-token",
-        "display_text": "noack",
-        "token": "NOACK",
-        "optional": true
-      },
-      {
-        "name": "streams",
-        "type": "block",
-        "token": "STREAMS",
-        "arguments": [
-          {
-            "name": "key",
-            "type": "key",
-            "display_text": "key",
-            "key_spec_index": 0,
-            "multiple": true
-          },
-          {
-            "name": "id",
-            "type": "string",
-            "display_text": "id",
-            "multiple": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "blocking",
-      "movablekeys"
     ]
   },
   "XREVRANGE": {
@@ -17207,18 +19674,42 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
-    "history": [
-      [
-        "6.2.0",
-        "Added exclusive ranges."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@stream",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "end",
+        "type": "string"
+      },
+      {
+        "name": "start",
+        "type": "string"
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added exclusive ranges."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17238,34 +19729,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "end",
-        "type": "string",
-        "display_text": "end"
-      },
-      {
-        "name": "start",
-        "type": "string",
-        "display_text": "start"
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "XSETID": {
@@ -17273,18 +19736,48 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(1)",
-    "history": [
-      [
-        "7.0.0",
-        "Added the `entries_added` and `max_deleted_entry_id` arguments."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@stream",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "last-id",
+        "type": "string"
+      },
+      {
+        "name": "entries-added",
+        "token": "ENTRIESADDED",
+        "type": "integer",
+        "optional": true,
+        "since": "7.0.0"
+      },
+      {
+        "name": "max-deleted-id",
+        "token": "MAXDELETEDID",
+        "type": "string",
+        "optional": true,
+        "since": "7.0.0"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.0.0",
+        "Added the `entries_added` and `max_deleted_entry_id` arguments."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17304,40 +19797,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "last-id",
-        "type": "string",
-        "display_text": "last-id"
-      },
-      {
-        "name": "entries-added",
-        "type": "integer",
-        "display_text": "entries-added",
-        "token": "ENTRIESADDED",
-        "since": "7.0.0",
-        "optional": true
-      },
-      {
-        "name": "max-deleted-id",
-        "type": "string",
-        "display_text": "max-deleted-id",
-        "token": "MAXDELETEDID",
-        "since": "7.0.0",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "XTRIM": {
@@ -17345,18 +19804,108 @@
     "since": "5.0.0",
     "group": "stream",
     "complexity": "O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `MINID` trimming strategy and the `LIMIT` option."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@stream",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "trim",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "strategy",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "maxlen",
+                "type": "pure-token",
+                "token": "MAXLEN"
+              },
+              {
+                "name": "minid",
+                "type": "pure-token",
+                "token": "MINID",
+                "since": "6.2.0"
+              }
+            ]
+          },
+          {
+            "name": "operator",
+            "type": "oneof",
+            "optional": true,
+            "arguments": [
+              {
+                "name": "equal",
+                "type": "pure-token",
+                "token": "="
+              },
+              {
+                "name": "approximately",
+                "type": "pure-token",
+                "token": "~"
+              }
+            ]
+          },
+          {
+            "name": "threshold",
+            "type": "string"
+          },
+          {
+            "token": "LIMIT",
+            "name": "count",
+            "type": "integer",
+            "optional": true,
+            "since": "6.2.0"
+          },
+          {
+            "name": "condition",
+            "type": "oneof",
+            "optional": true,
+            "arguments": [
+              {
+                "name": "keepref",
+                "type": "pure-token",
+                "token": "KEEPREF"
+              },
+              {
+                "name": "delref",
+                "type": "pure-token",
+                "token": "DELREF"
+              },
+              {
+                "name": "acked",
+                "type": "pure-token",
+                "token": "ACKED"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added the `MINID` trimming strategy and the `LIMIT` option."
+      ],
+      [
+        "8.2.0",
+        "Added the `KEEPREF`, `DELREF` and `ACKED` options."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17376,77 +19925,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "trim",
-        "type": "block",
-        "arguments": [
-          {
-            "name": "strategy",
-            "type": "oneof",
-            "arguments": [
-              {
-                "name": "maxlen",
-                "type": "pure-token",
-                "display_text": "maxlen",
-                "token": "MAXLEN"
-              },
-              {
-                "name": "minid",
-                "type": "pure-token",
-                "display_text": "minid",
-                "token": "MINID",
-                "since": "6.2.0"
-              }
-            ]
-          },
-          {
-            "name": "operator",
-            "type": "oneof",
-            "optional": true,
-            "arguments": [
-              {
-                "name": "equal",
-                "type": "pure-token",
-                "display_text": "equal",
-                "token": "="
-              },
-              {
-                "name": "approximately",
-                "type": "pure-token",
-                "display_text": "approximately",
-                "token": "~"
-              }
-            ]
-          },
-          {
-            "name": "threshold",
-            "type": "string",
-            "display_text": "threshold"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count",
-            "token": "LIMIT",
-            "since": "6.2.0",
-            "optional": true
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "ZADD": {
@@ -17454,6 +19932,89 @@
     "since": "1.2.0",
     "group": "sorted-set",
     "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
+    "acl_categories": [
+      "@write",
+      "@sortedset",
+      "@fast"
+    ],
+    "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "condition",
+        "type": "oneof",
+        "optional": true,
+        "since": "3.0.2",
+        "arguments": [
+          {
+            "name": "nx",
+            "type": "pure-token",
+            "token": "NX"
+          },
+          {
+            "name": "xx",
+            "type": "pure-token",
+            "token": "XX"
+          }
+        ]
+      },
+      {
+        "name": "comparison",
+        "type": "oneof",
+        "optional": true,
+        "since": "6.2.0",
+        "arguments": [
+          {
+            "name": "gt",
+            "type": "pure-token",
+            "token": "GT"
+          },
+          {
+            "name": "lt",
+            "type": "pure-token",
+            "token": "LT"
+          }
+        ]
+      },
+      {
+        "name": "change",
+        "token": "CH",
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.0.2"
+      },
+      {
+        "name": "increment",
+        "token": "INCR",
+        "type": "pure-token",
+        "optional": true,
+        "since": "3.0.2"
+      },
+      {
+        "name": "data",
+        "type": "block",
+        "multiple": true,
+        "arguments": [
+          {
+            "name": "score",
+            "type": "double"
+          },
+          {
+            "name": "member",
+            "type": "string"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "history": [
       [
         "2.4.0",
@@ -17468,12 +20029,6 @@
         "Added the `GT` and `LT` options."
       ]
     ],
-    "acl_categories": [
-      "@write",
-      "@sortedset",
-      "@fast"
-    ],
-    "arity": -4,
     "key_specs": [
       {
         "begin_search": {
@@ -17493,92 +20048,6 @@
         "RW": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "condition",
-        "type": "oneof",
-        "since": "3.0.2",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "nx",
-            "type": "pure-token",
-            "display_text": "nx",
-            "token": "NX"
-          },
-          {
-            "name": "xx",
-            "type": "pure-token",
-            "display_text": "xx",
-            "token": "XX"
-          }
-        ]
-      },
-      {
-        "name": "comparison",
-        "type": "oneof",
-        "since": "6.2.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "gt",
-            "type": "pure-token",
-            "display_text": "gt",
-            "token": "GT"
-          },
-          {
-            "name": "lt",
-            "type": "pure-token",
-            "display_text": "lt",
-            "token": "LT"
-          }
-        ]
-      },
-      {
-        "name": "change",
-        "type": "pure-token",
-        "display_text": "change",
-        "token": "CH",
-        "since": "3.0.2",
-        "optional": true
-      },
-      {
-        "name": "increment",
-        "type": "pure-token",
-        "display_text": "increment",
-        "token": "INCR",
-        "since": "3.0.2",
-        "optional": true
-      },
-      {
-        "name": "data",
-        "type": "block",
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "score",
-            "type": "double",
-            "display_text": "score"
-          },
-          {
-            "name": "member",
-            "type": "string",
-            "display_text": "member"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "ZCARD": {
@@ -17592,6 +20061,17 @@
       "@fast"
     ],
     "arity": 2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17610,18 +20090,6 @@
         },
         "RO": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZCOUNT": {
@@ -17635,6 +20103,25 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "min",
+        "type": "double"
+      },
+      {
+        "name": "max",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17654,28 +20141,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "min",
-        "type": "double",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "double",
-        "display_text": "max"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZDIFF": {
@@ -17689,6 +20154,27 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17708,31 +20194,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "movablekeys"
     ]
   },
   "ZDIFFSTORE": {
@@ -17746,6 +20207,27 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17783,31 +20265,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "movablekeys"
     ]
   },
   "ZINCRBY": {
@@ -17821,6 +20278,26 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "increment",
+        "type": "integer"
+      },
+      {
+        "name": "member",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17841,29 +20318,6 @@
         "access": true,
         "update": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "increment",
-        "type": "integer",
-        "display_text": "increment"
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "fast"
     ]
   },
   "ZINTER": {
@@ -17877,6 +20331,69 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "token": "WEIGHTS",
+        "name": "weight",
+        "type": "integer",
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "token": "AGGREGATE",
+        "name": "aggregate",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "sum",
+            "type": "pure-token",
+            "token": "SUM"
+          },
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          },
+          {
+            "name": "count",
+            "type": "pure-token",
+            "token": "COUNT",
+            "since": "8.8.0"
+          }
+        ]
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "8.8.0",
+        "Added `COUNT` aggregate option."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17896,65 +20413,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "weight",
-        "type": "integer",
-        "display_text": "weight",
-        "token": "WEIGHTS",
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "aggregate",
-        "type": "oneof",
-        "token": "AGGREGATE",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "sum",
-            "type": "pure-token",
-            "display_text": "sum",
-            "token": "SUM"
-          },
-          {
-            "name": "min",
-            "type": "pure-token",
-            "display_text": "min",
-            "token": "MIN"
-          },
-          {
-            "name": "max",
-            "type": "pure-token",
-            "display_text": "max",
-            "token": "MAX"
-          }
-        ]
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "movablekeys"
     ]
   },
   "ZINTERCARD": {
@@ -17968,6 +20426,27 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -17987,31 +20466,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "limit",
-        "type": "integer",
-        "display_text": "limit",
-        "token": "LIMIT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "movablekeys"
     ]
   },
   "ZINTERSTORE": {
@@ -18025,6 +20479,69 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      },
+      {
+        "token": "WEIGHTS",
+        "name": "weight",
+        "type": "integer",
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "token": "AGGREGATE",
+        "name": "aggregate",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "sum",
+            "type": "pure-token",
+            "token": "SUM"
+          },
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          },
+          {
+            "name": "count",
+            "type": "pure-token",
+            "token": "COUNT",
+            "since": "8.8.0"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "history": [
+      [
+        "8.8.0",
+        "Added `COUNT` aggregate option."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18062,65 +20579,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      },
-      {
-        "name": "weight",
-        "type": "integer",
-        "display_text": "weight",
-        "token": "WEIGHTS",
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "aggregate",
-        "type": "oneof",
-        "token": "AGGREGATE",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "sum",
-            "type": "pure-token",
-            "display_text": "sum",
-            "token": "SUM"
-          },
-          {
-            "name": "min",
-            "type": "pure-token",
-            "display_text": "min",
-            "token": "MIN"
-          },
-          {
-            "name": "max",
-            "type": "pure-token",
-            "display_text": "max",
-            "token": "MAX"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "movablekeys"
     ]
   },
   "ZLEXCOUNT": {
@@ -18134,6 +20592,25 @@
       "@fast"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "min",
+        "type": "string"
+      },
+      {
+        "name": "max",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18153,28 +20630,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "min",
-        "type": "string",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "string",
-        "display_text": "max"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZMPOP": {
@@ -18188,6 +20643,43 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "name": "where",
+        "type": "oneof",
+        "arguments": [
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          }
+        ]
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18208,49 +20700,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "where",
-        "type": "oneof",
-        "arguments": [
-          {
-            "name": "min",
-            "type": "pure-token",
-            "display_text": "min",
-            "token": "MIN"
-          },
-          {
-            "name": "max",
-            "type": "pure-token",
-            "display_text": "max",
-            "token": "MAX"
-          }
-        ]
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "movablekeys"
     ]
   },
   "ZMSCORE": {
@@ -18264,6 +20713,22 @@
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18283,24 +20748,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZPOPMAX": {
@@ -18314,6 +20761,22 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18334,24 +20797,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "ZPOPMIN": {
@@ -18365,6 +20810,22 @@
       "@fast"
     ],
     "arity": -2,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18385,24 +20846,6 @@
         "access": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "ZRANDMEMBER": {
@@ -18416,31 +20859,10 @@
       "@slow"
     ],
     "arity": -2,
-    "key_specs": [
-      {
-        "begin_search": {
-          "type": "index",
-          "spec": {
-            "index": 1
-          }
-        },
-        "find_keys": {
-          "type": "range",
-          "spec": {
-            "lastkey": 0,
-            "keystep": 1,
-            "limit": 0
-          }
-        },
-        "RO": true,
-        "access": true
-      }
-    ],
     "arguments": [
       {
         "name": "key",
         "type": "key",
-        "display_text": "key",
         "key_spec_index": 0
       },
       {
@@ -18450,14 +20872,12 @@
         "arguments": [
           {
             "name": "count",
-            "type": "integer",
-            "display_text": "count"
+            "type": "integer"
           },
           {
             "name": "withscores",
-            "type": "pure-token",
-            "display_text": "withscores",
             "token": "WITHSCORES",
+            "type": "pure-token",
             "optional": true
           }
         ]
@@ -18468,6 +20888,26 @@
     ],
     "hints": [
       "nondeterministic_output"
+    ],
+    "key_specs": [
+      {
+        "begin_search": {
+          "type": "index",
+          "spec": {
+            "index": 1
+          }
+        },
+        "find_keys": {
+          "type": "range",
+          "spec": {
+            "lastkey": 0,
+            "keystep": 1,
+            "limit": 0
+          }
+        },
+        "RO": true,
+        "access": true
+      }
     ]
   },
   "ZRANGE": {
@@ -18475,18 +20915,84 @@
     "since": "1.2.0",
     "group": "sorted-set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
-    "history": [
-      [
-        "6.2.0",
-        "Added the `REV`, `BYSCORE`, `BYLEX` and `LIMIT` options."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@sortedset",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "string"
+      },
+      {
+        "name": "stop",
+        "type": "string"
+      },
+      {
+        "name": "sortby",
+        "type": "oneof",
+        "optional": true,
+        "since": "6.2.0",
+        "arguments": [
+          {
+            "name": "byscore",
+            "type": "pure-token",
+            "token": "BYSCORE"
+          },
+          {
+            "name": "bylex",
+            "type": "pure-token",
+            "token": "BYLEX"
+          }
+        ]
+      },
+      {
+        "name": "rev",
+        "token": "REV",
+        "type": "pure-token",
+        "optional": true,
+        "since": "6.2.0"
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "since": "6.2.0",
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "6.2.0",
+        "Added the `REV`, `BYSCORE`, `BYLEX` and `LIMIT` options."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18506,81 +21012,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "string",
-        "display_text": "start"
-      },
-      {
-        "name": "stop",
-        "type": "string",
-        "display_text": "stop"
-      },
-      {
-        "name": "sortby",
-        "type": "oneof",
-        "since": "6.2.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "byscore",
-            "type": "pure-token",
-            "display_text": "byscore",
-            "token": "BYSCORE"
-          },
-          {
-            "name": "bylex",
-            "type": "pure-token",
-            "display_text": "bylex",
-            "token": "BYLEX"
-          }
-        ]
-      },
-      {
-        "name": "rev",
-        "type": "pure-token",
-        "display_text": "rev",
-        "token": "REV",
-        "since": "6.2.0",
-        "optional": true
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "since": "6.2.0",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
     ]
   },
   "ZRANGEBYLEX": {
@@ -18588,14 +21019,46 @@
     "since": "2.8.9",
     "group": "sorted-set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`ZRANGE` with the `BYLEX` argument",
     "acl_categories": [
       "@read",
       "@sortedset",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "min",
+        "type": "string"
+      },
+      {
+        "name": "max",
+        "type": "string"
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18616,45 +21079,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "min",
-        "type": "string",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "string",
-        "display_text": "max"
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`ZRANGE` with the `BYLEX` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -18664,20 +21090,59 @@
     "since": "1.0.5",
     "group": "sorted-set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`ZRANGE` with the `BYSCORE` argument",
-    "history": [
-      [
-        "2.0.0",
-        "Added the `WITHSCORES` modifier."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@sortedset",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "min",
+        "type": "double"
+      },
+      {
+        "name": "max",
+        "type": "double"
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true,
+        "since": "2.0.0"
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "2.0.0",
+        "Added the `WITHSCORES` modifier."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18698,53 +21163,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "min",
-        "type": "double",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "double",
-        "display_text": "max"
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "since": "2.0.0",
-        "optional": true
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`ZRANGE` with the `BYSCORE` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -18760,6 +21180,69 @@
       "@slow"
     ],
     "arity": -5,
+    "arguments": [
+      {
+        "name": "dst",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "src",
+        "type": "key",
+        "key_spec_index": 1
+      },
+      {
+        "name": "min",
+        "type": "string"
+      },
+      {
+        "name": "max",
+        "type": "string"
+      },
+      {
+        "name": "sortby",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "byscore",
+            "type": "pure-token",
+            "token": "BYSCORE"
+          },
+          {
+            "name": "bylex",
+            "type": "pure-token",
+            "token": "BYLEX"
+          }
+        ]
+      },
+      {
+        "name": "rev",
+        "token": "REV",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18797,78 +21280,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "dst",
-        "type": "key",
-        "display_text": "dst",
-        "key_spec_index": 0
-      },
-      {
-        "name": "src",
-        "type": "key",
-        "display_text": "src",
-        "key_spec_index": 1
-      },
-      {
-        "name": "min",
-        "type": "string",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "string",
-        "display_text": "max"
-      },
-      {
-        "name": "sortby",
-        "type": "oneof",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "byscore",
-            "type": "pure-token",
-            "display_text": "byscore",
-            "token": "BYSCORE"
-          },
-          {
-            "name": "bylex",
-            "type": "pure-token",
-            "display_text": "bylex",
-            "token": "BYLEX"
-          }
-        ]
-      },
-      {
-        "name": "rev",
-        "type": "pure-token",
-        "display_text": "rev",
-        "token": "REV",
-        "optional": true
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom"
     ]
   },
   "ZRANK": {
@@ -18876,18 +21287,39 @@
     "since": "2.0.0",
     "group": "sorted-set",
     "complexity": "O(log(N))",
-    "history": [
-      [
-        "7.2.0",
-        "Added the optional `WITHSCORE` argument."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@sortedset",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string"
+      },
+      {
+        "name": "withscore",
+        "token": "WITHSCORE",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.2.0",
+        "Added the optional `WITHSCORE` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18907,30 +21339,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      },
-      {
-        "name": "withscore",
-        "type": "pure-token",
-        "display_text": "withscore",
-        "token": "WITHSCORE",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZREM": {
@@ -18938,18 +21346,34 @@
     "since": "1.2.0",
     "group": "sorted-set",
     "complexity": "O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.",
-    "history": [
-      [
-        "2.4.0",
-        "Accepts multiple elements."
-      ]
-    ],
     "acl_categories": [
       "@write",
       "@sortedset",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "command_flags": [
+      "write",
+      "fast"
+    ],
+    "history": [
+      [
+        "2.4.0",
+        "Accepts multiple elements."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -18969,24 +21393,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member",
-        "multiple": true
-      }
-    ],
-    "command_flags": [
-      "write",
-      "fast"
     ]
   },
   "ZREMRANGEBYLEX": {
@@ -19000,6 +21406,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "min",
+        "type": "string"
+      },
+      {
+        "name": "max",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19019,27 +21443,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "min",
-        "type": "string",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "string",
-        "display_text": "max"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "ZREMRANGEBYRANK": {
@@ -19053,6 +21456,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "stop",
+        "type": "integer"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19072,27 +21493,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "integer",
-        "display_text": "start"
-      },
-      {
-        "name": "stop",
-        "type": "integer",
-        "display_text": "stop"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "ZREMRANGEBYSCORE": {
@@ -19106,6 +21506,24 @@
       "@slow"
     ],
     "arity": 4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "min",
+        "type": "double"
+      },
+      {
+        "name": "max",
+        "type": "double"
+      }
+    ],
+    "command_flags": [
+      "write"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19125,27 +21543,6 @@
         "RW": true,
         "delete": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "min",
-        "type": "double",
-        "display_text": "min"
-      },
-      {
-        "name": "max",
-        "type": "double",
-        "display_text": "max"
-      }
-    ],
-    "command_flags": [
-      "write"
     ]
   },
   "ZREVRANGE": {
@@ -19153,14 +21550,36 @@
     "since": "1.2.0",
     "group": "sorted-set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`ZRANGE` with the `REV` argument",
     "acl_categories": [
       "@read",
       "@sortedset",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "start",
+        "type": "integer"
+      },
+      {
+        "name": "stop",
+        "type": "integer"
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19181,34 +21600,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "start",
-        "type": "integer",
-        "display_text": "start"
-      },
-      {
-        "name": "stop",
-        "type": "integer",
-        "display_text": "stop"
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`ZRANGE` with the `REV` argument",
     "doc_flags": [
       "deprecated"
     ]
@@ -19218,14 +21611,46 @@
     "since": "2.8.9",
     "group": "sorted-set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`ZRANGE` with the `REV` and `BYLEX` arguments",
     "acl_categories": [
       "@read",
       "@sortedset",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "max",
+        "type": "string"
+      },
+      {
+        "name": "min",
+        "type": "string"
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19246,45 +21671,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "max",
-        "type": "string",
-        "display_text": "max"
-      },
-      {
-        "name": "min",
-        "type": "string",
-        "display_text": "min"
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`ZRANGE` with the `REV` and `BYLEX` arguments",
     "doc_flags": [
       "deprecated"
     ]
@@ -19294,20 +21682,58 @@
     "since": "2.2.0",
     "group": "sorted-set",
     "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
-    "deprecated_since": "6.2.0",
-    "replaced_by": "`ZRANGE` with the `REV` and `BYSCORE` arguments",
-    "history": [
-      [
-        "2.1.6",
-        "`min` and `max` can be exclusive."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@sortedset",
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "max",
+        "type": "double"
+      },
+      {
+        "name": "min",
+        "type": "double"
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true
+      },
+      {
+        "token": "LIMIT",
+        "name": "limit",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "offset",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "2.1.6",
+        "`min` and `max` can be exclusive."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19328,52 +21754,8 @@
         "access": true
       }
     ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "max",
-        "type": "double",
-        "display_text": "max"
-      },
-      {
-        "name": "min",
-        "type": "double",
-        "display_text": "min"
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "optional": true
-      },
-      {
-        "name": "limit",
-        "type": "block",
-        "token": "LIMIT",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "offset",
-            "type": "integer",
-            "display_text": "offset"
-          },
-          {
-            "name": "count",
-            "type": "integer",
-            "display_text": "count"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
+    "deprecated_since": "6.2.0",
+    "replaced_by": "`ZRANGE` with the `REV` and `BYSCORE` arguments",
     "doc_flags": [
       "deprecated"
     ]
@@ -19383,18 +21765,39 @@
     "since": "2.0.0",
     "group": "sorted-set",
     "complexity": "O(log(N))",
-    "history": [
-      [
-        "7.2.0",
-        "Added the optional `WITHSCORE` argument."
-      ]
-    ],
     "acl_categories": [
       "@read",
       "@sortedset",
       "@fast"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string"
+      },
+      {
+        "name": "withscore",
+        "token": "WITHSCORE",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
+    "history": [
+      [
+        "7.2.0",
+        "Added the optional `WITHSCORE` argument."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19414,30 +21817,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      },
-      {
-        "name": "withscore",
-        "type": "pure-token",
-        "display_text": "withscore",
-        "token": "WITHSCORE",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZSCAN": {
@@ -19451,6 +21830,35 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "cursor",
+        "type": "integer"
+      },
+      {
+        "token": "MATCH",
+        "name": "pattern",
+        "type": "pattern",
+        "optional": true
+      },
+      {
+        "token": "COUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "hints": [
+      "nondeterministic_output"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19470,39 +21878,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "cursor",
-        "type": "integer",
-        "display_text": "cursor"
-      },
-      {
-        "name": "pattern",
-        "type": "pattern",
-        "display_text": "pattern",
-        "token": "MATCH",
-        "optional": true
-      },
-      {
-        "name": "count",
-        "type": "integer",
-        "display_text": "count",
-        "token": "COUNT",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly"
-    ],
-    "hints": [
-      "nondeterministic_output"
     ]
   },
   "ZSCORE": {
@@ -19516,6 +21891,21 @@
       "@fast"
     ],
     "arity": 3,
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "member",
+        "type": "string"
+      }
+    ],
+    "command_flags": [
+      "readonly",
+      "fast"
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19535,23 +21925,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "display_text": "member"
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "fast"
     ]
   },
   "ZUNION": {
@@ -19565,6 +21938,69 @@
       "@slow"
     ],
     "arity": -3,
+    "arguments": [
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 0,
+        "multiple": true
+      },
+      {
+        "token": "WEIGHTS",
+        "name": "weight",
+        "type": "integer",
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "token": "AGGREGATE",
+        "name": "aggregate",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "sum",
+            "type": "pure-token",
+            "token": "SUM"
+          },
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          },
+          {
+            "name": "count",
+            "type": "pure-token",
+            "token": "COUNT",
+            "since": "8.8.0"
+          }
+        ]
+      },
+      {
+        "name": "withscores",
+        "token": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true
+      }
+    ],
+    "command_flags": [
+      "readonly"
+    ],
+    "history": [
+      [
+        "8.8.0",
+        "Added `COUNT` aggregate option."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19584,65 +22020,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 0,
-        "multiple": true
-      },
-      {
-        "name": "weight",
-        "type": "integer",
-        "display_text": "weight",
-        "token": "WEIGHTS",
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "aggregate",
-        "type": "oneof",
-        "token": "AGGREGATE",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "sum",
-            "type": "pure-token",
-            "display_text": "sum",
-            "token": "SUM"
-          },
-          {
-            "name": "min",
-            "type": "pure-token",
-            "display_text": "min",
-            "token": "MIN"
-          },
-          {
-            "name": "max",
-            "type": "pure-token",
-            "display_text": "max",
-            "token": "MAX"
-          }
-        ]
-      },
-      {
-        "name": "withscores",
-        "type": "pure-token",
-        "display_text": "withscores",
-        "token": "WITHSCORES",
-        "optional": true
-      }
-    ],
-    "command_flags": [
-      "readonly",
-      "movablekeys"
     ]
   },
   "ZUNIONSTORE": {
@@ -19656,6 +22033,69 @@
       "@slow"
     ],
     "arity": -4,
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "key",
+        "key_spec_index": 0
+      },
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "key",
+        "type": "key",
+        "key_spec_index": 1,
+        "multiple": true
+      },
+      {
+        "token": "WEIGHTS",
+        "name": "weight",
+        "type": "integer",
+        "optional": true,
+        "multiple": true
+      },
+      {
+        "token": "AGGREGATE",
+        "name": "aggregate",
+        "type": "oneof",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "sum",
+            "type": "pure-token",
+            "token": "SUM"
+          },
+          {
+            "name": "min",
+            "type": "pure-token",
+            "token": "MIN"
+          },
+          {
+            "name": "max",
+            "type": "pure-token",
+            "token": "MAX"
+          },
+          {
+            "name": "count",
+            "type": "pure-token",
+            "token": "COUNT",
+            "since": "8.8.0"
+          }
+        ]
+      }
+    ],
+    "command_flags": [
+      "write",
+      "denyoom"
+    ],
+    "history": [
+      [
+        "8.8.0",
+        "Added `COUNT` aggregate option."
+      ]
+    ],
     "key_specs": [
       {
         "begin_search": {
@@ -19693,79 +22133,6 @@
         "RO": true,
         "access": true
       }
-    ],
-    "arguments": [
-      {
-        "name": "destination",
-        "type": "key",
-        "display_text": "destination",
-        "key_spec_index": 0
-      },
-      {
-        "name": "numkeys",
-        "type": "integer",
-        "display_text": "numkeys"
-      },
-      {
-        "name": "key",
-        "type": "key",
-        "display_text": "key",
-        "key_spec_index": 1,
-        "multiple": true
-      },
-      {
-        "name": "weight",
-        "type": "integer",
-        "display_text": "weight",
-        "token": "WEIGHTS",
-        "optional": true,
-        "multiple": true
-      },
-      {
-        "name": "aggregate",
-        "type": "oneof",
-        "token": "AGGREGATE",
-        "optional": true,
-        "arguments": [
-          {
-            "name": "sum",
-            "type": "pure-token",
-            "display_text": "sum",
-            "token": "SUM"
-          },
-          {
-            "name": "min",
-            "type": "pure-token",
-            "display_text": "min",
-            "token": "MIN"
-          },
-          {
-            "name": "max",
-            "type": "pure-token",
-            "display_text": "max",
-            "token": "MAX"
-          }
-        ]
-      }
-    ],
-    "command_flags": [
-      "write",
-      "denyoom",
-      "movablekeys"
     ]
-  },
-  "JSON.GET": {
-    "summary": "Return the value at path in JSON serialized form",
-    "since": "1.0.0",
-    "group": "json",
-    "complexity": "O(N) when path is evaluated to a single value where N is the size of the value, O(N) when path is evaluated to multiple values, where N is the size of the key",
-    "arguments": []
-  },
-  "JSON.SET": {
-    "summary": "Sets or updates the JSON value at a path",
-    "since": "1.0.0",
-    "group": "json",
-    "complexity": "O(M+N) where M is the original size and N is the new size",
-    "arguments": []
   }
 }

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-10B-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-10B-expire-use-case.yml
@@ -28,7 +28,6 @@ tested-groups:
 - generic
 tested-commands:
 - set
-- setx
 - get
 - del
 - setex

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-100B-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-100B-expire-use-case.yml
@@ -25,7 +25,6 @@ tested-groups:
 - generic
 tested-commands:
 - set
-- setx
 - get
 - del
 - setex

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-10B-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-10B-expire-use-case.yml
@@ -25,7 +25,6 @@ tested-groups:
 - generic
 tested-commands:
 - set
-- setx
 - get
 - del
 - setex

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-1KiB-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-1KiB-expire-use-case.yml
@@ -24,7 +24,6 @@ tested-groups:
 - generic
 tested-commands:
 - set
-- setx
 - get
 - del
 - setex

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-4KiB-expire-use-case.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-4KiB-expire-use-case.yml
@@ -25,7 +25,6 @@ tested-groups:
 - generic
 tested-commands:
 - set
-- setx
 - get
 - del
 - setex

--- a/utils/regenerate_commands_json.py
+++ b/utils/regenerate_commands_json.py
@@ -8,9 +8,16 @@ generated against Redis <= 8.0.0; this script refreshes it from a newer tree.
 Sources, all read from the checkout passed as the first argument:
   - src/commands/*.json          command metadata (the command table)
   - modules/vector-sets/commands.json   vector-set module commands
-  - the existing commands.json   module entries not part of the checkout
-                                 (e.g. RedisJSON's JSON.* commands) are
-                                 carried over verbatim
+  - the existing commands.json   entries on the CARRIED_OVER_COMMANDS
+                                 allowlist (external module bundles such as
+                                 RedisJSON, not part of the checkout) are
+                                 carried over verbatim; anything else that
+                                 only exists in the file is treated as
+                                 drift and fails the run
+
+Every tested-commands entry of the suites must resolve in the result, which
+turns "a suite names a command that does not exist" (e.g. the historical
+`setx` typo) into a hard error instead of a silent statistics gap.
 
 Usage:
     python3 utils/regenerate_commands_json.py /path/to/redis [--check]
@@ -25,38 +32,15 @@ import json
 import os
 import sys
 
+import yaml
+
 VECTOR_SET_MODULE_FILE = "modules/vector-sets/commands.json"
 
-# Sentinel-only commands never run against the redis-server instances this
-# corpus benchmarks, so they are left out.
-EXCLUDED_FILES = {
-    "sentinel.json",
-    "sentinel-ckquorum.json",
-    "sentinel-config.json",
-    "sentinel-debug.json",
-    "sentinel-failover.json",
-    "sentinel-flushconfig.json",
-    "sentinel-get-master-addr-by-name.json",
-    "sentinel-help.json",
-    "sentinel-info-cache.json",
-    "sentinel-is-master-down-by-addr.json",
-    "sentinel-master.json",
-    "sentinel-masters.json",
-    "sentinel-monitor.json",
-    "sentinel-myid.json",
-    "sentinel-pending-scripts.json",
-    "sentinel-remove.json",
-    "sentinel-replicas.json",
-    "sentinel-reset.json",
-    "sentinel-sentinels.json",
-    "sentinel-set.json",
-    "sentinel-simulate-failure.json",
-    "sentinel-slaves.json",
-}
-
-# Commands whose registered name is itself hyphenated rather than a
-# "container subcommand" pair; keep the file name verbatim.
-NON_SUBCOMMAND_HYPHENATED = {"restore-asking"}
+# Commands that live outside the redis checkout (external module bundles,
+# e.g. RedisJSON) and are carried over verbatim from the committed corpus.
+# The allowlist is explicit on purpose: a command upstream removes must not
+# silently survive regeneration from the stale file being validated.
+CARRIED_OVER_COMMANDS = ("JSON.GET", "JSON.SET")
 
 # The command table spells some groups with underscores; the corpus uses the
 # canonical groups.json names (see PR #371 for the sorted-set precedent).
@@ -117,33 +101,24 @@ ENTRY_FIELD_ORDER = [
 ]
 
 
-def command_name_from_file(stem):
-    """Derive the corpus name from a command-file stem.
-
-    Subcommand files use hyphens as separators, but subcommand names may
-    contain hyphens themselves, so only the first one becomes a space:
-    acl-cat.json -> "ACL CAT", client-no-evict.json -> "CLIENT NO-EVICT".
-    """
-    if stem in NON_SUBCOMMAND_HYPHENATED or "-" not in stem:
-        return stem.upper()
-    parent, _, subcommand = stem.partition("-")
-    return "{} {}".format(parent.upper(), subcommand.upper())
-
-
 def load_core_command_table(redis_root):
     """Flatten src/commands/*.json into {COMMAND NAME: raw metadata}.
 
-    Each file holds a single top-level entry whose key is the bare command
-    name ("CAT" in acl-cat.json), so the full corpus name must come from the
-    file name rather than the key.
+    Subcommand entries declare their parent in a "container" field, so the
+    corpus name is "<container> <key>" ("ACL CAT"); standalone commands keep
+    their key verbatim ("MSETEX", "RESTORE-ASKING"). Sentinel-only commands
+    never run against the redis-server instances this corpus benchmarks.
     """
     table = {}
     for path in sorted(glob.glob(os.path.join(redis_root, "src", "commands", "*.json"))):
-        if os.path.basename(path) in EXCLUDED_FILES:
-            continue
         stem = os.path.basename(path)[:-len(".json")]
+        if stem == "sentinel" or stem.startswith("sentinel-"):
+            continue
         with open(path, encoding="utf-8") as handle:
-            table[command_name_from_file(stem)] = next(iter(json.load(handle).values()))
+            key, metadata = next(iter(json.load(handle).items()))
+        container = metadata.get("container")
+        name = "{} {}".format(container, key) if container else key
+        table[name] = metadata
     return table
 
 
@@ -248,11 +223,37 @@ def regenerate(redis_root, existing_corpus):
                 converted["group"] = "module"
                 corpus[name] = converted
 
-    # Commands tracked by the corpus but absent from the checkout (module
-    # commands of external bundles, e.g. RedisJSON) are carried over verbatim.
-    for name in sorted(set(existing_corpus) - set(corpus)):
-        corpus[name] = existing_corpus[name]
+    # External-bundle commands on the allowlist are carried over verbatim;
+    # anything else present only in the committed corpus is drift.
+    orphans = set(existing_corpus) - set(corpus) - set(CARRIED_OVER_COMMANDS)
+    if orphans:
+        sys.exit("commands present only in the committed corpus (removed upstream?): {}".format(sorted(orphans)))
+    for name in CARRIED_OVER_COMMANDS:
+        if name in existing_corpus:
+            corpus[name] = existing_corpus[name]
     return {name: corpus[name] for name in sorted(corpus)}
+
+
+def validate_suite_commands(repo_root, corpus):
+    """Fail when a suite declares a tested-command the corpus cannot resolve.
+
+    stats.py looks each suite command up as-is and then upper-cased; a name
+    that resolves neither way is silently dropped from coverage statistics.
+    Suites may spell subcommands with Redis' pipe separator (client|list)
+    while the corpus uses a space (CLIENT LIST), so both spellings resolve.
+    """
+    suites_dir = os.path.join(repo_root, "redis_benchmarks_specification", "test-suites")
+    unresolvable = []
+    for path in sorted(glob.glob(os.path.join(suites_dir, "*.yml"))):
+        with open(path, encoding="utf-8") as handle:
+            spec = yaml.safe_load(handle)
+        for command in (spec or {}).get("tested-commands") or []:
+            spaced = command.replace("|", " ")
+            candidates = {command, spaced, command.upper(), spaced.upper()}
+            if not candidates & set(corpus):
+                unresolvable.append("{}: {}".format(os.path.basename(path), command))
+    if unresolvable:
+        sys.exit("tested-commands that resolve nowhere in commands.json:\n  " + "\n  ".join(unresolvable))
 
 
 def main():
@@ -275,17 +276,18 @@ def main():
     if unknown_groups:
         sys.exit("groups {} are not present in groups.json; add them there first".format(sorted(unknown_groups)))
 
-    payload = json.dumps(regenerated, indent=2)
+    validate_suite_commands(repo_root, regenerated)
 
     if args.check:
         with open(corpus_path, encoding="utf-8") as handle:
-            drift = handle.read() != payload
+            drift = json.load(handle) != regenerated
         if drift:
             print("commands.json is stale relative to the checkout at {}".format(args.redis_root))
         else:
             print("commands.json matches the checkout at {}".format(args.redis_root))
         sys.exit(1 if drift else 0)
 
+    payload = json.dumps(regenerated, indent=2)
     with open(corpus_path, "w", encoding="utf-8") as handle:
         handle.write(payload)
     print("Wrote {} commands to {}".format(len(regenerated), corpus_path))

--- a/utils/regenerate_commands_json.py
+++ b/utils/regenerate_commands_json.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Regenerate the top-level commands.json corpus from a Redis checkout.
+
+The corpus mirrors the command table of a specific Redis release and is the
+lookup table __cli__/stats.py uses for group/ACL bookkeeping. It had been
+generated against Redis <= 8.0.0; this script refreshes it from a newer tree.
+
+Sources, all read from the checkout passed as the first argument:
+  - src/commands/*.json          command metadata (the command table)
+  - modules/vector-sets/commands.json   vector-set module commands
+  - the existing commands.json   module entries not part of the checkout
+                                 (e.g. RedisJSON's JSON.* commands) are
+                                 carried over verbatim
+
+Usage:
+    python3 utils/regenerate_commands_json.py /path/to/redis [--check]
+
+--check exits non-zero when the committed commands.json differs from a fresh
+regeneration, so a CI job can fail on drift instead of silently going stale.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+VECTOR_SET_MODULE_FILE = "modules/vector-sets/commands.json"
+
+# Sentinel-only commands never run against the redis-server instances this
+# corpus benchmarks, so they are left out.
+EXCLUDED_FILES = {
+    "sentinel.json",
+    "sentinel-ckquorum.json",
+    "sentinel-config.json",
+    "sentinel-debug.json",
+    "sentinel-failover.json",
+    "sentinel-flushconfig.json",
+    "sentinel-get-master-addr-by-name.json",
+    "sentinel-help.json",
+    "sentinel-info-cache.json",
+    "sentinel-is-master-down-by-addr.json",
+    "sentinel-master.json",
+    "sentinel-masters.json",
+    "sentinel-monitor.json",
+    "sentinel-myid.json",
+    "sentinel-pending-scripts.json",
+    "sentinel-remove.json",
+    "sentinel-replicas.json",
+    "sentinel-reset.json",
+    "sentinel-sentinels.json",
+    "sentinel-set.json",
+    "sentinel-simulate-failure.json",
+    "sentinel-slaves.json",
+}
+
+# Commands whose registered name is itself hyphenated rather than a
+# "container subcommand" pair; keep the file name verbatim.
+NON_SUBCOMMAND_HYPHENATED = {"restore-asking"}
+
+# The command table spells some groups with underscores; the corpus uses the
+# canonical groups.json names (see PR #371 for the sorted-set precedent).
+GROUP_CANONICAL_NAME = {"sorted_set": "sorted-set"}
+
+# COMMAND INFO reports implicit ACL categories on top of the explicit ones;
+# replicate setImplicitACLCategories() from src/server.c. Only the categories
+# the stats tool buckets on are emitted.
+IMPLICIT_ACL_CATEGORIES = [
+    ("write", lambda flags, acl: "WRITE" in flags),
+    ("read", lambda flags, acl: "READONLY" in flags and "scripting" not in acl),
+    ("admin", lambda flags, acl: "ADMIN" in flags),
+    ("dangerous", lambda flags, acl: "ADMIN" in flags),
+    ("pubsub", lambda flags, acl: "PUBSUB" in flags),
+    ("fast", lambda flags, acl: "FAST" in flags),
+    ("blocking", lambda flags, acl: "BLOCKING" in flags),
+]
+
+# Canonical category order of ACLDefaultCommandCategories in src/acl.c; the
+# corpus lists categories in this order.
+ACL_CATEGORY_ORDER = [
+    "keyspace", "read", "write", "set", "sortedset", "list", "hash",
+    "string", "array", "bitmap", "hyperloglog", "geo", "stream", "pubsub",
+    "admin", "fast", "slow", "blocking", "dangerous", "connection",
+    "transaction", "scripting", "ratelimit",
+]
+
+
+def derive_acl_categories(metadata):
+    """Merge explicit acl_categories with the implicit ones Redis derives."""
+    explicit = [category.lower() for category in metadata.get("acl_categories") or []]
+    flags = metadata.get("command_flags") or []
+    categories = set(explicit)
+    categories.update(name for name, predicate in IMPLICIT_ACL_CATEGORIES if predicate(flags, categories))
+    if "fast" not in categories:
+        categories.add("slow")
+    ordered = [name for name in ACL_CATEGORY_ORDER if name in categories]
+    ordered.extend(sorted(categories - set(ACL_CATEGORY_ORDER)))
+    return ["@" + name for name in ordered]
+
+# Field order of the historical corpus; regenerated entries follow it too.
+ENTRY_FIELD_ORDER = [
+    "summary",
+    "since",
+    "group",
+    "complexity",
+    "acl_categories",
+    "arity",
+    "arguments",
+    "command_flags",
+    "hints",
+    "history",
+    "key_specs",
+    "deprecated_since",
+    "replaced_by",
+    "doc_flags",
+    "module",
+]
+
+
+def command_name_from_file(stem):
+    """Derive the corpus name from a command-file stem.
+
+    Subcommand files use hyphens as separators, but subcommand names may
+    contain hyphens themselves, so only the first one becomes a space:
+    acl-cat.json -> "ACL CAT", client-no-evict.json -> "CLIENT NO-EVICT".
+    """
+    if stem in NON_SUBCOMMAND_HYPHENATED or "-" not in stem:
+        return stem.upper()
+    parent, _, subcommand = stem.partition("-")
+    return "{} {}".format(parent.upper(), subcommand.upper())
+
+
+def load_core_command_table(redis_root):
+    """Flatten src/commands/*.json into {COMMAND NAME: raw metadata}.
+
+    Each file holds a single top-level entry whose key is the bare command
+    name ("CAT" in acl-cat.json), so the full corpus name must come from the
+    file name rather than the key.
+    """
+    table = {}
+    for path in sorted(glob.glob(os.path.join(redis_root, "src", "commands", "*.json"))):
+        if os.path.basename(path) in EXCLUDED_FILES:
+            continue
+        stem = os.path.basename(path)[:-len(".json")]
+        with open(path, encoding="utf-8") as handle:
+            table[command_name_from_file(stem)] = next(iter(json.load(handle).values()))
+    return table
+
+
+def key_spec_flag_name(flag):
+    """Short flags stay uppercase; multi-word ones become snake_case."""
+    if len(flag) <= 2:
+        return flag
+    return flag.lower()
+
+
+def convert_key_specs(source_key_specs):
+    """Map source key_specs to the corpus shape (flag booleans, typed searches)."""
+    converted = []
+    for key_spec in source_key_specs:
+        entry = {}
+        if "notes" in key_spec:
+            entry["notes"] = key_spec["notes"]
+        begin_search = key_spec.get("begin_search") or {}
+        if "index" in begin_search:
+            entry["begin_search"] = {
+                "type": "index",
+                "spec": {"index": begin_search["index"]["pos"]},
+            }
+        elif "keyword" in begin_search:
+            entry["begin_search"] = {
+                "type": "keyword",
+                "spec": {"keyword": begin_search["keyword"]["keyword"], "startfrom": begin_search["keyword"]["startfrom"]},
+            }
+        elif "unknown" in begin_search:
+            entry["begin_search"] = {"type": "unknown", "spec": {}}
+        find_keys = key_spec.get("find_keys") or {}
+        if "range" in find_keys:
+            entry["find_keys"] = {
+                "type": "range",
+                "spec": {
+                    "lastkey": find_keys["range"]["lastkey"],
+                    "keystep": find_keys["range"]["step"],
+                    "limit": find_keys["range"]["limit"],
+                },
+            }
+        elif "keynum" in find_keys:
+            keynum_spec = {"keynumidx": find_keys["keynum"]["keynumidx"]}
+            keynum_spec["firstkey"] = find_keys["keynum"]["firstkey"]
+            if "step" in find_keys["keynum"]:
+                keynum_spec["keystep"] = find_keys["keynum"]["step"]
+            entry["find_keys"] = {"type": "keynum", "spec": keynum_spec}
+        elif "unknown" in find_keys:
+            entry["find_keys"] = {"type": "unknown", "spec": {}}
+        for flag in key_spec.get("flags", []):
+            entry[key_spec_flag_name(flag)] = True
+        converted.append(entry)
+    return converted
+
+
+def convert_entry(name, metadata, module_name=None):
+    """Project one source-table entry onto the corpus entry shape."""
+    entry = {}
+    if "summary" in metadata:
+        entry["summary"] = metadata["summary"]
+    if "since" in metadata:
+        entry["since"] = metadata["since"]
+    entry["group"] = GROUP_CANONICAL_NAME.get(metadata["group"], metadata["group"])
+    if "complexity" in metadata:
+        entry["complexity"] = metadata["complexity"]
+    # COMMAND DOCS reports no categories for module commands; skip deriving.
+    if module_name is None:
+        entry["acl_categories"] = derive_acl_categories(metadata)
+    if "arity" in metadata:
+        entry["arity"] = metadata["arity"]
+    if "arguments" in metadata:
+        entry["arguments"] = metadata["arguments"]
+    if "command_flags" in metadata:
+        entry["command_flags"] = [flag.lower() for flag in metadata["command_flags"]]
+    if "command_tips" in metadata:
+        entry["hints"] = [tip.lower() for tip in metadata["command_tips"]]
+    if "history" in metadata:
+        entry["history"] = metadata["history"]
+    if "key_specs" in metadata:
+        entry["key_specs"] = convert_key_specs(metadata["key_specs"])
+    if "deprecated_since" in metadata:
+        entry["deprecated_since"] = metadata["deprecated_since"]
+    if "replaced_by" in metadata:
+        entry["replaced_by"] = metadata["replaced_by"]
+    if "doc_flags" in metadata:
+        entry["doc_flags"] = [flag.lower() for flag in metadata["doc_flags"]]
+    if module_name:
+        entry["module"] = module_name
+    return {field: entry[field] for field in ENTRY_FIELD_ORDER if field in entry}
+
+
+def regenerate(redis_root, existing_corpus):
+    corpus = {}
+    core_table = load_core_command_table(redis_root)
+    for name in sorted(core_table):
+        corpus[name] = convert_entry(name, core_table[name])
+
+    vector_sets_path = os.path.join(redis_root, VECTOR_SET_MODULE_FILE)
+    if os.path.exists(vector_sets_path):
+        with open(vector_sets_path, encoding="utf-8") as handle:
+            for name, metadata in sorted(json.load(handle).items()):
+                converted = convert_entry(name, metadata, module_name="vectorset")
+                converted["group"] = "module"
+                corpus[name] = converted
+
+    # Commands tracked by the corpus but absent from the checkout (module
+    # commands of external bundles, e.g. RedisJSON) are carried over verbatim.
+    for name in sorted(set(existing_corpus) - set(corpus)):
+        corpus[name] = existing_corpus[name]
+    return {name: corpus[name] for name in sorted(corpus)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("redis_root", help="Path to a Redis source checkout at the target release")
+    parser.add_argument("--check", action="store_true", help="Compare against the committed corpus instead of rewriting it")
+    args = parser.parse_args()
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    corpus_path = os.path.join(repo_root, "commands.json")
+    with open(corpus_path, encoding="utf-8") as handle:
+        existing_corpus = json.load(handle)
+
+    regenerated = regenerate(args.redis_root, existing_corpus)
+
+    groups_path = os.path.join(repo_root, "groups.json")
+    with open(groups_path, encoding="utf-8") as handle:
+        known_groups = set(json.load(handle)) | {"module"}
+    unknown_groups = {entry["group"] for entry in regenerated.values()} - known_groups
+    if unknown_groups:
+        sys.exit("groups {} are not present in groups.json; add them there first".format(sorted(unknown_groups)))
+
+    payload = json.dumps(regenerated, indent=2)
+
+    if args.check:
+        with open(corpus_path, encoding="utf-8") as handle:
+            drift = handle.read() != payload
+        if drift:
+            print("commands.json is stale relative to the checkout at {}".format(args.redis_root))
+        else:
+            print("commands.json matches the checkout at {}".format(args.redis_root))
+        sys.exit(1 if drift else 0)
+
+    with open(corpus_path, "w", encoding="utf-8") as handle:
+        handle.write(payload)
+    print("Wrote {} commands to {}".format(len(regenerated), corpus_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #527

## What

Regenerates `commands.json` from the Redis **8.10.1** command table: **396 → 452 entries** (437 core + 13 vector-set + 2 carried-over RedisJSON entries), closing the 5-release gap and adding the ~56 missing commands (`MSETEX`, `INCREX`, the `AR*` auto-ring family, `BACKUP *`, `HOTKEYS *`, `HIMPORT *`, `XDELEX`, `XACKDEL`, `LMOVEM`/`BLMOVEM`, `SDIFFCARD`, `SUNIONCARD`, `VRANGE`, …). As suggested in the issue, the 22 `SENTINEL *` commands stay out of scope.

The generator is committed as `utils/regenerate_commands_json.py` so refreshes are reproducible; it supports `--check`, which exits non-zero on drift and can back a CI gate if maintainers want one (per the issue, the release-tracking policy for such a job is a maintainer decision, so no workflow change here).

## How the corpus was rebuilt

- Entry names derive from `src/commands/*.json` file names, preserving subcommand hyphens (`CLIENT NO-EVICT`, `CLUSTER SET-CONFIG-EPOCH`) to keep the existing corpus spelling.
- `acl_categories` replicate `setImplicitACLCategories()` from `src/server.c` (explicit categories plus derived `@read`/`@write`/`@fast`/`@slow`/…), in the canonical `src/acl.c` order. Cross-checked against `COMMAND INFO` on a live 8.10.1 instance: **zero divergence across all 449 reported commands**.
- The previously missing `HIMPORT`, `ARGET`, `ARRING` suite commands now resolve, and `groups.json`'s `array` group agrees with the corpus again.
- `JSON.*` entries not present in the checkout are carried over verbatim.
- Note: `arguments` no longer carry `display_text` — the source command table does not publish it anymore.

Second commit fixes the `setx` typo the issue calls out: it is dropped from `tested-commands` of the 5 `*-expire-use-case.yml` suites (they already list the correct `setex`).

## Verification

- `redis-benchmarks-spec-cli --tool stats --fail-on-required-diff` → exit 0
- `python3 utils/regenerate_commands_json.py <redis 8.10.1 checkout> --check` → `commands.json matches the checkout`
- Field-level diff against the old corpus audited: remaining deltas are genuine 8.0 → 8.10.1 evolution (e.g. new `sentinel` availability flags, `notes`/`incomplete` key-spec enrichments)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are corpus metadata and test-suite command lists for the stats CLI, not runtime Redis behavior; main risk is incorrect command metadata affecting reporting or validation.
> 
> **Overview**
> **Regenerates `commands.json` from the Redis 8.10.1 command table**, growing the corpus from ~396 to **452** entries (core commands, vector-set module, plus carried-over `JSON.GET`/`JSON.SET`) and adding missing commands such as `MSETEX`, `INCREX`, auto-ring `AR*`, `BACKUP *`, `HOTKEYS *`, `HIMPORT *`, stream helpers, and related list/set commands. **`SENTINEL *` stays excluded** as out of scope for this benchmark corpus.
> 
> Adds **`utils/regenerate_commands_json.py`** so refreshes are reproducible from a Redis checkout, with **`--check`** to fail on drift against the committed file. Regenerated metadata follows upstream naming (including hyphenated subcommands), **replicates implicit ACL categories** like `setImplicitACLCategories()`, and **drops `display_text` on arguments** where the upstream table no longer provides it.
> 
> Fixes benchmark suite hygiene by **removing the erroneous `setx` entry** from the `*-expire-use-case` suites (they already list `setex`), so stats validation treats unknown tested commands as errors rather than silent gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab3e8e3436698906d5df9f368ed3f7638ce6a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->