### PR TITLE
Add glob-pattern matcher coverage: KEYS, SCAN MATCH, HSCAN and SSCAN

### DIFF
--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-keys-leading-wildcard-match.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-keys-leading-wildcard-match.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-generic-keys-leading-wildcard-match
+description: Runs KEYS with a leading-wildcard glob pattern against the same 1M-key keyspace as the selective-prefix
+  variant. A pattern that begins with `*` forces stringmatchlen() to attempt the suffix match at every
+  position of every key -- the recursive backtracking path -- so the per-key matcher cost differs sharply
+  from a prefix-anchored pattern even though both walk all 1M keys. `*2345` matches 100 of 1,000,000 keys
+  (verified locally). Together the two KEYS specs price the two recursion behaviours of the shared matcher
+  that KEYS, SCAN MATCH, HSCAN, SSCAN and pattern pubsub all depend on.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram"
+      "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-10B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes.
+tested-commands:
+- keys
+tested-groups:
+- generic
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "KEYS *2345" --command-key-pattern R --hide-histogram --test-time 180 --pipeline
+    1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 44

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-keys-selective-prefix-match.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-keys-selective-prefix-match.yml
@@ -1,0 +1,44 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-generic-keys-selective-prefix-match
+description: Runs KEYS with a selective prefix glob pattern against a 1M-key keyspace. KEYS walks the
+  entire keyspace calling stringmatchlen() on every key, but the bare `*` pattern is special-cased and
+  skips the matcher entirely -- so only a non-trivial pattern exercises the recursive matcher. `memtier-12345*`
+  matches 11 of 1,000,000 keys (verified locally), keeping the reply small so the measurement reflects
+  matcher plus traversal cost rather than reply construction. A prefix-anchored pattern (literal characters
+  then a trailing `*`) takes stringmatchlen's low-backtracking path; pairs with the leading-wildcard variant
+  that takes the backtracking path.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram"
+      "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-10B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes.
+tested-commands:
+- keys
+tested-groups:
+- generic
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "KEYS memtier-12345*" --command-key-pattern R --hide-histogram --test-time 180
+    --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 44

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-scan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-generic-scan-match-count-100.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1Mkeys-generic-scan-match-count-100
+description: Runs SCAN with MATCH and COUNT 100 over a 1M-key keyspace. As with KEYS, SCAN's MATCH special-cases
+  the bare `*` pattern and skips stringmatchlen(), so a real pattern is required to exercise the matcher;
+  each call filters every key in the visited bucket through stringmatchlen(), which makes per-element
+  matching -- not the cursor walk -- the dominant cost. Mirrors the one existing ZSCAN MATCH spec (1key-zset-1K-elements-zscan-match-count-100),
+  extending the same MATCH coverage to the global-keyspace SCAN path. The pattern `memtier-12345*` is
+  selective (11 matches over a full iteration, verified locally).
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1000000
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" "--ratio" "1:0" "--key-pattern" "P:P" "-c" "50" "-t" "2" "--hide-histogram"
+      "--key-minimum" "1" "--key-maximum" "1000000" "-n" "allkeys" --pipeline 50'
+  resources:
+    requests:
+      memory: 1g
+  dataset_name: 1Mkeys-string-10B-size
+  dataset_description: This dataset contains 1 million string keys, each with a data size of 10 bytes.
+tested-commands:
+- scan
+tested-groups:
+- generic
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "SCAN 0 MATCH memtier-12345* COUNT 100" --command-key-pattern R --hide-histogram
+    --test-time 180 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 44

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-1K-fields-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-1K-fields-match-count-100.yml
@@ -1,0 +1,46 @@
+version: 0.4
+name: memtier_benchmark-1key-hash-hscan-1K-fields-match-count-100
+description: Runs HSCAN with MATCH on a hashtable-encoded hash (1000 fields, exceeds hash-max-listpack-entries=128).
+  Fields are named field:1..field:1000 so the pattern `field:1*` is selective -- it matches field:1, field:10-19,
+  field:100-199 and field:1000, i.e. 112 of 1000 (verified locally) -- exercising stringmatchlen() per
+  visited field on the hashtable scan path. The registered HSCAN specs issue `HSCAN key 0` with no MATCH
+  and never reach the matcher; this pairs with the listpack-encoded variant to cover both hash encodings
+  separately.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" --command "HSET test_hset field:__key__ __data__" --command-key-pattern
+      P --key-prefix "" --key-minimum 1 --key-maximum 1000 -n allkeys -c 1 -t 1 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1key-hash-hashtable-1K-fields-field-named
+  dataset_description: 'Single hash key `test_hset` with 1000 fields named `field:1`..`field:1000` (each
+    a 10-byte value); exceeds hash-max-listpack-entries=128, so hashtable encoded. Field-name distribution
+    is what matters: HSCAN walks the dict and filters each name through stringmatchlen.'
+tested-commands:
+- hscan
+tested-groups:
+- hash
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "HSCAN test_hset 0 MATCH field:1* COUNT 100" --command-key-pattern R --hide-histogram
+    --test-time 120 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 96

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-1K-fields-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-1K-fields-match-count-100.yml
@@ -15,7 +15,7 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "10" --command "HSET test_hset field:__key__ __data__" --command-key-pattern
-      P --key-prefix "" --key-minimum 1 --key-maximum 1000 -n allkeys -c 1 -t 1 --hide-histogram --pipeline
+      P --key-prefix "" --key-minimum 1 --key-maximum 1001 -n allkeys -c 1 -t 1 --hide-histogram --pipeline
       50'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-50-fields-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-50-fields-match-count-100.yml
@@ -1,0 +1,45 @@
+version: 0.4
+name: memtier_benchmark-1key-hash-hscan-50-fields-match-count-100
+description: 'Listpack-encoded counterpart to the hashtable HSCAN MATCH spec: a 50-field hash (below hash-max-listpack-entries=128
+  and hash-max-listpack-value=64, so listpack). HSCAN walks the listpack in full and filters every field
+  through stringmatchlen(); `field:1*` matches field:1 and field:10-19, i.e. 11 of 50 (verified locally).
+  Covers the matcher on the listpack scan path, which is a different iteration from the hashtable scan
+  path.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: '"--data-size" "10" --command "HSET test_hset50 field:__key__ __data__" --command-key-pattern
+      P --key-prefix "" --key-minimum 1 --key-maximum 50 -n allkeys -c 1 -t 1 --hide-histogram --pipeline
+      50'
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1key-hash-listpack-50-fields-field-named
+  dataset_description: Single hash key `test_hset50` with 50 fields named `field:1`..`field:50` (each
+    a 10-byte value); below hash-max-listpack-entries=128 and hash-max-listpack-value=64, so listpack
+    encoded.
+tested-commands:
+- hscan
+tested-groups:
+- hash
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "HSCAN test_hset50 0 MATCH field:1* COUNT 100" --command-key-pattern R --hide-histogram
+    --test-time 120 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 96

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-50-fields-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-hash-hscan-50-fields-match-count-100.yml
@@ -14,7 +14,7 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: '"--data-size" "10" --command "HSET test_hset50 field:__key__ __data__" --command-key-pattern
-      P --key-prefix "" --key-minimum 1 --key-maximum 50 -n allkeys -c 1 -t 1 --hide-histogram --pipeline
+      P --key-prefix "" --key-minimum 1 --key-maximum 51 -n allkeys -c 1 -t 1 --hide-histogram --pipeline
       50'
   resources:
     requests:

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-elements-sscan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-elements-sscan-match-count-100.yml
@@ -1,0 +1,42 @@
+version: 0.4
+name: memtier_benchmark-1key-set-100-elements-sscan-match-count-100
+description: 'Listpack-encoded counterpart to the hashtable SSCAN MATCH spec: a 100-member set (below
+  set-max-listpack-entries=128, so listpack). SSCAN walks the listpack and filters every member through
+  stringmatchlen(); `member:1*` matches member:1, member:10-19 and member:100, i.e. 12 of 100 (verified
+  locally -- member:100 also begins with `member:1`). Covers the matcher on the listpack scan path.'
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command "SADD test_sadd100 member:__key__" --command-key-pattern P --key-prefix "" --key-minimum
+      1 --key-maximum 100 -n allkeys -c 1 -t 1 --hide-histogram --pipeline 50
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1key-set-listpack-100-elements-member-named
+  dataset_description: Single set key `test_sadd100` with 100 members named `member:1`..`member:100`;
+    below set-max-listpack-entries=128, so listpack encoded.
+tested-commands:
+- sscan
+tested-groups:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "SSCAN test_sadd100 0 MATCH member:1* COUNT 100" --command-key-pattern R --hide-histogram
+    --test-time 120 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 23

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-elements-sscan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-elements-sscan-match-count-100.yml
@@ -13,7 +13,7 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --command "SADD test_sadd100 member:__key__" --command-key-pattern P --key-prefix "" --key-minimum
-      1 --key-maximum 100 -n allkeys -c 1 -t 1 --hide-histogram --pipeline 50
+      1 --key-maximum 101 -n allkeys -c 1 -t 1 --hide-histogram --pipeline 50
   resources:
     requests:
       memory: 2g

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-1K-elements-sscan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-1K-elements-sscan-match-count-100.yml
@@ -1,0 +1,43 @@
+version: 0.4
+name: memtier_benchmark-1key-set-1K-elements-sscan-match-count-100
+description: Runs SSCAN with MATCH on a hashtable-encoded set (1000 members, exceeds set-max-listpack-entries=128).
+  Members are named member:1..member:1000 -- structured naming following the ZSCAN MATCH spec's precedent,
+  since the random-token members of the registered SSCAN specs do not admit a predictable MATCH pattern.
+  `member:1*` matches 112 of 1000 (verified locally). The registered SSCAN specs issue `SSCAN key 0` with
+  no MATCH and never reach stringmatchlen(); this pairs with the listpack variant.
+dbconfig:
+  configuration-parameters:
+    save: '""'
+  check:
+    keyspacelen: 1
+  preload_tool:
+    run_image: redislabs/memtier_benchmark:edge
+    tool: memtier_benchmark
+    arguments: --command "SADD test_sadd member:__key__" --command-key-pattern P --key-prefix "" --key-minimum
+      1 --key-maximum 1000 -n allkeys -c 1 -t 1 --hide-histogram --pipeline 50
+  resources:
+    requests:
+      memory: 2g
+  dataset_name: 1key-set-hashtable-1K-elements-member-named
+  dataset_description: Single set key `test_sadd` with 1000 members named `member:1`..`member:1000`; exceeds
+    set-max-listpack-entries=128, so hashtable encoded.
+tested-commands:
+- sscan
+tested-groups:
+- set
+redis-topologies:
+- oss-standalone
+build-variants:
+- gcc:15.2.0-amd64-debian-bookworm-default
+- gcc:15.2.0-arm64-debian-bookworm-default
+- dockerhub
+clientconfig:
+  run_image: redislabs/memtier_benchmark:edge
+  tool: memtier_benchmark
+  arguments: --command "SSCAN test_sadd 0 MATCH member:1* COUNT 100" --command-key-pattern R --hide-histogram
+    --test-time 120 --pipeline 1 -c 1 -t 1
+  resources:
+    requests:
+      cpus: '2'
+      memory: 2g
+priority: 23

--- a/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-1K-elements-sscan-match-count-100.yml
+++ b/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-1K-elements-sscan-match-count-100.yml
@@ -14,7 +14,7 @@ dbconfig:
     run_image: redislabs/memtier_benchmark:edge
     tool: memtier_benchmark
     arguments: --command "SADD test_sadd member:__key__" --command-key-pattern P --key-prefix "" --key-minimum
-      1 --key-maximum 1000 -n allkeys -c 1 -t 1 --hide-histogram --pipeline 50
+      1 --key-maximum 1001 -n allkeys -c 1 -t 1 --hide-histogram --pipeline 50
   resources:
     requests:
       memory: 2g


### PR DESCRIPTION
Addresses #496 — adds benchmark coverage for the glob-pattern matcher (`stringmatchlen()` in `util.c`), which the suite barely touched.

## What this adds

Seven specs, all driving the matcher through `memtier_benchmark`:

| Spec | Command / pattern | Encoding | Why |
|---|---|---|---|
| `1Mkeys-generic-keys-selective-prefix-match` | `KEYS memtier-12345*` | — | prefix-anchored pattern → low-backtracking path |
| `1Mkeys-generic-keys-leading-wildcard-match` | `KEYS *2345` | — | leading `*` → suffix-match-at-every-position path |
| `1Mkeys-generic-scan-match-count-100` | `SCAN 0 MATCH memtier-12345* COUNT 100` | — | per-element matching dominates the cursor walk |
| `1key-hash-hscan-1K-fields-match-count-100` | `HSCAN test_hset 0 MATCH field:1* COUNT 100` | hashtable (1000 fields) | dict scan path |
| `1key-hash-hscan-50-fields-match-count-100` | `HSCAN test_hset50 0 MATCH field:1* COUNT 100` | listpack (50 fields) | listpack scan path |
| `1key-set-1K-elements-sscan-match-count-100` | `SSCAN test_sadd 0 MATCH member:1* COUNT 100` | hashtable (1000 members) | dict scan path |
| `1key-set-100-elements-sscan-match-count-100` | `SSCAN test_sadd100 0 MATCH member:1* COUNT 100` | listpack (100 members) | listpack scan path |

HSCAN and SSCAN are each split across the two encodings, as suggested, so the hashtable and listpack iteration paths are priced separately.

## On the bare-`*` subtlety

Every pattern here is non-trivial on purpose. As the issue notes, both call sites short-circuit before the matcher — `db.c` sets `allkeys = (pattern[0] == "*" && plen == 1)` for KEYS and `use_pattern = !(patlen == 1 && pat[0] == "*")` for the SCAN family — so a `KEYS *` or `SCAN ... MATCH *` spec would add zero matcher coverage. The prefix vs. leading-wildcard KEYS pair is there specifically to separate the two recursion behaviours of `stringmatchlen()`. Match counts were verified locally against a preloaded keyspace (`memtier-12345*` → 11/1,000,000; `*2345` → 100/1,000,000; `field:1*` → 112/1000 hashtable, 11/50 listpack; `member:1*` → 112/1000 hashtable, 12/100 listpack).

`tested-commands` / `tested-groups` line up with `commands.json` (KEYS/SCAN → generic, HSCAN → hash, SSCAN → set).

## The pattern-pubsub item — deferred, and a question

The fourth suggestion (subscribers on `PSUBSCRIBE news.*` with publishers on matching channels) is **not** in this PR, and I wanted to flag why rather than quietly drop it.

The existing pubsub specs drive the subscriber side with `pubsub-sub-bench`, and as far as I can tell from its documented flags it only exposes channel-based subscribe (`-channel-minimum` / `-channel-maximum` / `-subscriber-prefix` / `-subscribers-per-channel`) — there's no PSUBSCRIBE / pattern mode. So a pattern-pubsub workload that actually reaches the per-pattern loop on the publish path can't be driven with the current subscriber tooling.

@fcostaoliveira since `pubsub-sub-bench` is your tool: would you want a `-mode psubscribe` (or a `-subscriber-pattern`) added there first, after which I'm happy to contribute the matching spec? Or if there's already a way to drive pattern subscriptions that I've missed, point me at it and I'll fold a pubsub spec into this PR. I kept the matcher-path specs separate so they're not blocked on that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds benchmark YAML definitions only; no runtime or Redis server code changes.
> 
> **Overview**
> Adds **seven new memtier benchmark specs** (YAML only) to exercise Redis’s shared glob matcher (`stringmatchlen`) on paths that existing suites mostly skipped because bare `*` bypasses matching.
> 
> **KEYS** on a 1M-key space uses two deliberate patterns: prefix `memtier-12345*` (low-backtracking) and leading-wildcard `*2345` (backtracking at every position). **SCAN** gets the same selective prefix with `MATCH` and `COUNT 100`, paralleling the existing ZSCAN MATCH spec.
> 
> **HSCAN** and **SSCAN** each add **hashtable vs listpack** pairs with structured field/member names and `field:1*` / `member:1*` patterns so matcher cost is measured on dict and listpack iteration separately. Pattern pubsub coverage is explicitly out of scope here.
> 
> All specs use the usual preload + single-client `memtier_benchmark` workload shape, oss-standalone, and the standard gcc/dockerhub build matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11254622092a497f653c08f99e02d9e33c76f0b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->